### PR TITLE
feat: Tier 1 MVP — complete OAR Priority Manager backend + UI shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint with ruff
+        run: ruff check src/ tests/
+
+      - name: Type check with mypy (advisory)
+        run: mypy src/ --ignore-missing-imports
+        continue-on-error: true
+
+      - name: Run tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: pytest -v --tb=short

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# OAR Priority Manager
+
+A desktop tool for Skyrim modders using Mod Organizer 2 (MO2) and Open Animation Replacer (OAR). Inspect which OAR submods compete for the same animation files, see who's winning, and adjust priorities — without modifying source mod files.
+
+## Quick Start
+
+### As an MO2 Executable (recommended)
+
+1. Download the latest release zip from GitHub Releases.
+2. Extract to your MO2 tools directory (e.g. `<instance>/tools/oar-priority-manager/`).
+3. In MO2, go to **Tools → Executables → Add**.
+4. Set the binary path to the extracted `.exe`.
+5. Set arguments: `--mods-path "%BASE_DIR%/mods"`
+6. Run from MO2 so the tool sees the merged VFS.
+
+### Development Setup
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+pytest -v
+python -m oar_priority_manager --mods-path "C:\path\to\your\MO2\instance\mods"
+```
+
+## How It Works
+
+The tool scans your MO2 mods directory for OAR submod folders (`config.json` files under `OpenAnimationReplacer/`). For each animation file (`.hkx`), it builds a **priority stack** — the ordered list of all submods that provide that animation, sorted by OAR's evaluation order (priority descending, first-match-wins).
+
+You can:
+- **Search** for any mod, submod, or animation filename
+- **See** exactly who's winning each animation and by how much
+- **Fix it** with Move to Top (one click) or Set Exact Priority
+- All changes are written to MO2 Overwrite — source mods are never touched
+
+## Technology
+
+- Python 3.11+ / PySide6
+- Packaged with Nuitka for native Windows binaries
+- Tests: pytest + pytest-qt
+
+## License
+
+TBD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=68.0", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oar-priority-manager"
+version = "0.1.0"
+description = "OAR priority management tool for Skyrim modders using MO2"
+requires-python = ">=3.11"
+dependencies = [
+    "PySide6-Essentials>=6.6,<6.9",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-qt>=4.4",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+[project.gui-scripts]
+oar-priority-manager = "oar_priority_manager.app.main:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/oar_priority_manager/__init__.py
+++ b/src/oar_priority_manager/__init__.py
@@ -1,0 +1,3 @@
+"""OAR Priority Manager — priority management tool for Skyrim modders using MO2."""
+
+__version__ = "0.1.0"

--- a/src/oar_priority_manager/app/__init__.py
+++ b/src/oar_priority_manager/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application infrastructure: config, entry point."""

--- a/src/oar_priority_manager/app/config.py
+++ b/src/oar_priority_manager/app/config.py
@@ -1,0 +1,127 @@
+"""Application config and MO2 instance root detection.
+
+See spec §8.3 (tool config), §8.3.1 (detection chain).
+"""
+from __future__ import annotations
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class DetectionError(Exception):
+    """Raised when MO2 instance root cannot be detected."""
+
+
+@dataclass
+class AppConfig:
+    """Tool configuration persisted to disk. One config per MO2 instance."""
+
+    relative_or_absolute: str = "relative"
+    submod_sort: str = "priority"
+    window_geometry: str = ""
+    splitter_positions: list[int] = field(default_factory=list)
+    search_history: list[str] = field(default_factory=list)
+    last_selected_path: str = ""
+
+
+def detect_instance_root(
+    mods_path: str | None = None,
+    cwd: Path | None = None,
+) -> Path:
+    """Detect the MO2 instance root using the fallback chain (spec §8.3.1).
+
+    Detection order:
+      1. ``mods_path`` CLI arg — parent directory is the instance root.
+      2. ``cwd`` contains both ``ModOrganizer.ini`` and ``mods/``.
+      3. Walk up from ``cwd`` looking for ``ModOrganizer.ini`` + ``mods/``.
+      4. Raise :class:`DetectionError` — no instance found.
+
+    Args:
+        mods_path: Explicit path to the MO2 ``mods/`` directory, typically
+            supplied via the ``--mods-path`` CLI argument.
+        cwd: Directory to start the walk-up search from.  Defaults to
+            ``None`` (walk-up step is skipped when not provided).
+
+    Returns:
+        The resolved MO2 instance root directory.
+
+    Raises:
+        DetectionError: When the instance root cannot be determined.
+    """
+    if mods_path:
+        mods = Path(mods_path)
+        if mods.is_dir():
+            return mods.parent
+        raise DetectionError(
+            f"--mods-path '{mods_path}' does not exist or is not a directory."
+        )
+
+    if cwd is not None:
+        if (cwd / "ModOrganizer.ini").is_file() and (cwd / "mods").is_dir():
+            return cwd
+
+        current = cwd
+        while current != current.parent:
+            if (
+                (current / "ModOrganizer.ini").is_file()
+                and (current / "mods").is_dir()
+            ):
+                return current
+            current = current.parent
+
+    raise DetectionError(
+        "Could not detect MO2 instance. Please configure the executable with "
+        "--mods-path or run the tool from within your MO2 instance directory."
+    )
+
+
+def load_config(path: Path) -> AppConfig:
+    """Load tool config from disk, returning defaults on any failure.
+
+    Graceful degradation: if the file is missing, unreadable, or contains
+    malformed JSON the function logs a warning and returns a default
+    :class:`AppConfig` rather than propagating an exception.
+
+    Args:
+        path: Absolute path to the JSON config file.
+
+    Returns:
+        The loaded (or default) :class:`AppConfig` instance.
+    """
+    if not path.is_file():
+        return AppConfig()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            logger.warning("Config at %s is not a JSON object, using defaults", path)
+            return AppConfig()
+        return AppConfig(
+            relative_or_absolute=data.get("relative_or_absolute", "relative"),
+            submod_sort=data.get("submod_sort", "priority"),
+            window_geometry=data.get("window_geometry", ""),
+            splitter_positions=data.get("splitter_positions", []),
+            search_history=data.get("search_history", []),
+            last_selected_path=data.get("last_selected_path", ""),
+        )
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Corrupt config at %s, using defaults", path)
+        return AppConfig()
+
+
+def save_config(config: AppConfig, path: Path) -> None:
+    """Persist tool config to disk as formatted JSON.
+
+    Creates parent directories as needed.
+
+    Args:
+        config: The :class:`AppConfig` instance to serialise.
+        path: Destination file path (will be created or overwritten).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(asdict(config), indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/src/oar_priority_manager/app/config.py
+++ b/src/oar_priority_manager/app/config.py
@@ -3,6 +3,7 @@
 See spec §8.3 (tool config), §8.3.1 (detection chain).
 """
 from __future__ import annotations
+
 import json
 import logging
 from dataclasses import asdict, dataclass, field

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -1,0 +1,113 @@
+"""Application entry point.
+
+See spec §6.3 (data flow). Parses CLI args, detects MO2 instance,
+runs scan pipeline, constructs UI.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from oar_priority_manager.app.config import (
+    AppConfig,
+    DetectionError,
+    detect_instance_root,
+    load_config,
+    save_config,
+)
+from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.priority_resolver import build_stacks
+from oar_priority_manager.core.scanner import scan_mods
+
+logger = logging.getLogger(__name__)
+
+CONFIG_SUBDIR = "oar-priority-manager"
+CONFIG_FILENAME = "config.json"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="oar-priority-manager",
+        description="OAR priority management tool for Skyrim modders using MO2",
+    )
+    parser.add_argument(
+        "--mods-path",
+        help='Path to MO2 mods/ directory. Recommended: --mods-path "%%BASE_DIR%%/mods"',
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    return parser.parse_args(argv)
+
+
+def run_scan(instance_root: Path) -> tuple:
+    """Execute the full scan pipeline (spec §6.3 steps 2-3).
+
+    Returns (submods, conflict_map, stacks).
+    """
+    mods_dir = instance_root / "mods"
+    overwrite_dir = instance_root / "overwrite"
+
+    submods = scan_mods(mods_dir, overwrite_dir)
+    scan_animations(submods)
+    conflict_map = build_conflict_map(submods)
+    stacks = build_stacks(conflict_map)
+
+    for sm in submods:
+        present, negated = extract_condition_types(sm.conditions)
+        sm.condition_types_present = present
+        sm.condition_types_negated = negated
+
+    return submods, conflict_map, stacks
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point."""
+    args = parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(name)s %(levelname)s: %(message)s",
+    )
+
+    try:
+        instance_root = detect_instance_root(
+            mods_path=args.mods_path,
+            cwd=Path.cwd(),
+        )
+    except DetectionError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    logger.info("MO2 instance root: %s", instance_root)
+
+    config_path = instance_root / CONFIG_SUBDIR / CONFIG_FILENAME
+    app_config = load_config(config_path)
+
+    submods, conflict_map, stacks = run_scan(instance_root)
+    logger.info("Loaded %d submods, %d animation stacks", len(submods), len(stacks))
+
+    app = QApplication(sys.argv)
+    app.setApplicationName("OAR Priority Manager")
+
+    from oar_priority_manager.ui.main_window import MainWindow
+
+    window = MainWindow(
+        submods=submods,
+        conflict_map=conflict_map,
+        stacks=stacks,
+        app_config=app_config,
+        instance_root=instance_root,
+    )
+    window.show()
+
+    exit_code = app.exec()
+    save_config(app_config, config_path)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -10,10 +10,9 @@ import logging
 import sys
 from pathlib import Path
 
-from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtWidgets import QApplication
 
 from oar_priority_manager.app.config import (
-    AppConfig,
     DetectionError,
     detect_instance_root,
     load_config,

--- a/src/oar_priority_manager/core/__init__.py
+++ b/src/oar_priority_manager/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core engine: parser, scanner, serializer, priority resolver."""

--- a/src/oar_priority_manager/core/anim_scanner.py
+++ b/src/oar_priority_manager/core/anim_scanner.py
@@ -1,0 +1,79 @@
+"""Animation file scanner and conflict map builder.
+
+See spec §6.2 (anim_scanner responsibilities).
+Scans each submod's animation files, including overrideAnimationsFolder redirection.
+overrideAnimationsFolder resolves relative to the PARENT of the submod directory
+(the replacer folder), matching OAR's own resolution logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+from oar_priority_manager.core.models import SubMod
+
+logger = logging.getLogger(__name__)
+
+
+def _get_animation_dir(submod: SubMod) -> Path:
+    """Determine where to look for .hkx files.
+
+    If overrideAnimationsFolder is set in raw_dict, resolve it relative to
+    the parent of the submod directory (the replacer folder).
+    Otherwise, look in the submod directory itself.
+    """
+    submod_dir = submod.config_path.parent
+    override_folder = submod.raw_dict.get("overrideAnimationsFolder")
+
+    if override_folder and isinstance(override_folder, str):
+        # Resolve relative to the PARENT of submod dir (the replacer folder)
+        replacer_dir = submod_dir.parent
+        resolved = (replacer_dir / override_folder).resolve()
+        if resolved.is_dir():
+            return resolved
+        else:
+            submod.warnings.append(
+                f"overrideAnimationsFolder '{override_folder}' resolves to "
+                f"'{resolved}' which does not exist"
+            )
+    return submod_dir
+
+
+def scan_animations(submods: list[SubMod]) -> None:
+    """Populate each SubMod's animations list with lowercased .hkx filenames.
+
+    Modifies submods in place.
+    """
+    for sm in submods:
+        anim_dir = _get_animation_dir(sm)
+        try:
+            hkx_files = [
+                f.name.lower()
+                for f in anim_dir.iterdir()
+                if f.is_file() and f.suffix.lower() == ".hkx"
+            ]
+        except OSError as e:
+            sm.warnings.append(f"Cannot read animation directory {anim_dir}: {e}")
+            hkx_files = []
+
+        sm.animations = sorted(hkx_files)
+
+
+def build_conflict_map(submods: list[SubMod]) -> dict[str, list[SubMod]]:
+    """Build a map of animation filename -> list of competing submods, sorted by priority descending.
+
+    See spec §5.4 (PriorityStack).
+    """
+    anim_to_submods: dict[str, list[SubMod]] = defaultdict(list)
+
+    for sm in submods:
+        for anim in sm.animations:
+            anim_to_submods[anim].append(sm)
+
+    # Sort each list by priority descending
+    for anim in anim_to_submods:
+        anim_to_submods[anim].sort(key=lambda s: s.priority, reverse=True)
+
+    return dict(anim_to_submods)

--- a/src/oar_priority_manager/core/anim_scanner.py
+++ b/src/oar_priority_manager/core/anim_scanner.py
@@ -62,7 +62,7 @@ def scan_animations(submods: list[SubMod]) -> None:
 
 
 def build_conflict_map(submods: list[SubMod]) -> dict[str, list[SubMod]]:
-    """Build a map of animation filename -> list of competing submods, sorted by priority descending.
+    """Build a map of animation filename -> list of competing submods, sorted by priority desc.
 
     See spec §5.4 (PriorityStack).
     """

--- a/src/oar_priority_manager/core/filter_engine.py
+++ b/src/oar_priority_manager/core/filter_engine.py
@@ -1,0 +1,186 @@
+"""Condition-tree walker and search-bar filter engine for OAR Priority Manager.
+
+See spec §6.2 (filter_engine), §7.6 (condition filter semantics).
+
+This module operates purely on already-parsed condition data stored on SubMod
+objects (condition_types_present, condition_types_negated).  It does NOT read
+JSON files; that is the scanner's responsibility.
+
+Public API
+----------
+extract_condition_types(conditions)
+    Walk an OAR condition tree and return (present, negated) type-name sets.
+
+FilterQuery
+    Dataclass produced by parse_filter_query — holds required/excluded sets.
+
+parse_filter_query(text)
+    Parse a search-bar string such as "IsFemale NOT HasPerk" into a FilterQuery.
+
+match_filter(present, negated, query)
+    Test whether a SubMod's condition sets satisfy a FilterQuery.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# OAR group-node types — these are structural and must NOT appear in the
+# output sets produced by extract_condition_types.
+_GROUP_TYPES: frozenset[str] = frozenset({"AND", "OR"})
+
+
+def extract_condition_types(
+    conditions: dict | list,
+) -> tuple[set[str], set[str]]:
+    """Walk an OAR condition tree and collect every leaf condition type name.
+
+    Args:
+        conditions: Either a list of condition dicts (the top-level format used
+            by OAR config.json) or a dict that has a ``"conditions"`` key
+            (a group node encountered during recursion or passed directly).
+
+    Returns:
+        A two-tuple ``(present, negated)`` where:
+
+        * ``present`` — every non-group condition type name found anywhere in
+          the tree.
+        * ``negated`` — the subset of ``present`` where at least one occurrence
+          had ``negated: True``.  A type can appear in both sets when it occurs
+          both negated and non-negated in the same tree.
+    """
+    present: set[str] = set()
+    negated: set[str] = set()
+    _walk(conditions, present, negated)
+    return present, negated
+
+
+def _walk(node: dict | list, present: set[str], negated: set[str]) -> None:
+    """Recursive helper that mutates *present* and *negated* in place.
+
+    Args:
+        node: The current tree node — either a list of siblings or a single
+            condition/group dict.
+        present: Accumulator for all condition type names seen so far.
+        negated: Accumulator for condition type names seen with negated=True.
+    """
+    if isinstance(node, list):
+        for child in node:
+            _walk(child, present, negated)
+        return
+
+    if not isinstance(node, dict):
+        # Defensive: skip unexpected node types without crashing.
+        return
+
+    condition_type: str | None = node.get("condition")
+
+    # If this dict has a "conditions" key it is a group node — recurse into
+    # children.  We do this regardless of whether "condition" is AND/OR or
+    # absent, to handle any variation in the serialised format.
+    if "conditions" in node:
+        _walk(node["conditions"], present, negated)
+        # Group labels (AND, OR) are structural — do not add to present.
+        return
+
+    # Leaf condition node.
+    if condition_type is not None and condition_type not in _GROUP_TYPES:
+        present.add(condition_type)
+        if node.get("negated", False):
+            negated.add(condition_type)
+
+
+# ---------------------------------------------------------------------------
+# Filter query parsing and matching
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FilterQuery:
+    """Parsed representation of a search-bar filter string.
+
+    Attributes:
+        required: Condition type names that MUST be present in a SubMod for it
+            to pass the filter.  Corresponds to bare tokens in the query string.
+        excluded: Condition type names that must NOT be present in a SubMod for
+            it to pass the filter.  Corresponds to ``NOT <name>`` tokens.
+    """
+
+    required: set[str] = field(default_factory=set)
+    excluded: set[str] = field(default_factory=set)
+
+
+def parse_filter_query(text: str) -> FilterQuery:
+    """Parse a free-text condition filter string into a :class:`FilterQuery`.
+
+    Grammar (case-sensitive, whitespace-separated tokens)::
+
+        query  ::= token*
+        token  ::= "NOT" name | name
+        name   ::= any non-whitespace string
+
+    Examples::
+
+        "IsFemale"                 → required={"IsFemale"}, excluded=set()
+        "NOT HasPerk"              → required=set(), excluded={"HasPerk"}
+        "IsFemale NOT HasPerk"     → required={"IsFemale"}, excluded={"HasPerk"}
+        ""                         → required=set(), excluded=set()
+
+    Args:
+        text: Raw text from the UI search bar.
+
+    Returns:
+        A :class:`FilterQuery` with the parsed required and excluded sets.
+    """
+    query = FilterQuery()
+    tokens = text.split()
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "NOT":
+            # Consume the next token as the excluded term (if present).
+            if i + 1 < len(tokens):
+                query.excluded.add(tokens[i + 1])
+                i += 2
+            else:
+                # Trailing "NOT" with no following name — skip silently.
+                i += 1
+        else:
+            query.required.add(token)
+            i += 1
+    return query
+
+
+def match_filter(
+    present: set[str],
+    negated: set[str],  # noqa: ARG001 — reserved for future semantics
+    query: FilterQuery,
+) -> bool:
+    """Test whether a SubMod's condition sets satisfy *query*.
+
+    The ``negated`` parameter is accepted for API completeness and future
+    extension (e.g. filtering *only* on negated occurrences) but is not used
+    by the current MVP semantics.
+
+    Matching rules (spec §7.6):
+
+    * An empty query (no required, no excluded tokens) matches every SubMod.
+    * All required type names must appear in ``present``.
+    * None of the excluded type names may appear in ``present``.
+
+    Args:
+        present: Set of condition type names found anywhere in the SubMod's
+            condition tree (i.e. ``SubMod.condition_types_present``).
+        negated: Set of condition type names that appeared with ``negated:
+            True`` (i.e. ``SubMod.condition_types_negated``).  Currently unused.
+        query: The parsed filter produced by :func:`parse_filter_query`.
+
+    Returns:
+        ``True`` if the SubMod passes the filter, ``False`` otherwise.
+    """
+    # All required types must be present.
+    if not query.required.issubset(present):
+        return False
+    # No excluded type may be present.
+    if query.excluded & present:
+        return False
+    return True

--- a/src/oar_priority_manager/core/filter_engine.py
+++ b/src/oar_priority_manager/core/filter_engine.py
@@ -181,6 +181,4 @@ def match_filter(
     if not query.required.issubset(present):
         return False
     # No excluded type may be present.
-    if query.excluded & present:
-        return False
-    return True
+    return not (query.excluded & present)

--- a/src/oar_priority_manager/core/models.py
+++ b/src/oar_priority_manager/core/models.py
@@ -1,0 +1,90 @@
+"""Core data model types for OAR Priority Manager.
+
+See spec §5.2 (SubMod), §5.4 (PriorityStack), §3.3 (IllegalMutationError).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class OverrideSource(Enum):
+    """Where the effective priority was read from (spec §5.3)."""
+
+    SOURCE = "source"          # config.json in source mod
+    USER_JSON = "user_json"    # user.json in source mod (OAR in-game override)
+    OVERWRITE = "overwrite"    # user.json in MO2 Overwrite folder
+
+
+@dataclass
+class SubMod:
+    """A single OAR submod discovered during scan.
+
+    Fields match spec §5.2. raw_dict comes from the WINNING file in the
+    override precedence chain (§5.3) — NOT always from config.json.
+    When user.json exists, it is a complete data replacement for all fields
+    except name and description (§4).
+    """
+
+    mo2_mod: str
+    replacer: str
+    name: str
+    description: str
+    priority: int
+    source_priority: int
+    disabled: bool
+    config_path: Path
+    override_source: OverrideSource
+    override_is_ours: bool
+    raw_dict: dict
+    animations: list[str] = field(default_factory=list)
+    conditions: dict = field(default_factory=dict)
+    condition_types_present: set[str] = field(default_factory=set)
+    condition_types_negated: set[str] = field(default_factory=set)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def has_warnings(self) -> bool:
+        """True if this submod has parse/validation warnings. Edits are blocked."""
+        return len(self.warnings) > 0
+
+    @property
+    def is_overridden(self) -> bool:
+        """True if priority differs from the source config.json value."""
+        return self.priority != self.source_priority
+
+    @property
+    def display_path(self) -> str:
+        """Human-readable breadcrumb: 'MO2 Mod / Replacer / Submod'."""
+        return f"{self.mo2_mod} / {self.replacer} / {self.name}"
+
+
+@dataclass
+class PriorityStack:
+    """All submods competing for one animation filename, sorted by priority descending.
+
+    See spec §5.4. Built by priority_resolver.py.
+    """
+
+    animation_filename: str
+    competitors: list[SubMod] = field(default_factory=list)
+
+
+class IllegalMutationError(Exception):
+    """Raised by serializer when a non-allowlisted field has been modified.
+
+    See spec §3.3 and §6.2. This is the architectural guardrail that prevents
+    scope creep into condition editing or disable toggling.
+    """
+
+    def __init__(self, field_name: str, original_value: object, new_value: object) -> None:
+        self.field_name = field_name
+        self.original_value = original_value
+        self.new_value = new_value
+        super().__init__(
+            f"Illegal mutation of field '{field_name}': "
+            f"original={original_value!r}, new={new_value!r}. "
+            f"Only 'priority' may be modified."
+        )

--- a/src/oar_priority_manager/core/models.py
+++ b/src/oar_priority_manager/core/models.py
@@ -18,7 +18,7 @@ class OverrideSource(Enum):
     OVERWRITE = "overwrite"    # user.json in MO2 Overwrite folder
 
 
-@dataclass
+@dataclass(eq=False)
 class SubMod:
     """A single OAR submod discovered during scan.
 

--- a/src/oar_priority_manager/core/models.py
+++ b/src/oar_priority_manager/core/models.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+# Shared constants — single source of truth
+OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
+METADATA_KEY = "_oarPriorityManager"
+
 
 class OverrideSource(Enum):
     """Where the effective priority was read from (spec §5.3)."""
@@ -41,9 +45,19 @@ class SubMod:
     raw_dict: dict
     animations: list[str] = field(default_factory=list)
     conditions: dict = field(default_factory=dict)
+    # Populated by filter_engine.py (Task 9). Empty until that module exists.
     condition_types_present: set[str] = field(default_factory=set)
     condition_types_negated: set[str] = field(default_factory=set)
     warnings: list[str] = field(default_factory=list)
+
+    def __eq__(self, other: object) -> bool:
+        """Two SubMods are equal if they point to the same config.json."""
+        if not isinstance(other, SubMod):
+            return NotImplemented
+        return self.config_path == other.config_path
+
+    def __hash__(self) -> int:
+        return hash(self.config_path)
 
     @property
     def has_warnings(self) -> bool:

--- a/src/oar_priority_manager/core/override_manager.py
+++ b/src/oar_priority_manager/core/override_manager.py
@@ -1,0 +1,86 @@
+"""Override manager — writes priority changes to MO2 Overwrite at mirrored paths.
+
+See spec §6.2 (override_manager), §8.1 (OAR overrides), §8.2 (clear overrides).
+NEVER writes to source mod paths. Only writes user.json to the Overwrite folder.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.serializer import serialize_raw_dict
+
+logger = logging.getLogger(__name__)
+
+# Relative path within the OAR structure
+OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
+
+
+def compute_overwrite_path(submod: SubMod, overwrite_dir: Path) -> Path:
+    """Compute the mirrored path in MO2 Overwrite for a submod's user.json.
+
+    The path mirrors the source mod's relative OAR structure:
+    overwrite/<OAR_REL>/<replacer>/<submod_folder>/user.json
+    """
+    submod_folder = submod.config_path.parent.name
+    return overwrite_dir / OAR_REL / submod.replacer / submod_folder / "user.json"
+
+
+def write_override(submod: SubMod, new_priority: int, overwrite_dir: Path) -> None:
+    """Write a priority override to MO2 Overwrite for the given submod.
+
+    Builds a new raw_dict with only priority changed, writes via serializer
+    (which enforces the mutable-field allowlist), and updates the SubMod
+    in-memory state.
+    """
+    original_raw = submod.raw_dict
+    previous_priority = submod.priority
+
+    # Build modified dict — only change priority
+    modified = dict(original_raw)
+    modified["priority"] = new_priority
+
+    output_path = compute_overwrite_path(submod, overwrite_dir)
+
+    serialize_raw_dict(
+        modified=modified,
+        original=original_raw,
+        output_path=output_path,
+        previous_priority=previous_priority,
+    )
+
+    # Update in-memory state
+    submod.priority = new_priority
+    submod.override_source = OverrideSource.OVERWRITE
+    submod.override_is_ours = True
+    submod.raw_dict = modified
+
+    logger.info(
+        "Wrote override for %s: %d → %d at %s",
+        submod.display_path, previous_priority, new_priority, output_path,
+    )
+
+
+def clear_override(submod: SubMod, overwrite_dir: Path) -> None:
+    """Delete the Overwrite-layer user.json for a submod.
+
+    See spec §8.2. Reverts to whatever is in the source mod.
+    """
+    output_path = compute_overwrite_path(submod, overwrite_dir)
+    if output_path.exists():
+        output_path.unlink()
+        logger.info("Cleared override for %s: deleted %s", submod.display_path, output_path)
+        _remove_empty_parents(output_path.parent, overwrite_dir)
+
+
+def _remove_empty_parents(directory: Path, stop_at: Path) -> None:
+    """Remove empty parent directories up to (but not including) stop_at."""
+    current = directory
+    while current != stop_at and current.is_dir():
+        try:
+            current.rmdir()  # Only removes if empty
+            current = current.parent
+        except OSError:
+            break

--- a/src/oar_priority_manager/core/override_manager.py
+++ b/src/oar_priority_manager/core/override_manager.py
@@ -6,16 +6,15 @@ NEVER writes to source mod paths. Only writes user.json to the Overwrite folder.
 
 from __future__ import annotations
 
+import copy
 import logging
 from pathlib import Path
 
-from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.models import METADATA_KEY, OAR_REL, OverrideSource, SubMod
+from oar_priority_manager.core.parser import parse_config
 from oar_priority_manager.core.serializer import serialize_raw_dict
 
 logger = logging.getLogger(__name__)
-
-# Relative path within the OAR structure
-OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
 
 
 def compute_overwrite_path(submod: SubMod, overwrite_dir: Path) -> Path:
@@ -38,8 +37,9 @@ def write_override(submod: SubMod, new_priority: int, overwrite_dir: Path) -> No
     original_raw = submod.raw_dict
     previous_priority = submod.priority
 
-    # Build modified dict — only change priority
-    modified = dict(original_raw)
+    # Build modified dict — only change priority (deepcopy ensures allowlist
+    # check in serializer compares truly independent objects, not aliased dicts)
+    modified = copy.deepcopy(original_raw)
     modified["priority"] = new_priority
 
     output_path = compute_overwrite_path(submod, overwrite_dir)
@@ -66,7 +66,8 @@ def write_override(submod: SubMod, new_priority: int, overwrite_dir: Path) -> No
 def clear_override(submod: SubMod, overwrite_dir: Path) -> None:
     """Delete the Overwrite-layer user.json for a submod.
 
-    See spec §8.2. Reverts to whatever is in the source mod.
+    See spec §8.2. Reverts in-memory SubMod state to whatever is in the
+    source mod (source user.json if present, otherwise config.json).
     """
     output_path = compute_overwrite_path(submod, overwrite_dir)
     if output_path.exists():
@@ -74,11 +75,42 @@ def clear_override(submod: SubMod, overwrite_dir: Path) -> None:
         logger.info("Cleared override for %s: deleted %s", submod.display_path, output_path)
         _remove_empty_parents(output_path.parent, overwrite_dir)
 
+    # Revert in-memory state by re-reading source files to determine correct
+    # post-clear state (mirrors scanner precedence: source user.json > config.json)
+    config_dict, _config_warnings = parse_config(submod.config_path)
+    source_priority = config_dict.get("priority", 0)
+
+    source_user = submod.config_path.parent / "user.json"
+    if source_user.exists():
+        su_dict, su_warnings = parse_config(source_user)
+        if su_dict:
+            winning_dict = su_dict
+            winning_priority = su_dict.get("priority", source_priority)
+            override_source = OverrideSource.USER_JSON
+            override_is_ours = METADATA_KEY in su_dict
+        else:
+            winning_dict = config_dict
+            winning_priority = source_priority
+            override_source = OverrideSource.SOURCE
+            override_is_ours = False
+    else:
+        winning_dict = config_dict
+        winning_priority = source_priority
+        override_source = OverrideSource.SOURCE
+        override_is_ours = False
+
+    submod.priority = winning_priority
+    submod.override_source = override_source
+    submod.override_is_ours = override_is_ours
+    submod.raw_dict = winning_dict
+
 
 def _remove_empty_parents(directory: Path, stop_at: Path) -> None:
     """Remove empty parent directories up to (but not including) stop_at."""
-    current = directory
-    while current != stop_at and current.is_dir():
+    # Resolve both paths at entry for case-insensitive comparison on Windows
+    current = directory.resolve()
+    boundary = stop_at.resolve()
+    while current != boundary and current.is_dir():
         try:
             current.rmdir()  # Only removes if empty
             current = current.parent

--- a/src/oar_priority_manager/core/parser.py
+++ b/src/oar_priority_manager/core/parser.py
@@ -1,0 +1,77 @@
+"""Lenient JSON parser for OAR config.json / user.json files.
+
+See spec §6.2. Handles:
+- Standard JSON
+- Trailing commas (common hand-edit artifact)
+- Produces warnings on malformed input instead of raising
+
+Returns (raw_dict, warnings). raw_dict is {} on failure.
+Key ordering is preserved for round-trip (Python 3.7+ dicts are insertion-ordered).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas before } and ] to make JSON valid.
+
+    Handles nested cases. This is a regex-based repair — it won't fix all
+    malformed JSON, but catches the most common hand-edit artifact.
+
+    Args:
+        text: JSON text potentially containing trailing commas.
+
+    Returns:
+        Text with trailing commas removed.
+    """
+    # Remove comma followed by optional whitespace/newlines then } or ]
+    return re.sub(r",\s*([}\]])", r"\1", text)
+
+
+def parse_config(path: Path) -> tuple[dict, list[str]]:
+    """Parse a config.json or user.json file into a raw_dict.
+
+    Lenient parsing: repairs trailing commas and produces warnings instead
+    of raising exceptions.
+
+    Args:
+        path: Absolute path to the JSON file.
+
+    Returns:
+        Tuple of (raw_dict, warnings).
+        raw_dict is {} if the file cannot be parsed.
+        warnings is [] on success, contains error messages on failure.
+    """
+    warnings: list[str] = []
+
+    # Read the file
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}, [f"File not found: {path}"]
+    except OSError as e:
+        return {}, [f"Cannot read {path}: {e}"]
+
+    if not text.strip():
+        return {}, [f"Empty file: {path}"]
+
+    # Try standard JSON first
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        # Try with trailing-comma repair
+        repaired = _strip_trailing_commas(text)
+        try:
+            data = json.loads(repaired)
+        except json.JSONDecodeError as e:
+            return {}, [f"JSON parse error in {path}: {e}"]
+
+    # Must be a dict (JSON object)
+    if not isinstance(data, dict):
+        return {}, [f"Expected JSON object in {path}, got {type(data).__name__}"]
+
+    return data, warnings

--- a/src/oar_priority_manager/core/priority_resolver.py
+++ b/src/oar_priority_manager/core/priority_resolver.py
@@ -1,0 +1,184 @@
+"""Priority resolver — builds PriorityStacks and exposes mutation operations.
+
+See spec §5.4 (PriorityStack), §6.2 (priority_resolver responsibilities).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from oar_priority_manager.core.models import PriorityStack, SubMod
+
+logger = logging.getLogger(__name__)
+
+INT32_MAX = 2_147_483_647
+INT32_MIN = -2_147_483_648
+
+
+class OverflowError(Exception):
+    """Raised when a computed priority would exceed INT32 range."""
+
+    def __init__(self, computed: int) -> None:
+        self.computed = computed
+        super().__init__(
+            f"Computed priority {computed} exceeds INT32 range "
+            f"[{INT32_MIN}, {INT32_MAX}]. Operation cancelled."
+        )
+
+
+def _check_overflow(value: int) -> None:
+    if value > INT32_MAX or value < INT32_MIN:
+        raise OverflowError(value)
+
+
+def build_stacks(conflict_map: dict[str, list[SubMod]]) -> list[PriorityStack]:
+    """Build PriorityStack objects from the conflict map, sorted alphabetically by filename."""
+    stacks = []
+    for filename in sorted(conflict_map.keys()):
+        stacks.append(PriorityStack(
+            animation_filename=filename,
+            competitors=conflict_map[filename],
+        ))
+    return stacks
+
+
+def _get_scope_submods(
+    target: SubMod,
+    conflict_map: dict[str, list[SubMod]],
+    scope: str,
+) -> list[SubMod]:
+    """Get all unique submods in the scope (submod/replacer/mod)."""
+    seen: set[int] = set()
+    result: list[SubMod] = []
+
+    for anim in target.animations:
+        if anim not in conflict_map:
+            continue
+        for sm in conflict_map[anim]:
+            sm_id = id(sm)
+            if sm_id in seen:
+                continue
+            if scope == "submod" and sm is target:
+                seen.add(sm_id)
+                result.append(sm)
+            elif scope == "replacer" and sm.mo2_mod == target.mo2_mod and sm.replacer == target.replacer:
+                seen.add(sm_id)
+                result.append(sm)
+            elif scope == "mod" and sm.mo2_mod == target.mo2_mod:
+                seen.add(sm_id)
+                result.append(sm)
+
+    return result
+
+
+def _get_external_max(
+    scope_submods: list[SubMod],
+    conflict_map: dict[str, list[SubMod]],
+) -> int | None:
+    """Find the highest priority among external competitors (not in scope)."""
+    scope_ids = {id(sm) for sm in scope_submods}
+    max_ext: int | None = None
+
+    for sm in scope_submods:
+        for anim in sm.animations:
+            if anim not in conflict_map:
+                continue
+            for competitor in conflict_map[anim]:
+                if id(competitor) not in scope_ids:
+                    if max_ext is None or competitor.priority > max_ext:
+                        max_ext = competitor.priority
+
+    return max_ext
+
+
+def move_to_top(
+    target: SubMod,
+    conflict_map: dict[str, list[SubMod]],
+    scope: str = "submod",
+) -> dict[SubMod, int]:
+    """Compute new priorities to make target (and scope) #1 in all stacks.
+
+    Args:
+        target: The submod the user selected.
+        conflict_map: Animation filename -> list of competing submods.
+        scope: "submod", "replacer", or "mod".
+
+    Returns:
+        Dict of SubMod -> new_priority. Empty if already winning everywhere.
+
+    Raises:
+        OverflowError: If computed priority exceeds INT32_MAX.
+    """
+    scope_submods = _get_scope_submods(target, conflict_map, scope)
+    if not scope_submods:
+        return {}
+
+    external_max = _get_external_max(scope_submods, conflict_map)
+    if external_max is None:
+        # No external competitors — already winning
+        return {}
+
+    # Check if already winning (all scope submods have priority > external_max)
+    if all(sm.priority > external_max for sm in scope_submods):
+        return {}
+
+    if scope == "submod":
+        new_priority = external_max + 1
+        _check_overflow(new_priority)
+        return {target: new_priority}
+
+    # Replacer/mod scope: floor-anchored shift
+    old_priorities = [sm.priority for sm in scope_submods]
+    min_old = min(old_priorities)
+    base = external_max + 1
+
+    result: dict[SubMod, int] = {}
+    for sm in scope_submods:
+        new_p = base + (sm.priority - min_old)
+        _check_overflow(new_p)
+        result[sm] = new_p
+
+    return result
+
+
+def set_exact(target: SubMod, priority: int) -> dict[SubMod, int]:
+    """Set an exact priority for a single submod.
+
+    Raises:
+        OverflowError: If priority exceeds INT32 range.
+    """
+    _check_overflow(priority)
+    return {target: priority}
+
+
+def shift(
+    submods: list[SubMod],
+    floor_priority: int,
+) -> dict[SubMod, int]:
+    """Shift a group of submods so the lowest lands at floor_priority,
+    preserving relative gaps.
+
+    Args:
+        submods: The submods to shift.
+        floor_priority: The target priority for the lowest submod.
+
+    Returns:
+        Dict of SubMod -> new_priority.
+
+    Raises:
+        OverflowError: If any computed priority exceeds INT32 range.
+    """
+    if not submods:
+        return {}
+
+    old_priorities = [sm.priority for sm in submods]
+    min_old = min(old_priorities)
+
+    result: dict[SubMod, int] = {}
+    for sm in submods:
+        new_p = floor_priority + (sm.priority - min_old)
+        _check_overflow(new_p)
+        result[sm] = new_p
+
+    return result

--- a/src/oar_priority_manager/core/priority_resolver.py
+++ b/src/oar_priority_manager/core/priority_resolver.py
@@ -6,7 +6,6 @@ See spec §5.4 (PriorityStack), §6.2 (priority_resolver responsibilities).
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 from oar_priority_manager.core.models import PriorityStack, SubMod
 
@@ -59,13 +58,16 @@ def _get_scope_submods(
             sm_id = id(sm)
             if sm_id in seen:
                 continue
-            if scope == "submod" and sm is target:
-                seen.add(sm_id)
-                result.append(sm)
-            elif scope == "replacer" and sm.mo2_mod == target.mo2_mod and sm.replacer == target.replacer:
-                seen.add(sm_id)
-                result.append(sm)
-            elif scope == "mod" and sm.mo2_mod == target.mo2_mod:
+            in_scope = (
+                (scope == "submod" and sm is target)
+                or (
+                    scope == "replacer"
+                    and sm.mo2_mod == target.mo2_mod
+                    and sm.replacer == target.replacer
+                )
+                or (scope == "mod" and sm.mo2_mod == target.mo2_mod)
+            )
+            if in_scope:
                 seen.add(sm_id)
                 result.append(sm)
 
@@ -85,9 +87,10 @@ def _get_external_max(
             if anim not in conflict_map:
                 continue
             for competitor in conflict_map[anim]:
-                if id(competitor) not in scope_ids:
-                    if max_ext is None or competitor.priority > max_ext:
-                        max_ext = competitor.priority
+                if id(competitor) not in scope_ids and (
+                    max_ext is None or competitor.priority > max_ext
+                ):
+                    max_ext = competitor.priority
 
     return max_ext
 

--- a/src/oar_priority_manager/core/priority_resolver.py
+++ b/src/oar_priority_manager/core/priority_resolver.py
@@ -16,7 +16,7 @@ INT32_MAX = 2_147_483_647
 INT32_MIN = -2_147_483_648
 
 
-class OverflowError(Exception):
+class PriorityOverflowError(Exception):
     """Raised when a computed priority would exceed INT32 range."""
 
     def __init__(self, computed: int) -> None:
@@ -29,7 +29,7 @@ class OverflowError(Exception):
 
 def _check_overflow(value: int) -> None:
     if value > INT32_MAX or value < INT32_MIN:
-        raise OverflowError(value)
+        raise PriorityOverflowError(value)
 
 
 def build_stacks(conflict_map: dict[str, list[SubMod]]) -> list[PriorityStack]:
@@ -108,7 +108,7 @@ def move_to_top(
         Dict of SubMod -> new_priority. Empty if already winning everywhere.
 
     Raises:
-        OverflowError: If computed priority exceeds INT32_MAX.
+        PriorityOverflowError: If computed priority exceeds INT32_MAX.
     """
     scope_submods = _get_scope_submods(target, conflict_map, scope)
     if not scope_submods:
@@ -146,7 +146,7 @@ def set_exact(target: SubMod, priority: int) -> dict[SubMod, int]:
     """Set an exact priority for a single submod.
 
     Raises:
-        OverflowError: If priority exceeds INT32 range.
+        PriorityOverflowError: If priority exceeds INT32 range.
     """
     _check_overflow(priority)
     return {target: priority}
@@ -167,7 +167,12 @@ def shift(
         Dict of SubMod -> new_priority.
 
     Raises:
-        OverflowError: If any computed priority exceeds INT32 range.
+        PriorityOverflowError: If any computed priority exceeds INT32 range.
+
+    Note:
+        The caller is responsible for ensuring all submods belong to the same
+        logical group. Passing submods from different mods preserves relative
+        gaps but may produce semantically meaningless results.
     """
     if not submods:
         return {}

--- a/src/oar_priority_manager/core/scanner.py
+++ b/src/oar_priority_manager/core/scanner.py
@@ -1,0 +1,179 @@
+"""MO2 mod directory scanner — discovers OAR submods and applies override precedence.
+
+See spec §5.3 (override precedence), §6.2 (scanner responsibilities).
+
+CRITICAL: raw_dict must come from the WINNING file in the precedence chain,
+not always from config.json. When user.json exists, it is a complete data
+replacement for all fields except name/description (spec §4).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.parser import parse_config
+
+logger = logging.getLogger(__name__)
+
+# The relative path within a mod that marks the OAR animation replacer root
+OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
+
+# Metadata key injected by this tool into Overwrite user.json files
+METADATA_KEY = "_oarPriorityManager"
+
+
+def _find_submod_dirs(mods_dir: Path) -> list[tuple[str, str, str, Path]]:
+    """Find all submod directories under mods/.
+
+    Returns list of (mo2_mod, replacer, submod_folder_name, submod_path).
+    A submod directory is any folder under <mod>/<OAR_REL>/<replacer>/<submod>/
+    that either contains config.json or contains .hkx files.
+    """
+    results = []
+    if not mods_dir.is_dir():
+        return results
+
+    for mod_dir in sorted(mods_dir.iterdir()):
+        if not mod_dir.is_dir():
+            continue
+        oar_root = mod_dir / OAR_REL
+        if not oar_root.is_dir():
+            continue
+
+        mo2_mod = mod_dir.name
+
+        for replacer_dir in sorted(oar_root.iterdir()):
+            if not replacer_dir.is_dir():
+                continue
+            replacer = replacer_dir.name
+
+            for submod_dir in sorted(replacer_dir.iterdir()):
+                if not submod_dir.is_dir():
+                    continue
+                # A submod candidate: has config.json or has .hkx files
+                has_config = (submod_dir / "config.json").exists()
+                has_hkx = any(submod_dir.glob("*.hkx"))
+                if has_config or has_hkx:
+                    results.append((mo2_mod, replacer, submod_dir.name, submod_dir))
+
+    return results
+
+
+def _build_submod(
+    mo2_mod: str,
+    replacer: str,
+    submod_folder: str,
+    submod_path: Path,
+    overwrite_dir: Path,
+) -> SubMod:
+    """Build a SubMod record for one discovered submod, applying override precedence.
+
+    Precedence (spec §5.3):
+    1. Overwrite user.json (at mirrored path)
+    2. Source user.json (in source mod)
+    3. Source config.json
+
+    raw_dict comes from the WINNING file. name/description always from config.json.
+    """
+    warnings: list[str] = []
+
+    # Always read config.json for name/description (OAR kInfoOnly)
+    config_path = submod_path / "config.json"
+    config_dict, config_warnings = parse_config(config_path)
+    warnings.extend(config_warnings)
+
+    # Extract name/description from config.json (always, per OAR §4)
+    name = config_dict.get("name", submod_folder)
+    description = config_dict.get("description", "")
+    source_priority = config_dict.get("priority", 0)
+    if not isinstance(source_priority, int):
+        warnings.append(
+            f"Priority is not an integer in {config_path}: {source_priority!r}"
+        )
+        source_priority = 0
+
+    # Determine override precedence and select winning file for raw_dict.
+    # The mirrored path in Overwrite uses the relative path from OAR root.
+    rel_from_oar = Path(replacer) / submod_folder
+    overwrite_user = overwrite_dir / OAR_REL / rel_from_oar / "user.json"
+    source_user = submod_path / "user.json"
+
+    override_source = OverrideSource.SOURCE
+    override_is_ours = False
+    raw_dict = config_dict
+    effective_priority = source_priority
+
+    # Check precedence: Overwrite > source user.json > config.json
+    if overwrite_user.is_file():
+        ow_dict, ow_warnings = parse_config(overwrite_user)
+        warnings.extend(ow_warnings)
+        if ow_dict:
+            override_source = OverrideSource.OVERWRITE
+            raw_dict = ow_dict
+            effective_priority = ow_dict.get("priority", source_priority)
+            if not isinstance(effective_priority, int):
+                warnings.append(
+                    f"Priority is not an integer in {overwrite_user}: {effective_priority!r}"
+                )
+                effective_priority = source_priority
+            override_is_ours = METADATA_KEY in ow_dict
+    elif source_user.is_file():
+        su_dict, su_warnings = parse_config(source_user)
+        warnings.extend(su_warnings)
+        if su_dict:
+            override_source = OverrideSource.USER_JSON
+            # CRITICAL: raw_dict from user.json, not config.json (spec §4)
+            raw_dict = su_dict
+            effective_priority = su_dict.get("priority", source_priority)
+            if not isinstance(effective_priority, int):
+                warnings.append(
+                    f"Priority is not an integer in {source_user}: {effective_priority!r}"
+                )
+                effective_priority = source_priority
+
+    # Read disabled from the winning raw_dict (user.json is complete replacement)
+    disabled = bool(raw_dict.get("disabled", False))
+
+    # Read conditions from winning raw_dict for display/filtering
+    conditions = raw_dict.get("conditions", {})
+    if not isinstance(conditions, (dict, list)):
+        conditions = {}
+
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description=description,
+        priority=effective_priority,
+        source_priority=source_priority,
+        disabled=disabled,
+        config_path=config_path,
+        override_source=override_source,
+        override_is_ours=override_is_ours,
+        raw_dict=raw_dict,
+        conditions=conditions,
+        warnings=warnings,
+    )
+
+
+def scan_mods(mods_dir: Path, overwrite_dir: Path) -> list[SubMod]:
+    """Scan the MO2 instance and build SubMod records for every OAR submod.
+
+    Args:
+        mods_dir: Path to the MO2 mods/ directory.
+        overwrite_dir: Path to the MO2 overwrite/ directory.
+
+    Returns:
+        List of SubMod records. Submods with parse errors have non-empty warnings.
+    """
+    submod_dirs = _find_submod_dirs(mods_dir)
+    submods: list[SubMod] = []
+
+    for mo2_mod, replacer, submod_folder, submod_path in submod_dirs:
+        sm = _build_submod(mo2_mod, replacer, submod_folder, submod_path, overwrite_dir)
+        submods.append(sm)
+
+    logger.info("Scanned %d submods from %s", len(submods), mods_dir)
+    return submods

--- a/src/oar_priority_manager/core/scanner.py
+++ b/src/oar_priority_manager/core/scanner.py
@@ -10,8 +10,8 @@ replacement for all fields except name/description (spec §4).
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from oar_priority_manager.core.models import METADATA_KEY, OAR_REL, OverrideSource, SubMod
 from oar_priority_manager.core.parser import parse_config

--- a/src/oar_priority_manager/core/scanner.py
+++ b/src/oar_priority_manager/core/scanner.py
@@ -11,17 +11,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Callable
 
-from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.models import METADATA_KEY, OAR_REL, OverrideSource, SubMod
 from oar_priority_manager.core.parser import parse_config
 
 logger = logging.getLogger(__name__)
-
-# The relative path within a mod that marks the OAR animation replacer root
-OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
-
-# Metadata key injected by this tool into Overwrite user.json files
-METADATA_KEY = "_oarPriorityManager"
 
 
 def _find_submod_dirs(mods_dir: Path) -> list[tuple[str, str, str, Path]]:
@@ -109,7 +104,7 @@ def _build_submod(
     if overwrite_user.is_file():
         ow_dict, ow_warnings = parse_config(overwrite_user)
         warnings.extend(ow_warnings)
-        if ow_dict:
+        if ow_dict:  # Empty dict {} means parse failed or no useful data — fall through
             override_source = OverrideSource.OVERWRITE
             raw_dict = ow_dict
             effective_priority = ow_dict.get("priority", source_priority)
@@ -122,7 +117,7 @@ def _build_submod(
     elif source_user.is_file():
         su_dict, su_warnings = parse_config(source_user)
         warnings.extend(su_warnings)
-        if su_dict:
+        if su_dict:  # Empty dict {} means parse failed or no useful data — fall through
             override_source = OverrideSource.USER_JSON
             # CRITICAL: raw_dict from user.json, not config.json (spec §4)
             raw_dict = su_dict
@@ -158,22 +153,32 @@ def _build_submod(
     )
 
 
-def scan_mods(mods_dir: Path, overwrite_dir: Path) -> list[SubMod]:
+def scan_mods(
+    mods_dir: Path,
+    overwrite_dir: Path,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> list[SubMod]:
     """Scan the MO2 instance and build SubMod records for every OAR submod.
 
     Args:
         mods_dir: Path to the MO2 mods/ directory.
         overwrite_dir: Path to the MO2 overwrite/ directory.
+        on_progress: Optional callback invoked after each submod is built.
+            Called with (current, total) where current is the number of submods
+            built so far and total is the total number to build.
 
     Returns:
         List of SubMod records. Submods with parse errors have non-empty warnings.
     """
     submod_dirs = _find_submod_dirs(mods_dir)
+    total = len(submod_dirs)
     submods: list[SubMod] = []
 
     for mo2_mod, replacer, submod_folder, submod_path in submod_dirs:
         sm = _build_submod(mo2_mod, replacer, submod_folder, submod_path, overwrite_dir)
         submods.append(sm)
+        if on_progress is not None:
+            on_progress(len(submods), total)
 
     logger.info("Scanned %d submods from %s", len(submods), mods_dir)
     return submods

--- a/src/oar_priority_manager/core/serializer.py
+++ b/src/oar_priority_manager/core/serializer.py
@@ -1,0 +1,116 @@
+"""JSON serializer with mutable-field allowlist for OAR user.json files.
+
+See spec §3.3 (architectural enforcement), §6.2 (serializer responsibilities),
+§8.1.1 (provenance metadata), §8.1.2 (round-trip precision).
+
+CRITICAL ARCHITECTURAL GUARDRAIL: Only the 'priority' field may be modified.
+Any other field change raises IllegalMutationError. This prevents scope creep
+into condition editing or disable toggling — the trap that killed attempts 1 and 2.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from oar_priority_manager.core.models import IllegalMutationError
+
+# The ONLY fields the tool is allowed to modify. Everything else must round-trip
+# unchanged. _oarPriorityManager is handled separately (always injected/updated).
+MUTABLE_FIELDS: frozenset[str] = frozenset({"priority"})
+
+# Metadata key injected into every tool-written user.json (spec §8.1.1)
+METADATA_KEY = "_oarPriorityManager"
+
+# Current tool version — embedded in metadata for provenance tracking
+_TOOL_VERSION = "0.1.0"
+
+
+def _deep_equal(a: object, b: object) -> bool:
+    """Deep equality check that handles nested dicts, lists, and primitives."""
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, dict):
+        if a.keys() != b.keys():  # type: ignore[union-attr]
+            return False
+        return all(_deep_equal(a[k], b[k]) for k in a)  # type: ignore[index]
+    if isinstance(a, list):
+        if len(a) != len(b):  # type: ignore[arg-type]
+            return False
+        return all(_deep_equal(x, y) for x, y in zip(a, b))  # type: ignore[arg-type]
+    return a == b
+
+
+def _validate_allowlist(modified: dict, original: dict) -> None:
+    """Check that only allowlisted fields have changed.
+
+    Raises IllegalMutationError if any non-allowlisted field differs.
+    """
+    # Check for removed keys
+    for key in original:
+        if key == METADATA_KEY:
+            continue
+        if key not in modified:
+            raise IllegalMutationError(key, original[key], "<removed>")
+
+    # Check for added keys
+    for key in modified:
+        if key == METADATA_KEY:
+            continue
+        if key not in original:
+            raise IllegalMutationError(key, "<absent>", modified[key])
+
+    # Check for modified values in non-allowlisted fields
+    for key in original:
+        if key == METADATA_KEY:
+            continue
+        if key in MUTABLE_FIELDS:
+            continue
+        if not _deep_equal(original[key], modified[key]):
+            raise IllegalMutationError(key, original[key], modified[key])
+
+
+def _build_metadata(previous_priority: int | None) -> dict:
+    """Build the _oarPriorityManager metadata object."""
+    meta: dict = {
+        "toolVersion": _TOOL_VERSION,
+        "writtenAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if previous_priority is not None:
+        meta["previousPriority"] = previous_priority
+    return meta
+
+
+def serialize_raw_dict(
+    modified: dict,
+    original: dict,
+    output_path: Path,
+    previous_priority: int | None = None,
+) -> None:
+    """Write a modified raw_dict to disk as JSON.
+
+    Args:
+        modified: The raw_dict with updated priority.
+        original: The raw_dict as originally read (for allowlist diffing).
+        output_path: Where to write the file.
+        previous_priority: The priority value before this change (for metadata).
+
+    Raises:
+        IllegalMutationError: If any non-allowlisted field has been modified.
+    """
+    # Validate before writing — the guardrail
+    _validate_allowlist(modified, original)
+
+    # Build output dict preserving key order from modified, inject metadata
+    output = dict(modified)
+    output[METADATA_KEY] = _build_metadata(previous_priority)
+
+    # Create parent directories
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write with consistent formatting (spec §8.1.2)
+    output_path.write_text(
+        json.dumps(output, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )

--- a/src/oar_priority_manager/core/serializer.py
+++ b/src/oar_priority_manager/core/serializer.py
@@ -11,17 +11,16 @@ into condition editing or disable toggling — the trap that killed attempts 1 a
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-from oar_priority_manager.core.models import IllegalMutationError
+from oar_priority_manager.core.models import METADATA_KEY, IllegalMutationError
 
 # The ONLY fields the tool is allowed to modify. Everything else must round-trip
 # unchanged. _oarPriorityManager is handled separately (always injected/updated).
 MUTABLE_FIELDS: frozenset[str] = frozenset({"priority"})
-
-# Metadata key injected into every tool-written user.json (spec §8.1.1)
-METADATA_KEY = "_oarPriorityManager"
 
 # Current tool version — embedded in metadata for provenance tracking
 _TOOL_VERSION = "0.1.0"
@@ -106,11 +105,18 @@ def serialize_raw_dict(
     output = dict(modified)
     output[METADATA_KEY] = _build_metadata(previous_priority)
 
-    # Create parent directories
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    json_text = json.dumps(output, indent=2, ensure_ascii=False) + "\n"
 
-    # Write with consistent formatting (spec §8.1.2)
-    output_path.write_text(
-        json.dumps(output, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
+    # Atomic write: write to temp file then rename (safe on NTFS).
+    # Prevents a crash mid-write from leaving a partial/corrupt user.json.
+    fd, tmp_path_str = tempfile.mkstemp(
+        dir=output_path.parent, suffix=".tmp", prefix=".oar_"
     )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json_text)
+        Path(tmp_path_str).replace(output_path)
+    except BaseException:
+        Path(tmp_path_str).unlink(missing_ok=True)
+        raise

--- a/src/oar_priority_manager/core/serializer.py
+++ b/src/oar_priority_manager/core/serializer.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from oar_priority_manager.core.models import METADATA_KEY, IllegalMutationError
@@ -37,7 +37,7 @@ def _deep_equal(a: object, b: object) -> bool:
     if isinstance(a, list):
         if len(a) != len(b):  # type: ignore[arg-type]
             return False
-        return all(_deep_equal(x, y) for x, y in zip(a, b))  # type: ignore[arg-type]
+        return all(_deep_equal(x, y) for x, y in zip(a, b, strict=True))  # type: ignore[arg-type]
     return a == b
 
 
@@ -74,7 +74,7 @@ def _build_metadata(previous_priority: int | None) -> dict:
     """Build the _oarPriorityManager metadata object."""
     meta: dict = {
         "toolVersion": _TOOL_VERSION,
-        "writtenAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "writtenAt": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     if previous_priority is not None:
         meta["previousPriority"] = previous_priority

--- a/src/oar_priority_manager/ui/__init__.py
+++ b/src/oar_priority_manager/ui/__init__.py
@@ -1,0 +1,1 @@
+"""PySide6 user interface modules."""

--- a/src/oar_priority_manager/ui/conditions_panel.py
+++ b/src/oar_priority_manager/ui/conditions_panel.py
@@ -1,0 +1,39 @@
+"""Conditions panel — read-only display of a competitor's condition tree.
+
+See spec §7.5. Right pane of the main layout.
+"""
+
+from __future__ import annotations
+
+import json
+
+from PySide6.QtWidgets import QLabel, QTextEdit, QVBoxLayout, QWidget
+
+from oar_priority_manager.core.models import SubMod
+
+
+class ConditionsPanel(QWidget):
+    """Right pane: conditions for the focused competitor."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._header = QLabel("Conditions")
+        layout.addWidget(self._header)
+
+        self._text = QTextEdit()
+        self._text.setReadOnly(True)
+        layout.addWidget(self._text)
+
+    def update_focus(self, submod: SubMod | None) -> None:
+        """Update conditions display for the focused competitor."""
+        if submod is None:
+            self._header.setText("Conditions")
+            self._text.clear()
+            return
+
+        self._header.setText(f"<b>Conditions</b> · {submod.mo2_mod} / {submod.name}")
+        # Raw JSON display (Tier 2: formatted REQUIRED/ONE OF/EXCLUDED view)
+        self._text.setPlainText(json.dumps(submod.conditions, indent=2))

--- a/src/oar_priority_manager/ui/details_panel.py
+++ b/src/oar_priority_manager/ui/details_panel.py
@@ -1,0 +1,45 @@
+"""Details panel — read-only metadata for the currently selected tree node.
+
+See spec §7.3. Shows different content for mod/replacer/submod selection levels.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from oar_priority_manager.core.models import SubMod
+from oar_priority_manager.ui.tree_model import NodeType
+
+
+class DetailsPanel(QWidget):
+    """Bottom section of left column — read-only metadata."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        self._label = QLabel("Select an item in the tree to see details.")
+        self._label.setWordWrap(True)
+        layout.addWidget(self._label)
+
+    def update_selection(self, node_type: NodeType | None, submod: SubMod | None) -> None:
+        """Update display based on tree selection."""
+        if node_type is None or (node_type == NodeType.SUBMOD and submod is None):
+            self._label.setText("Select an item in the tree to see details.")
+            return
+
+        if node_type == NodeType.SUBMOD and submod is not None:
+            lines = [
+                f"<b>{submod.name}</b>",
+                f"<span style='color:gray'>{submod.display_path}</span>",
+                f"Priority: <b>{submod.priority:,}</b>",
+            ]
+            if submod.is_overridden:
+                lines.append(f"<span style='color:#aa4'>was {submod.source_priority:,}</span>")
+            lines.append(f"MO2 source: <code>{submod.mo2_mod}</code>")
+            lines.append(f"Animations: {len(submod.animations)} files")
+            self._label.setText("<br>".join(lines))
+        elif node_type == NodeType.MOD:
+            self._label.setText("<b>Mod</b> — select a submod for details")
+        elif node_type == NodeType.REPLACER:
+            self._label.setText("<b>Replacer</b> — select a submod for details")

--- a/src/oar_priority_manager/ui/filter_builder.py
+++ b/src/oar_priority_manager/ui/filter_builder.py
@@ -1,0 +1,19 @@
+"""Advanced filter builder modal — three pill buckets.
+
+See spec §7.7. Stub for now — Tier 2: three pill buckets with autocomplete.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog, QLabel, QVBoxLayout
+
+
+class FilterBuilder(QDialog):
+    """Modal dialog with REQUIRED / ANY OF / EXCLUDED pill buckets."""
+
+    def __init__(self, known_types: list[str], parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Advanced Condition Filter")
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Advanced filter builder — coming soon"))
+        self._known_types = known_types

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -1,0 +1,152 @@
+"""Main application window — three-pane layout with splitters.
+
+See spec §7.1 (layout), §6.3 (data flow).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtWidgets import QMainWindow, QSplitter, QVBoxLayout, QWidget
+
+from oar_priority_manager.app.config import AppConfig
+from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.models import PriorityStack, SubMod
+from oar_priority_manager.core.priority_resolver import build_stacks
+from oar_priority_manager.core.scanner import scan_mods
+from oar_priority_manager.ui.conditions_panel import ConditionsPanel
+from oar_priority_manager.ui.details_panel import DetailsPanel
+from oar_priority_manager.ui.search_bar import SearchBar
+from oar_priority_manager.ui.stacks_panel import StacksPanel
+from oar_priority_manager.ui.tree_panel import TreePanel
+
+
+class MainWindow(QMainWindow):
+    """Three-pane main window: (Tree+Details) | Stacks | Conditions."""
+
+    def __init__(
+        self,
+        submods: list[SubMod],
+        conflict_map: dict[str, list[SubMod]],
+        stacks: list[PriorityStack],
+        app_config: AppConfig,
+        instance_root: Path,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("OAR Priority Manager")
+        self.resize(1400, 800)
+
+        self._submods = submods
+        self._conflict_map = conflict_map
+        self._stacks = stacks
+        self._config = app_config
+        self._instance_root = instance_root
+
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        central = QWidget()
+        self.setCentralWidget(central)
+        main_layout = QVBoxLayout(central)
+        main_layout.setContentsMargins(4, 4, 4, 4)
+
+        # Top bar: search + advanced + refresh
+        self._search_bar = SearchBar()
+        main_layout.addWidget(self._search_bar)
+
+        # Three-pane splitter
+        self._main_splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left column: tree + details (vertical split)
+        self._left_splitter = QSplitter(Qt.Orientation.Vertical)
+        self._tree_panel = TreePanel(self._submods)
+        self._details_panel = DetailsPanel()
+        self._left_splitter.addWidget(self._tree_panel)
+        self._left_splitter.addWidget(self._details_panel)
+        self._left_splitter.setStretchFactor(0, 3)
+        self._left_splitter.setStretchFactor(1, 1)
+
+        # Center: priority stacks
+        self._stacks_panel = StacksPanel(self._conflict_map)
+
+        # Right: conditions
+        self._conditions_panel = ConditionsPanel()
+
+        self._main_splitter.addWidget(self._left_splitter)
+        self._main_splitter.addWidget(self._stacks_panel)
+        self._main_splitter.addWidget(self._conditions_panel)
+        self._main_splitter.setStretchFactor(0, 1)
+        self._main_splitter.setStretchFactor(1, 2)
+        self._main_splitter.setStretchFactor(2, 1)
+
+        main_layout.addWidget(self._main_splitter)
+
+        # Ctrl+F shortcut to focus search
+        shortcut = QShortcut(QKeySequence("Ctrl+F"), self)
+        shortcut.activated.connect(self._search_bar.focus_search)
+
+    def _connect_signals(self) -> None:
+        self._tree_panel.selection_changed.connect(self._on_tree_selection)
+        self._search_bar.refresh_requested.connect(self._on_refresh)
+        self._stacks_panel.action_triggered.connect(self._on_action)
+
+    def _on_tree_selection(self, node_type, submod) -> None:
+        self._details_panel.update_selection(node_type, submod)
+        self._stacks_panel.update_selection(submod)
+        if submod:
+            self._conditions_panel.update_focus(submod)
+
+    def _on_action(self, action: str, submod: SubMod, value: object) -> None:
+        """Handle priority mutation actions from the stacks panel (spec §6.3 step 5)."""
+        from oar_priority_manager.core.override_manager import write_override
+        from oar_priority_manager.core.priority_resolver import (
+            PriorityOverflowError,
+            move_to_top,
+            set_exact,
+        )
+
+        try:
+            if action == "move_to_top":
+                new_priorities = move_to_top(submod, self._conflict_map, scope="submod")
+            elif action == "set_exact" and isinstance(value, int):
+                new_priorities = set_exact(submod, value)
+            else:
+                return
+
+            overwrite_dir = self._instance_root / "overwrite"
+            for sm, new_p in new_priorities.items():
+                write_override(sm, new_p, overwrite_dir)
+
+            # Refresh stacks display (in-memory, no re-scan)
+            self._conflict_map = build_conflict_map(self._submods)
+            self._stacks = build_stacks(self._conflict_map)
+            self._stacks_panel.refresh(self._conflict_map)
+            self._stacks_panel.update_selection(submod)
+            self._tree_panel.refresh(self._submods)
+
+        except PriorityOverflowError as e:
+            from PySide6.QtWidgets import QMessageBox
+            QMessageBox.warning(self, "Priority Overflow", str(e))
+
+    def _on_refresh(self) -> None:
+        """Re-scan the VFS and rebuild all models (spec §6.3 step 6)."""
+        mods_dir = self._instance_root / "mods"
+        overwrite_dir = self._instance_root / "overwrite"
+
+        self._submods = scan_mods(mods_dir, overwrite_dir)
+        scan_animations(self._submods)
+        self._conflict_map = build_conflict_map(self._submods)
+        self._stacks = build_stacks(self._conflict_map)
+
+        for sm in self._submods:
+            present, negated = extract_condition_types(sm.conditions)
+            sm.condition_types_present = present
+            sm.condition_types_negated = negated
+
+        self._tree_panel.refresh(self._submods)
+        self._stacks_panel.refresh(self._conflict_map)

--- a/src/oar_priority_manager/ui/search_bar.py
+++ b/src/oar_priority_manager/ui/search_bar.py
@@ -1,0 +1,40 @@
+"""Unified search bar — name search + condition filter mode.
+
+See spec §7.2. Tier 2: condition filter mode (AND/OR/NOT), autocomplete.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QWidget
+
+
+class SearchBar(QWidget):
+    """Top-bar search input with Advanced button and Refresh button."""
+
+    search_changed = Signal(str)
+    refresh_requested = Signal()
+    advanced_requested = Signal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        self._input = QLineEdit()
+        self._input.setPlaceholderText("Search mods, submods, animations...")
+        self._input.textChanged.connect(self.search_changed.emit)
+        layout.addWidget(self._input, stretch=1)
+
+        self._advanced_btn = QPushButton("Advanced...")
+        self._advanced_btn.clicked.connect(self.advanced_requested.emit)
+        layout.addWidget(self._advanced_btn)
+
+        self._refresh_btn = QPushButton("Refresh")
+        self._refresh_btn.clicked.connect(self.refresh_requested.emit)
+        layout.addWidget(self._refresh_btn)
+
+    def focus_search(self) -> None:
+        """Focus the search input and select all text."""
+        self._input.setFocus()
+        self._input.selectAll()

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from oar_priority_manager.core.models import PriorityStack, SubMod
+from oar_priority_manager.core.models import SubMod
 
 
 class StacksPanel(QWidget):
@@ -103,7 +103,10 @@ class StacksPanel(QWidget):
         priorities = [c.priority for c in competitors]
         has_ties = len(priorities) != len(set(priorities))
         if has_ties and rank >= 0:
-            tied_with = [c for c in competitors if c.priority == selected.priority and c is not selected]
+            tied_with = [
+                c for c in competitors
+                if c.priority == selected.priority and c is not selected
+            ]
             if tied_with:
                 status += " <span style='color:#aa4'>⚠ TIED</span>"
 

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -1,0 +1,171 @@
+"""Priority stacks panel — shows animation competition for the selected submod.
+
+See spec §7.4. Center pane of the main layout.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from oar_priority_manager.core.models import PriorityStack, SubMod
+
+
+class StacksPanel(QWidget):
+    """Center pane: priority stacks for the selected submod's animations."""
+
+    # Emitted when user clicks a competitor row: (submod,)
+    competitor_focused = Signal(object)
+    # Emitted when user triggers a priority action: (action_name, submod, value)
+    action_triggered = Signal(str, object, object)
+
+    def __init__(
+        self,
+        conflict_map: dict[str, list[SubMod]],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._conflict_map = conflict_map
+        self._current_submod: SubMod | None = None
+        self._relative_mode = True
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._header = QLabel("Select a submod to see priority stacks.")
+        layout.addWidget(self._header)
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._content = QWidget()
+        self._content_layout = QVBoxLayout(self._content)
+        self._scroll.setWidget(self._content)
+        layout.addWidget(self._scroll)
+
+        # Action buttons (spec §7.4)
+        layout.addWidget(self._build_action_bar())
+
+    def update_selection(self, submod: SubMod | None) -> None:
+        """Update stacks display for the selected submod."""
+        self._current_submod = submod
+        self._refresh_display()
+
+    def _refresh_display(self) -> None:
+        # Clear existing content
+        while self._content_layout.count():
+            child = self._content_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+        sm = self._current_submod
+        if sm is None:
+            self._header.setText("Select a submod to see priority stacks.")
+            return
+
+        self._header.setText(f"<b>Priority Stacks</b> · <code>{sm.name}</code>")
+
+        for anim in sm.animations:
+            competitors = self._conflict_map.get(anim, [])
+            section = self._build_stack_section(anim, competitors, sm)
+            self._content_layout.addWidget(section)
+
+        self._content_layout.addStretch()
+
+    def _build_stack_section(
+        self, anim: str, competitors: list[SubMod], selected: SubMod,
+    ) -> QWidget:
+        """Build one expandable stack section for an animation."""
+        section = QWidget()
+        layout = QVBoxLayout(section)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        # Header
+        rank = next((i for i, c in enumerate(competitors) if c is selected), -1)
+        if rank == 0:
+            status = "<span style='color:#4a9'>you're #1</span>"
+        elif rank > 0 and competitors:
+            delta = competitors[0].priority - selected.priority
+            target = competitors[0].priority + 1
+            status = f"<span style='color:#e66'>losing by {delta} · set to {target:,} to win</span>"
+        else:
+            status = ""
+
+        # Check for ties
+        priorities = [c.priority for c in competitors]
+        has_ties = len(priorities) != len(set(priorities))
+        if has_ties and rank >= 0:
+            tied_with = [c for c in competitors if c.priority == selected.priority and c is not selected]
+            if tied_with:
+                status += " <span style='color:#aa4'>⚠ TIED</span>"
+
+        header = QLabel(f"▾ <b>{anim}</b> · {len(competitors)} competitors · {status}")
+        header.setTextFormat(1)  # RichText
+        layout.addWidget(header)
+
+        # Competitor rows
+        for i, comp in enumerate(competitors):
+            is_you = comp is selected
+            rank_num = i + 1
+            if self._relative_mode:
+                delta = comp.priority - competitors[0].priority if competitors else 0
+                val_text = f"+{delta}" if delta >= 0 else str(delta)
+            else:
+                val_text = f"{comp.priority:,}"
+
+            you_marker = " <b>(you)</b>" if is_you else ""
+            row_text = f"  #{rank_num} {val_text}  {comp.mo2_mod} / {comp.name}{you_marker}"
+            row = QLabel(row_text)
+            layout.addWidget(row)
+
+        return section
+
+    def _build_action_bar(self) -> QWidget:
+        """Build Move to Top / Set Exact action buttons."""
+        bar = QWidget()
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        self._move_to_top_btn = QPushButton("Move to Top")
+        self._move_to_top_btn.clicked.connect(
+            lambda: self.action_triggered.emit("move_to_top", self._current_submod, None)
+        )
+        layout.addWidget(self._move_to_top_btn)
+
+        self._set_exact_btn = QPushButton("Set Exact…")
+        self._set_exact_btn.clicked.connect(self._on_set_exact)
+        layout.addWidget(self._set_exact_btn)
+
+        layout.addStretch()
+        return bar
+
+    def _on_set_exact(self) -> None:
+        from PySide6.QtWidgets import QInputDialog
+        if self._current_submod is None:
+            return
+        value, ok = QInputDialog.getInt(
+            self, "Set Exact Priority",
+            f"New priority for {self._current_submod.name}:",
+            value=self._current_submod.priority,
+            min=-2_147_483_648, max=2_147_483_647,
+        )
+        if ok:
+            self.action_triggered.emit("set_exact", self._current_submod, value)
+
+    def set_relative_mode(self, relative: bool) -> None:
+        """Switch between relative (delta) and absolute priority display."""
+        self._relative_mode = relative
+        self._refresh_display()
+
+    def refresh(self, conflict_map: dict[str, list[SubMod]]) -> None:
+        """Refresh display using updated conflict map."""
+        self._conflict_map = conflict_map
+        self._refresh_display()

--- a/src/oar_priority_manager/ui/tree_model.py
+++ b/src/oar_priority_manager/ui/tree_model.py
@@ -1,0 +1,214 @@
+"""UI tree model for OAR Priority Manager.
+
+Builds a Mod -> Replacer -> SubMod hierarchy from a flat list[SubMod], and
+provides a SearchIndex for the unified search bar.
+
+See spec §6.2 (tree_model), §7.3 (tree sort order):
+  - Mods: alphabetical
+  - Replacers: alphabetical
+  - Submods: priority descending
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import NamedTuple
+
+from oar_priority_manager.core.models import SubMod
+
+
+class NodeType(Enum):
+    """Identifies the role of a node in the three-level tree.
+
+    ROOT is the invisible container at the top; MOD, REPLACER, and SUBMOD
+    correspond to each level of the OAR directory hierarchy.
+    """
+
+    ROOT = auto()
+    MOD = auto()
+    REPLACER = auto()
+    SUBMOD = auto()
+
+
+@dataclass
+class TreeNode:
+    """One node in the Mod -> Replacer -> SubMod display tree.
+
+    Attributes:
+        display_name: The human-readable label shown in the UI.
+        node_type: Which level of the hierarchy this node occupies.
+        children: Ordered child nodes (see §7.3 for sort rules).
+        submod: The underlying SubMod, populated only for SUBMOD nodes.
+        parent: The parent TreeNode (None for ROOT).
+        auto_expand: True when this REPLACER node is the sole replacer
+            under its parent MOD — the UI should expand it automatically.
+    """
+
+    display_name: str
+    node_type: NodeType
+    children: list[TreeNode] = field(default_factory=list)
+    submod: SubMod | None = None
+    parent: TreeNode | None = field(default=None, repr=False)
+    auto_expand: bool = False
+
+
+def build_tree(submods: list[SubMod]) -> TreeNode:
+    """Construct the three-level display tree from a flat SubMod list.
+
+    Sort order per spec §7.3:
+      - MOD nodes: alphabetical by display_name (case-sensitive)
+      - REPLACER nodes: alphabetical by display_name (case-sensitive)
+      - SUBMOD nodes: priority descending (highest priority first)
+
+    A REPLACER node gains ``auto_expand = True`` when its parent MOD has
+    exactly one replacer, so the UI can expand it without user interaction.
+
+    Args:
+        submods: Flat list of SubMod instances from the scanner.
+
+    Returns:
+        The ROOT TreeNode whose children are the sorted MOD nodes.
+    """
+    root = TreeNode(display_name="", node_type=NodeType.ROOT)
+
+    # Group: mod -> replacer -> [submods]
+    # Use nested defaultdicts keyed by (mo2_mod, replacer)
+    grouped: dict[str, dict[str, list[SubMod]]] = defaultdict(lambda: defaultdict(list))
+    for sm in submods:
+        grouped[sm.mo2_mod][sm.replacer].append(sm)
+
+    # Build MOD nodes sorted alphabetically
+    for mod_name in sorted(grouped.keys()):
+        mod_node = TreeNode(
+            display_name=mod_name,
+            node_type=NodeType.MOD,
+            parent=root,
+        )
+
+        replacer_dict = grouped[mod_name]
+        single_replacer = len(replacer_dict) == 1
+
+        # Build REPLACER nodes sorted alphabetically
+        for rep_name in sorted(replacer_dict.keys()):
+            rep_node = TreeNode(
+                display_name=rep_name,
+                node_type=NodeType.REPLACER,
+                parent=mod_node,
+                auto_expand=single_replacer,
+            )
+
+            # Build SUBMOD nodes sorted by priority descending
+            for sm in sorted(replacer_dict[rep_name], key=lambda s: s.priority, reverse=True):
+                sub_node = TreeNode(
+                    display_name=sm.name,
+                    node_type=NodeType.SUBMOD,
+                    submod=sm,
+                    parent=rep_node,
+                )
+                rep_node.children.append(sub_node)
+
+            mod_node.children.append(rep_node)
+
+        root.children.append(mod_node)
+
+    return root
+
+
+class SearchResult(NamedTuple):
+    """A single hit returned from SearchIndex.search().
+
+    Attributes:
+        display_text: Human-readable label for this result (shown in the UI).
+        node_type: Which level of the tree this result came from.
+        node: The matching TreeNode so the UI can navigate to it.
+    """
+
+    display_text: str
+    node_type: NodeType
+    node: TreeNode
+
+
+class SearchIndex:
+    """Case-insensitive substring search across the entire tree.
+
+    Indexes mod names, replacer names, submod names, and animation
+    filenames. Animation hits resolve to the SUBMOD nodes that own
+    the matching animation via ``conflict_map``.
+
+    Args:
+        root: The ROOT TreeNode produced by :func:`build_tree`.
+        conflict_map: Mapping from animation filename to list[SubMod],
+            as produced by the priority resolver. Used to resolve
+            animation-filename hits back to tree nodes.
+    """
+
+    def __init__(self, root: TreeNode, conflict_map: dict[str, list[SubMod]]) -> None:
+        self._root = root
+        self._conflict_map = conflict_map
+        # Maps id(SubMod) -> SUBMOD TreeNode for O(1) animation lookup
+        self._submod_node_map: dict[int, TreeNode] = {}
+        # Pre-built list of (lowercased_text, SearchResult) for non-animation entries
+        self._entries: list[tuple[str, SearchResult]] = []
+        self._build()
+
+    def _build(self) -> None:
+        """Walk the tree once to populate the search index."""
+        self._entries.clear()
+        self._submod_node_map.clear()
+
+        def _walk(node: TreeNode) -> None:
+            if node.node_type == NodeType.ROOT:
+                for child in node.children:
+                    _walk(child)
+                return
+
+            # Index this node's display name
+            result = SearchResult(
+                display_text=node.display_name,
+                node_type=node.node_type,
+                node=node,
+            )
+            self._entries.append((node.display_name.lower(), result))
+
+            if node.node_type == NodeType.SUBMOD and node.submod is not None:
+                # Register for animation-filename lookups
+                self._submod_node_map[id(node.submod)] = node
+
+            for child in node.children:
+                _walk(child)
+
+        _walk(self._root)
+
+        # Index animation filenames from conflict_map
+        for anim_filename, competing_submods in self._conflict_map.items():
+            for sm in competing_submods:
+                tree_node = self._submod_node_map.get(id(sm))
+                if tree_node is None:
+                    continue
+                result = SearchResult(
+                    display_text=anim_filename,
+                    node_type=NodeType.SUBMOD,
+                    node=tree_node,
+                )
+                self._entries.append((anim_filename.lower(), result))
+
+    def search(self, query: str) -> list[SearchResult]:
+        """Return all indexed entries whose text contains *query*.
+
+        The match is case-insensitive substring. An empty query returns an
+        empty list immediately so the search bar stays clear when unfocused.
+
+        Args:
+            query: The string typed into the search bar.
+
+        Returns:
+            List of :class:`SearchResult` in index order (no additional
+            ranking — callers may sort as needed).
+        """
+        if not query:
+            return []
+
+        q = query.lower()
+        return [result for text, result in self._entries if q in text]

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -1,0 +1,74 @@
+"""Left-column tree panel showing Mod → Replacer → Submod hierarchy.
+
+See spec §7.3. Full implementation in Task 14.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QLabel, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+
+from oar_priority_manager.core.models import SubMod
+from oar_priority_manager.ui.tree_model import NodeType, TreeNode, build_tree
+
+
+class TreePanel(QWidget):
+    """Tree panel: Mod → Replacer → Submod hierarchy with status icons."""
+
+    # Emitted when a tree node is selected: (node_type, submod_or_None)
+    selection_changed = Signal(object, object)
+
+    def __init__(self, submods: list[SubMod], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._submods = submods
+        self._root = build_tree(submods)
+        self._setup_ui()
+        self._populate()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._tree = QTreeWidget()
+        self._tree.setHeaderHidden(True)
+        self._tree.currentItemChanged.connect(self._on_selection)
+        layout.addWidget(self._tree)
+
+    def _populate(self) -> None:
+        self._tree.clear()
+        self._item_map: dict[int, TreeNode] = {}
+
+        for mod_node in self._root.children:
+            mod_item = QTreeWidgetItem([mod_node.display_name])
+            self._item_map[id(mod_item)] = mod_node
+
+            for rep_node in mod_node.children:
+                rep_item = QTreeWidgetItem([rep_node.display_name])
+                self._item_map[id(rep_item)] = rep_node
+
+                for sub_node in rep_node.children:
+                    sm = sub_node.submod
+                    icon = "⚠" if (sm and sm.has_warnings) else ("✗" if (sm and sm.disabled) else "✓")
+                    sub_item = QTreeWidgetItem([f"{icon} {sub_node.display_name}"])
+                    self._item_map[id(sub_item)] = sub_node
+                    rep_item.addChild(sub_item)
+
+                mod_item.addChild(rep_item)
+                if rep_node.auto_expand:
+                    rep_item.setExpanded(True)
+
+            self._tree.addTopLevelItem(mod_item)
+
+    def _on_selection(self, current: QTreeWidgetItem | None, _previous: QTreeWidgetItem | None) -> None:
+        if current is None:
+            self.selection_changed.emit(None, None)
+            return
+        node = self._item_map.get(id(current))
+        if node:
+            self.selection_changed.emit(node.node_type, node.submod)
+
+    def refresh(self, submods: list[SubMod]) -> None:
+        """Refresh tree from new submod data."""
+        self._submods = submods
+        self._root = build_tree(submods)
+        self._populate()

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -6,10 +6,10 @@ See spec §7.3. Full implementation in Task 14.
 from __future__ import annotations
 
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QLabel, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from oar_priority_manager.core.models import SubMod
-from oar_priority_manager.ui.tree_model import NodeType, TreeNode, build_tree
+from oar_priority_manager.ui.tree_model import TreeNode, build_tree
 
 
 class TreePanel(QWidget):
@@ -48,7 +48,12 @@ class TreePanel(QWidget):
 
                 for sub_node in rep_node.children:
                     sm = sub_node.submod
-                    icon = "⚠" if (sm and sm.has_warnings) else ("✗" if (sm and sm.disabled) else "✓")
+                    if sm and sm.has_warnings:
+                        icon = "⚠"
+                    elif sm and sm.disabled:
+                        icon = "✗"
+                    else:
+                        icon = "✓"
                     sub_item = QTreeWidgetItem([f"{icon} {sub_node.display_name}"])
                     self._item_map[id(sub_item)] = sub_node
                     rep_item.addChild(sub_item)
@@ -59,7 +64,9 @@ class TreePanel(QWidget):
 
             self._tree.addTopLevelItem(mod_item)
 
-    def _on_selection(self, current: QTreeWidgetItem | None, _previous: QTreeWidgetItem | None) -> None:
+    def _on_selection(
+        self, current: QTreeWidgetItem | None, _previous: QTreeWidgetItem | None
+    ) -> None:
         if current is None:
             self.selection_changed.emit(None, None)
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,105 @@
+"""Shared test fixtures for OAR Priority Manager.
+
+Provides factory functions that create synthetic MO2 mod directories
+with OAR config files on disk. Used by parser, scanner, anim_scanner,
+serializer, and override_manager tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# --- Standard OAR directory path segments ---
+OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> Path:
+    """Write a dict as JSON to the given path, creating parents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def make_config_json(
+    name: str = "test_submod",
+    description: str = "",
+    priority: int = 100,
+    disabled: bool = False,
+    conditions: dict | list | None = None,
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a config.json dict with standard OAR fields."""
+    data: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "priority": priority,
+        "disabled": disabled,
+        "conditions": conditions if conditions is not None else [],
+    }
+    if extra_fields:
+        data.update(extra_fields)
+    return data
+
+
+def make_submod_dir(
+    mods_dir: Path,
+    mo2_mod: str,
+    replacer: str,
+    submod_name: str,
+    config: dict[str, Any] | None = None,
+    user_json: dict[str, Any] | None = None,
+    animations: list[str] | None = None,
+) -> Path:
+    """Create a complete submod directory with config.json, optional user.json, and .hkx files.
+
+    Returns the submod directory path.
+    """
+    submod_dir = mods_dir / mo2_mod / OAR_REL / replacer / submod_name
+    submod_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write config.json (always present)
+    if config is None:
+        config = make_config_json(name=submod_name)
+    _write_json(submod_dir / "config.json", config)
+
+    # Write user.json (optional)
+    if user_json is not None:
+        _write_json(submod_dir / "user.json", user_json)
+
+    # Write .hkx animation files (empty files, just need to exist)
+    if animations:
+        for anim in animations:
+            anim_path = submod_dir / anim
+            anim_path.touch()
+
+    return submod_dir
+
+
+@pytest.fixture
+def tmp_mods_dir(tmp_path: Path) -> Path:
+    """Provide a temporary 'mods/' directory."""
+    mods = tmp_path / "mods"
+    mods.mkdir()
+    return mods
+
+
+@pytest.fixture
+def tmp_overwrite_dir(tmp_path: Path) -> Path:
+    """Provide a temporary 'overwrite/' directory."""
+    ow = tmp_path / "overwrite"
+    ow.mkdir()
+    return ow
+
+
+@pytest.fixture
+def tmp_instance(tmp_path: Path) -> Path:
+    """Provide a complete MO2 instance root with mods/ and overwrite/ dirs."""
+    (tmp_path / "mods").mkdir()
+    (tmp_path / "overwrite").mkdir()
+    (tmp_path / "ModOrganizer.ini").touch()
+    return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,7 @@ from typing import Any
 
 import pytest
 
-
-# --- Standard OAR directory path segments ---
-OAR_REL = Path("meshes/actors/character/animations/OpenAnimationReplacer")
+from oar_priority_manager.core.models import OAR_REL
 
 
 def _write_json(path: Path, data: dict[str, Any]) -> Path:

--- a/tests/fixtures/mods/README.md
+++ b/tests/fixtures/mods/README.md
@@ -1,0 +1,15 @@
+# Test Fixtures
+
+## Synthetic fixtures (created by tests)
+
+Tests use `conftest.py` factory functions (`make_submod_dir`, `make_config_json`)
+to create fixture directories in `tmp_path`. No static fixtures are committed here
+for the initial implementation.
+
+## Real-world fixtures (to be added during first milestone)
+
+During the first implementation milestone, harvest config.json files from 10+
+popular OAR mods on Nexus Mods. Place them here with mod author attribution.
+These validate the parser against undocumented fields and non-standard formatting.
+
+See spec §11.1 for details.

--- a/tests/integration/test_write_clear_rescan.py
+++ b/tests/integration/test_write_clear_rescan.py
@@ -1,0 +1,147 @@
+"""Integration test: write_override → clear_override → re-scan round-trip.
+
+Verifies that:
+1. write_override correctly updates both disk and in-memory SubMod state.
+2. clear_override removes the Overwrite file and reverts in-memory state.
+3. A fresh scan_mods() after clear produces a SubMod that matches the
+   in-memory state clear_override left behind.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.anim_scanner import scan_animations
+from oar_priority_manager.core.models import OverrideSource
+from oar_priority_manager.core.override_manager import clear_override, write_override
+from oar_priority_manager.core.scanner import scan_mods
+from tests.conftest import make_config_json, make_submod_dir
+
+
+class TestWriteClearRescan:
+    """Full round-trip: write override, clear it, re-scan — state must be consistent."""
+
+    def _setup_instance(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Create two competing mods sharing an animation file. Returns (mods_dir, overwrite_dir)."""
+        mods_dir = tmp_path / "mods"
+        mods_dir.mkdir()
+        overwrite_dir = tmp_path / "overwrite"
+        overwrite_dir.mkdir()
+
+        # ModA: replacer "Rep", submod "sub1", priority 100, with a shared animation
+        make_submod_dir(
+            mods_dir,
+            mo2_mod="ModA",
+            replacer="Rep",
+            submod_name="sub1",
+            config=make_config_json(name="sub1", priority=100),
+            animations=["attack.hkx"],
+        )
+
+        # ModB: replacer "Rep", submod "sub2", priority 200, same animation filename
+        make_submod_dir(
+            mods_dir,
+            mo2_mod="ModB",
+            replacer="Rep",
+            submod_name="sub2",
+            config=make_config_json(name="sub2", priority=200),
+            animations=["attack.hkx"],
+        )
+
+        return mods_dir, overwrite_dir
+
+    def test_write_updates_disk_and_memory(self, tmp_path: Path):
+        """write_override must create the Overwrite user.json and update in-memory fields."""
+        mods_dir, overwrite_dir = self._setup_instance(tmp_path)
+
+        submods = scan_mods(mods_dir, overwrite_dir)
+        assert len(submods) == 2
+
+        # Pick sub1 (priority 100) and write a new priority
+        sub1 = next(sm for sm in submods if sm.name == "sub1")
+        write_override(sub1, 999, overwrite_dir)
+
+        # In-memory state
+        assert sub1.priority == 999
+        assert sub1.override_source == OverrideSource.OVERWRITE
+        assert sub1.override_is_ours is True
+
+        # Disk state
+        from oar_priority_manager.core.override_manager import compute_overwrite_path
+        ow_path = compute_overwrite_path(sub1, overwrite_dir)
+        assert ow_path.exists()
+        data = json.loads(ow_path.read_text(encoding="utf-8"))
+        assert data["priority"] == 999
+        assert "_oarPriorityManager" in data
+        assert data["_oarPriorityManager"]["previousPriority"] == 100
+
+    def test_clear_removes_disk_file_and_reverts_memory(self, tmp_path: Path):
+        """clear_override must delete the Overwrite file and revert in-memory to source state."""
+        mods_dir, overwrite_dir = self._setup_instance(tmp_path)
+
+        submods = scan_mods(mods_dir, overwrite_dir)
+        sub1 = next(sm for sm in submods if sm.name == "sub1")
+
+        # Write then clear
+        write_override(sub1, 999, overwrite_dir)
+        clear_override(sub1, overwrite_dir)
+
+        # Disk file must be gone
+        from oar_priority_manager.core.override_manager import compute_overwrite_path
+        ow_path = compute_overwrite_path(sub1, overwrite_dir)
+        assert not ow_path.exists()
+
+        # In-memory state must revert to source config.json values
+        assert sub1.priority == 100
+        assert sub1.override_source == OverrideSource.SOURCE
+        assert sub1.override_is_ours is False
+        assert sub1.raw_dict.get("priority") == 100
+
+    def test_rescan_after_clear_matches_cleared_state(self, tmp_path: Path):
+        """A fresh scan_mods after clear must produce a SubMod matching the post-clear in-memory state."""
+        mods_dir, overwrite_dir = self._setup_instance(tmp_path)
+
+        submods = scan_mods(mods_dir, overwrite_dir)
+        sub1 = next(sm for sm in submods if sm.name == "sub1")
+
+        # Write then clear
+        write_override(sub1, 999, overwrite_dir)
+        clear_override(sub1, overwrite_dir)
+
+        # Re-scan
+        rescanned = scan_mods(mods_dir, overwrite_dir)
+        rescanned_sub1 = next(sm for sm in rescanned if sm.name == "sub1")
+
+        # Rescanned SubMod must agree with post-clear in-memory state on every
+        # state field the tool manages
+        assert rescanned_sub1.priority == sub1.priority
+        assert rescanned_sub1.override_source == sub1.override_source
+        assert rescanned_sub1.override_is_ours == sub1.override_is_ours
+        # raw_dict keys should be identical (both from config.json)
+        assert set(rescanned_sub1.raw_dict.keys()) == set(sub1.raw_dict.keys())
+
+    def test_write_clear_write_again(self, tmp_path: Path):
+        """After a clear, a second write_override must succeed and write correct state."""
+        mods_dir, overwrite_dir = self._setup_instance(tmp_path)
+
+        submods = scan_mods(mods_dir, overwrite_dir)
+        sub1 = next(sm for sm in submods if sm.name == "sub1")
+
+        # First write, then clear, then second write
+        write_override(sub1, 999, overwrite_dir)
+        clear_override(sub1, overwrite_dir)
+        write_override(sub1, 777, overwrite_dir)
+
+        assert sub1.priority == 777
+        assert sub1.override_source == OverrideSource.OVERWRITE
+        assert sub1.override_is_ours is True
+
+        from oar_priority_manager.core.override_manager import compute_overwrite_path
+        ow_path = compute_overwrite_path(sub1, overwrite_dir)
+        data = json.loads(ow_path.read_text(encoding="utf-8"))
+        assert data["priority"] == 777
+        # previousPriority should reflect the priority at time of second write (100, not 999)
+        assert data["_oarPriorityManager"]["previousPriority"] == 100

--- a/tests/integration/test_write_clear_rescan.py
+++ b/tests/integration/test_write_clear_rescan.py
@@ -12,9 +12,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-from oar_priority_manager.core.anim_scanner import scan_animations
 from oar_priority_manager.core.models import OverrideSource
 from oar_priority_manager.core.override_manager import clear_override, write_override
 from oar_priority_manager.core.scanner import scan_mods
@@ -25,7 +22,10 @@ class TestWriteClearRescan:
     """Full round-trip: write override, clear it, re-scan — state must be consistent."""
 
     def _setup_instance(self, tmp_path: Path) -> tuple[Path, Path]:
-        """Create two competing mods sharing an animation file. Returns (mods_dir, overwrite_dir)."""
+        """Create two competing mods sharing an animation file.
+
+        Returns (mods_dir, overwrite_dir).
+        """
         mods_dir = tmp_path / "mods"
         mods_dir.mkdir()
         overwrite_dir = tmp_path / "overwrite"
@@ -101,7 +101,7 @@ class TestWriteClearRescan:
         assert sub1.raw_dict.get("priority") == 100
 
     def test_rescan_after_clear_matches_cleared_state(self, tmp_path: Path):
-        """A fresh scan_mods after clear must produce a SubMod matching the post-clear in-memory state."""
+        """A fresh scan_mods after clear must match the post-clear in-memory state."""
         mods_dir, overwrite_dir = self._setup_instance(tmp_path)
 
         submods = scan_mods(mods_dir, overwrite_dir)

--- a/tests/smoke/test_ui_smoke.py
+++ b/tests/smoke/test_ui_smoke.py
@@ -10,7 +10,6 @@ import pytest
 
 from oar_priority_manager.app.config import AppConfig
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
-from oar_priority_manager.core.models import PriorityStack
 from oar_priority_manager.core.priority_resolver import build_stacks
 from oar_priority_manager.core.scanner import scan_mods
 from oar_priority_manager.ui.main_window import MainWindow

--- a/tests/smoke/test_ui_smoke.py
+++ b/tests/smoke/test_ui_smoke.py
@@ -1,0 +1,85 @@
+"""UI smoke tests — verify panels construct and basic interactions don't crash.
+
+See spec §11.1 (smoke tests).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.app.config import AppConfig
+from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.models import PriorityStack
+from oar_priority_manager.core.priority_resolver import build_stacks
+from oar_priority_manager.core.scanner import scan_mods
+from oar_priority_manager.ui.main_window import MainWindow
+from tests.conftest import make_config_json, make_submod_dir
+
+
+@pytest.fixture
+def populated_instance(tmp_path: Path) -> Path:
+    """Create a tmp MO2 instance with a few OAR mods."""
+    instance = tmp_path
+    mods = instance / "mods"
+    mods.mkdir()
+    (instance / "overwrite").mkdir()
+    (instance / "ModOrganizer.ini").touch()
+
+    make_submod_dir(
+        mods, "Female Combat Pack", "AMA", "heavy",
+        config=make_config_json(name="heavy", priority=500),
+        animations=["mt_idle.hkx", "mt_walkforward.hkx"],
+    )
+    make_submod_dir(
+        mods, "Female Combat Pack", "AMA", "light",
+        config=make_config_json(name="light", priority=400),
+        animations=["mt_idle.hkx"],
+    )
+    make_submod_dir(
+        mods, "Vanilla Tweaks", "VT", "idle",
+        config=make_config_json(name="idle", priority=200),
+        animations=["mt_idle.hkx", "mt_walkforward.hkx"],
+    )
+    return instance
+
+
+@pytest.fixture
+def main_window(qtbot, populated_instance: Path) -> MainWindow:
+    mods_dir = populated_instance / "mods"
+    overwrite_dir = populated_instance / "overwrite"
+
+    submods = scan_mods(mods_dir, overwrite_dir)
+    scan_animations(submods)
+    conflict_map = build_conflict_map(submods)
+    stacks = build_stacks(conflict_map)
+
+    window = MainWindow(
+        submods=submods,
+        conflict_map=conflict_map,
+        stacks=stacks,
+        app_config=AppConfig(),
+        instance_root=populated_instance,
+    )
+    qtbot.addWidget(window)
+    window.show()
+    return window
+
+
+def test_main_window_constructs(main_window: MainWindow):
+    """Main window constructs without crashing."""
+    assert main_window.isVisible()
+
+
+def test_window_has_three_panes(main_window: MainWindow):
+    """Window has the expected panel structure."""
+    assert main_window._tree_panel is not None
+    assert main_window._stacks_panel is not None
+    assert main_window._conditions_panel is not None
+    assert main_window._details_panel is not None
+
+
+def test_tree_has_items(main_window: MainWindow):
+    """Tree is populated with mod data."""
+    tree = main_window._tree_panel._tree
+    assert tree.topLevelItemCount() > 0

--- a/tests/unit/test_anim_scanner.py
+++ b/tests/unit/test_anim_scanner.py
@@ -1,0 +1,123 @@
+"""Tests for core/anim_scanner.py — animation file discovery and conflict map.
+
+See spec §6.2 (anim_scanner responsibilities).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.models import OverrideSource, SubMod
+
+
+def _make_submod(
+    name: str = "sub1",
+    mo2_mod: str = "ModA",
+    replacer: str = "Rep",
+    priority: int = 100,
+    config_path: Path | None = None,
+    animations: list[str] | None = None,
+    raw_dict: dict | None = None,
+) -> SubMod:
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=False,
+        config_path=config_path or Path("C:/fake/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict=raw_dict or {"name": name, "priority": priority},
+        animations=animations or [],
+        conditions={},
+        warnings=[],
+    )
+
+
+class TestScanAnimations:
+    """scan_animations populates each SubMod's animations list."""
+
+    def test_discovers_hkx_files(self, tmp_path: Path):
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        (submod_dir / "mt_idle.hkx").touch()
+        (submod_dir / "mt_walkforward.hkx").touch()
+        (submod_dir / "not_an_anim.txt").touch()
+
+        sm = _make_submod(config_path=submod_dir / "config.json")
+        scan_animations([sm])
+        assert sorted(sm.animations) == ["mt_idle.hkx", "mt_walkforward.hkx"]
+
+    def test_case_insensitive_lowercase(self, tmp_path: Path):
+        """Animation filenames are normalized to lowercase (spec §4)."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        (submod_dir / "MT_Idle.HKX").touch()
+
+        sm = _make_submod(config_path=submod_dir / "config.json")
+        scan_animations([sm])
+        assert sm.animations == ["mt_idle.hkx"]
+
+    def test_override_animations_folder(self, tmp_path: Path):
+        """overrideAnimationsFolder resolves relative to PARENT of submod dir (replacer dir)."""
+        replacer_dir = tmp_path / "ReplacerA"
+        submod_dir = replacer_dir / "sub1"
+        submod_dir.mkdir(parents=True)
+        (submod_dir / "config.json").touch()
+
+        # Shared animations folder next to the submod (sibling under replacer)
+        shared = replacer_dir / "shared_anims"
+        shared.mkdir()
+        (shared / "mt_idle.hkx").touch()
+
+        sm = _make_submod(
+            config_path=submod_dir / "config.json",
+            raw_dict={"name": "sub1", "priority": 100, "overrideAnimationsFolder": "shared_anims"},
+        )
+        scan_animations([sm])
+        assert "mt_idle.hkx" in sm.animations
+
+    def test_no_hkx_files_empty_list(self, tmp_path: Path):
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        (submod_dir / "config.json").touch()
+
+        sm = _make_submod(config_path=submod_dir / "config.json")
+        scan_animations([sm])
+        assert sm.animations == []
+
+
+class TestBuildConflictMap:
+    """build_conflict_map groups submods by shared animation filename."""
+
+    def test_two_submods_sharing_animation(self):
+        sm1 = _make_submod(name="sub1", priority=100, animations=["mt_idle.hkx"])
+        sm2 = _make_submod(name="sub2", mo2_mod="ModB", priority=200, animations=["mt_idle.hkx"])
+        cmap = build_conflict_map([sm1, sm2])
+        assert "mt_idle.hkx" in cmap
+        assert len(cmap["mt_idle.hkx"]) == 2
+
+    def test_no_overlap_separate_entries(self):
+        sm1 = _make_submod(name="sub1", animations=["mt_idle.hkx"])
+        sm2 = _make_submod(name="sub2", animations=["mt_walkforward.hkx"])
+        cmap = build_conflict_map([sm1, sm2])
+        assert len(cmap["mt_idle.hkx"]) == 1
+        assert len(cmap["mt_walkforward.hkx"]) == 1
+
+    def test_sorted_by_priority_descending(self):
+        sm1 = _make_submod(name="low", priority=100, animations=["mt_idle.hkx"])
+        sm2 = _make_submod(name="high", priority=500, animations=["mt_idle.hkx"])
+        sm3 = _make_submod(name="mid", priority=300, animations=["mt_idle.hkx"])
+        cmap = build_conflict_map([sm1, sm2, sm3])
+        priorities = [s.priority for s in cmap["mt_idle.hkx"]]
+        assert priorities == [500, 300, 100]
+
+    def test_empty_input(self):
+        cmap = build_conflict_map([])
+        assert cmap == {}

--- a/tests/unit/test_anim_scanner.py
+++ b/tests/unit/test_anim_scanner.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
 from oar_priority_manager.core.models import OverrideSource, SubMod
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,9 +3,11 @@
 See spec §8.3 (tool config), §8.3.1 (instance detection chain).
 """
 from __future__ import annotations
-import json
+
 from pathlib import Path
+
 import pytest
+
 from oar_priority_manager.app.config import (
     AppConfig,
     DetectionError,
@@ -13,6 +15,7 @@ from oar_priority_manager.app.config import (
     load_config,
     save_config,
 )
+
 
 class TestInstanceDetection:
     def test_mods_path_cli_arg(self, tmp_path: Path):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,75 @@
+"""Tests for app/config.py — tool config and MO2 instance detection.
+
+See spec §8.3 (tool config), §8.3.1 (instance detection chain).
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+import pytest
+from oar_priority_manager.app.config import (
+    AppConfig,
+    DetectionError,
+    detect_instance_root,
+    load_config,
+    save_config,
+)
+
+class TestInstanceDetection:
+    def test_mods_path_cli_arg(self, tmp_path: Path):
+        mods = tmp_path / "mods"
+        mods.mkdir()
+        result = detect_instance_root(mods_path=str(mods))
+        assert result == tmp_path
+
+    def test_mods_path_nonexistent_raises(self, tmp_path: Path):
+        with pytest.raises(DetectionError):
+            detect_instance_root(mods_path=str(tmp_path / "nonexistent" / "mods"))
+
+    def test_cwd_with_mo_ini(self, tmp_path: Path):
+        (tmp_path / "ModOrganizer.ini").touch()
+        (tmp_path / "mods").mkdir()
+        result = detect_instance_root(cwd=tmp_path)
+        assert result == tmp_path
+
+    def test_walk_up_finds_instance(self, tmp_path: Path):
+        (tmp_path / "ModOrganizer.ini").touch()
+        (tmp_path / "mods").mkdir()
+        nested = tmp_path / "tools" / "oar-manager"
+        nested.mkdir(parents=True)
+        result = detect_instance_root(cwd=nested)
+        assert result == tmp_path
+
+    def test_no_detection_raises(self, tmp_path: Path):
+        with pytest.raises(DetectionError):
+            detect_instance_root(cwd=tmp_path)
+
+class TestAppConfig:
+    def test_default_values(self):
+        cfg = AppConfig()
+        assert cfg.relative_or_absolute == "relative"
+        assert cfg.submod_sort == "priority"
+        assert cfg.search_history == []
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path):
+        cfg = AppConfig(
+            relative_or_absolute="absolute",
+            submod_sort="name",
+            search_history=["IsFemale", "walkforward"],
+        )
+        config_path = tmp_path / "oar-priority-manager" / "config.json"
+        save_config(cfg, config_path)
+        assert config_path.exists()
+        loaded = load_config(config_path)
+        assert loaded.relative_or_absolute == "absolute"
+        assert loaded.submod_sort == "name"
+        assert loaded.search_history == ["IsFemale", "walkforward"]
+
+    def test_load_missing_file_returns_defaults(self, tmp_path: Path):
+        loaded = load_config(tmp_path / "nonexistent.json")
+        assert loaded.relative_or_absolute == "relative"
+
+    def test_load_corrupt_file_returns_defaults(self, tmp_path: Path):
+        bad = tmp_path / "config.json"
+        bad.write_text("not json!", encoding="utf-8")
+        loaded = load_config(bad)
+        assert loaded.relative_or_absolute == "relative"

--- a/tests/unit/test_filter_engine.py
+++ b/tests/unit/test_filter_engine.py
@@ -1,0 +1,146 @@
+"""Tests for core/filter_engine.py — structural condition-presence filter.
+
+See spec §6.2 (filter_engine), §7.6 (condition filter semantics).
+"""
+from __future__ import annotations
+import pytest
+from oar_priority_manager.core.filter_engine import (
+    extract_condition_types,
+    match_filter,
+    parse_filter_query,
+)
+
+class TestExtractConditionTypes:
+    def test_flat_condition_list(self):
+        conditions = [
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "IsInCombat", "negated": False},
+        ]
+        present, negated = extract_condition_types(conditions)
+        assert present == {"IsFemale", "IsInCombat"}
+        assert negated == set()
+
+    def test_negated_condition(self):
+        conditions = [
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "IsWearingHelmet", "negated": True},
+        ]
+        present, negated = extract_condition_types(conditions)
+        assert present == {"IsFemale", "IsWearingHelmet"}
+        assert negated == {"IsWearingHelmet"}
+
+    def test_nested_and_group(self):
+        conditions = [
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": False},
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            },
+        ]
+        present, negated = extract_condition_types(conditions)
+        assert "IsFemale" in present
+        assert "IsInCombat" in present
+
+    def test_nested_or_group(self):
+        conditions = [
+            {
+                "condition": "OR",
+                "conditions": [
+                    {"condition": "HasKeyword", "negated": False},
+                    {"condition": "HasPerk", "negated": False},
+                ],
+            },
+        ]
+        present, negated = extract_condition_types(conditions)
+        assert present == {"HasKeyword", "HasPerk"}
+
+    def test_type_in_both_present_and_negated(self):
+        conditions = [
+            {"condition": "IsFemale", "negated": False},
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": True},
+                ],
+            },
+        ]
+        present, negated = extract_condition_types(conditions)
+        assert "IsFemale" in present
+        assert "IsFemale" in negated
+
+    def test_empty_conditions(self):
+        present, negated = extract_condition_types([])
+        assert present == set()
+        assert negated == set()
+
+    def test_conditions_as_dict_with_conditions_key(self):
+        conditions = {
+            "type": "AND",
+            "conditions": [
+                {"condition": "IsFemale", "negated": False},
+            ],
+        }
+        present, negated = extract_condition_types(conditions)
+        assert "IsFemale" in present
+
+    def test_deeply_nested(self):
+        conditions = [
+            {
+                "condition": "AND",
+                "conditions": [
+                    {
+                        "condition": "OR",
+                        "conditions": [
+                            {"condition": "DeepType", "negated": False},
+                        ],
+                    },
+                ],
+            },
+        ]
+        present, _ = extract_condition_types(conditions)
+        assert "DeepType" in present
+
+
+class TestParseFilterQuery:
+    def test_simple_type_name(self):
+        query = parse_filter_query("IsFemale")
+        assert query.required == {"IsFemale"}
+        assert query.excluded == set()
+
+    def test_not_prefix(self):
+        query = parse_filter_query("NOT IsInCombat")
+        assert query.excluded == {"IsInCombat"}
+
+    def test_multiple_terms(self):
+        query = parse_filter_query("IsFemale IsInCombat")
+        assert "IsFemale" in query.required
+        assert "IsInCombat" in query.required
+
+    def test_mixed_required_and_excluded(self):
+        query = parse_filter_query("IsFemale NOT HasPerk")
+        assert query.required == {"IsFemale"}
+        assert query.excluded == {"HasPerk"}
+
+
+class TestMatchFilter:
+    def test_match_required(self):
+        query = parse_filter_query("IsFemale")
+        assert match_filter({"IsFemale", "IsInCombat"}, set(), query) is True
+
+    def test_no_match_required(self):
+        query = parse_filter_query("IsFemale")
+        assert match_filter({"IsInCombat"}, set(), query) is False
+
+    def test_excluded_rejects(self):
+        query = parse_filter_query("NOT IsFemale")
+        assert match_filter({"IsFemale"}, set(), query) is False
+
+    def test_excluded_accepts_absent(self):
+        query = parse_filter_query("NOT IsFemale")
+        assert match_filter({"IsInCombat"}, set(), query) is True
+
+    def test_empty_query_matches_all(self):
+        query = parse_filter_query("")
+        assert match_filter({"anything"}, set(), query) is True

--- a/tests/unit/test_filter_engine.py
+++ b/tests/unit/test_filter_engine.py
@@ -3,12 +3,13 @@
 See spec §6.2 (filter_engine), §7.6 (condition filter semantics).
 """
 from __future__ import annotations
-import pytest
+
 from oar_priority_manager.core.filter_engine import (
     extract_condition_types,
     match_filter,
     parse_filter_query,
 )
+
 
 class TestExtractConditionTypes:
     def test_flat_condition_list(self):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,109 @@
+"""Tests for core data model types."""
+
+from pathlib import Path
+
+from oar_priority_manager.core.models import (
+    IllegalMutationError,
+    OverrideSource,
+    PriorityStack,
+    SubMod,
+)
+
+
+def test_submod_creation():
+    """SubMod can be constructed with all required fields."""
+    sm = SubMod(
+        mo2_mod="Female Combat Pack v2.3",
+        replacer="AMA",
+        name="heavy",
+        description="Heavy armor combat idles",
+        priority=500,
+        source_priority=300,
+        disabled=False,
+        config_path=Path("C:/mods/FCP/meshes/actors/character/animations/OpenAnimationReplacer/AMA/heavy/config.json"),
+        override_source=OverrideSource.OVERWRITE,
+        override_is_ours=True,
+        raw_dict={"name": "heavy", "priority": 500},
+        animations=["mt_idle.hkx", "mt_walkforward.hkx"],
+        conditions={"type": "AND", "conditions": []},
+        condition_types_present={"IsFemale", "IsInCombat"},
+        condition_types_negated={"IsWearingHelmet"},
+        warnings=[],
+    )
+    assert sm.mo2_mod == "Female Combat Pack v2.3"
+    assert sm.priority == 500
+    assert sm.source_priority == 300
+    assert sm.override_source == OverrideSource.OVERWRITE
+    assert sm.override_is_ours is True
+    assert len(sm.animations) == 2
+    assert "IsFemale" in sm.condition_types_present
+    assert "IsWearingHelmet" in sm.condition_types_negated
+
+
+def test_submod_has_warnings():
+    """SubMod with non-empty warnings list is considered a warning item."""
+    sm = SubMod(
+        mo2_mod="Broken Mod",
+        replacer="rep",
+        name="bad",
+        description="",
+        priority=0,
+        source_priority=0,
+        disabled=False,
+        config_path=Path("C:/mods/Broken/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        animations=[],
+        conditions={},
+        condition_types_present=set(),
+        condition_types_negated=set(),
+        warnings=["Missing required field: priority"],
+    )
+    assert sm.has_warnings is True
+
+
+def test_submod_no_warnings():
+    sm = SubMod(
+        mo2_mod="Good Mod",
+        replacer="rep",
+        name="ok",
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path("C:/mods/Good/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": "ok", "priority": 100},
+        animations=["mt_idle.hkx"],
+        conditions={},
+        condition_types_present=set(),
+        condition_types_negated=set(),
+        warnings=[],
+    )
+    assert sm.has_warnings is False
+
+
+def test_override_source_values():
+    """OverrideSource enum has the three expected values."""
+    assert OverrideSource.SOURCE.value == "source"
+    assert OverrideSource.USER_JSON.value == "user_json"
+    assert OverrideSource.OVERWRITE.value == "overwrite"
+
+
+def test_priority_stack_creation():
+    """PriorityStack holds an animation filename and a list of competitors."""
+    stack = PriorityStack(
+        animation_filename="mt_idle.hkx",
+        competitors=[],
+    )
+    assert stack.animation_filename == "mt_idle.hkx"
+    assert stack.competitors == []
+
+
+def test_illegal_mutation_error():
+    """IllegalMutationError can be raised with field details."""
+    err = IllegalMutationError("conditions", "original_value", "new_value")
+    assert "conditions" in str(err)
+    assert isinstance(err, Exception)

--- a/tests/unit/test_override_manager.py
+++ b/tests/unit/test_override_manager.py
@@ -12,6 +12,7 @@ import pytest
 
 from oar_priority_manager.core.models import OverrideSource, SubMod
 from oar_priority_manager.core.override_manager import (
+    _remove_empty_parents,
     clear_override,
     compute_overwrite_path,
     write_override,
@@ -117,3 +118,51 @@ class TestClearOverride:
         overwrite_dir.mkdir()
         # Should not raise
         clear_override(sm, overwrite_dir)
+
+
+class TestRemoveEmptyParents:
+    def test_removes_empty_parents_up_to_boundary(self, tmp_path: Path):
+        """Nested empty dirs are removed; boundary dir itself is kept."""
+        boundary = tmp_path / "stop"
+        boundary.mkdir()
+        leaf = boundary / "a" / "b" / "c"
+        leaf.mkdir(parents=True)
+
+        _remove_empty_parents(leaf, boundary)
+
+        # All intermediate dirs should be gone
+        assert not (boundary / "a").exists()
+        # Boundary itself must survive
+        assert boundary.exists()
+
+    def test_stops_at_nonempty_parent(self, tmp_path: Path):
+        """Stops climbing when a parent directory still has content."""
+        boundary = tmp_path / "stop"
+        boundary.mkdir()
+        mid = boundary / "mid"
+        mid.mkdir()
+        # Sibling file makes mid non-empty
+        (mid / "sibling.txt").write_text("keep me")
+        leaf = mid / "empty_child"
+        leaf.mkdir()
+
+        _remove_empty_parents(leaf, boundary)
+
+        # The empty leaf is removed
+        assert not leaf.exists()
+        # mid still exists because it has sibling.txt
+        assert mid.exists()
+
+    def test_stops_at_boundary(self, tmp_path: Path):
+        """Boundary directory is never removed even when empty."""
+        boundary = tmp_path / "stop"
+        boundary.mkdir()
+        leaf = boundary / "child"
+        leaf.mkdir()
+
+        _remove_empty_parents(leaf, boundary)
+
+        # child was empty and removed
+        assert not leaf.exists()
+        # boundary survives
+        assert boundary.exists()

--- a/tests/unit/test_override_manager.py
+++ b/tests/unit/test_override_manager.py
@@ -1,0 +1,119 @@
+"""Tests for core/override_manager.py — Overwrite path computation and write operations.
+
+See spec §6.2 (override_manager), §8.1 (OAR overrides).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.override_manager import (
+    clear_override,
+    compute_overwrite_path,
+    write_override,
+)
+
+
+def _make_submod(
+    tmp_path: Path,
+    name: str = "sub1",
+    mo2_mod: str = "ModA",
+    replacer: str = "Rep",
+    priority: int = 100,
+    raw_dict: dict | None = None,
+) -> SubMod:
+    config_path = (
+        tmp_path / "mods" / mo2_mod
+        / "meshes" / "actors" / "character" / "animations"
+        / "OpenAnimationReplacer" / replacer / name / "config.json"
+    )
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    rd = raw_dict or {"name": name, "priority": priority, "conditions": []}
+    config_path.write_text(json.dumps(rd), encoding="utf-8")
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=False,
+        config_path=config_path,
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict=rd,
+        animations=[],
+        conditions={},
+        warnings=[],
+    )
+
+
+class TestComputeOverwritePath:
+    def test_mirrors_relative_path(self, tmp_path: Path):
+        sm = _make_submod(tmp_path, name="sub1", mo2_mod="ModA", replacer="Rep")
+        overwrite_dir = tmp_path / "overwrite"
+        result = compute_overwrite_path(sm, overwrite_dir)
+        expected = (
+            overwrite_dir
+            / "meshes" / "actors" / "character" / "animations"
+            / "OpenAnimationReplacer" / "Rep" / "sub1" / "user.json"
+        )
+        assert result == expected
+
+
+class TestWriteOverride:
+    def test_writes_user_json_to_overwrite(self, tmp_path: Path):
+        sm = _make_submod(tmp_path, priority=100)
+        overwrite_dir = tmp_path / "overwrite"
+        overwrite_dir.mkdir()
+        write_override(sm, 500, overwrite_dir)
+
+        ow_path = compute_overwrite_path(sm, overwrite_dir)
+        assert ow_path.exists()
+        data = json.loads(ow_path.read_text(encoding="utf-8"))
+        assert data["priority"] == 500
+        assert data["_oarPriorityManager"]["previousPriority"] == 100
+        # Non-priority fields preserved
+        assert data["name"] == "sub1"
+        assert data["conditions"] == []
+
+    def test_updates_submod_in_memory(self, tmp_path: Path):
+        sm = _make_submod(tmp_path, priority=100)
+        overwrite_dir = tmp_path / "overwrite"
+        overwrite_dir.mkdir()
+        write_override(sm, 500, overwrite_dir)
+        assert sm.priority == 500
+        assert sm.override_source == OverrideSource.OVERWRITE
+        assert sm.override_is_ours is True
+
+    def test_never_writes_to_source_mod(self, tmp_path: Path):
+        sm = _make_submod(tmp_path, priority=100)
+        overwrite_dir = tmp_path / "overwrite"
+        overwrite_dir.mkdir()
+        source_user = sm.config_path.parent / "user.json"
+        write_override(sm, 500, overwrite_dir)
+        assert not source_user.exists()
+
+
+class TestClearOverride:
+    def test_deletes_overwrite_user_json(self, tmp_path: Path):
+        sm = _make_submod(tmp_path, priority=100)
+        overwrite_dir = tmp_path / "overwrite"
+        overwrite_dir.mkdir()
+        write_override(sm, 500, overwrite_dir)
+        ow_path = compute_overwrite_path(sm, overwrite_dir)
+        assert ow_path.exists()
+
+        clear_override(sm, overwrite_dir)
+        assert not ow_path.exists()
+
+    def test_clear_nonexistent_is_noop(self, tmp_path: Path):
+        sm = _make_submod(tmp_path, priority=100)
+        overwrite_dir = tmp_path / "overwrite"
+        overwrite_dir.mkdir()
+        # Should not raise
+        clear_override(sm, overwrite_dir)

--- a/tests/unit/test_override_manager.py
+++ b/tests/unit/test_override_manager.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from oar_priority_manager.core.models import OverrideSource, SubMod
 from oar_priority_manager.core.override_manager import (
     _remove_empty_parents,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,0 +1,133 @@
+"""Tests for core/parser.py — lenient JSON parsing of OAR config files.
+
+See spec §6.2 (parser responsibilities).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.parser import parse_config
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestValidJson:
+    """Parser handles well-formed JSON config files."""
+
+    def test_minimal_config(self, tmp_path: Path):
+        f = _write(tmp_path / "config.json", json.dumps({
+            "name": "test",
+            "priority": 100,
+        }))
+        raw, warnings = parse_config(f)
+        assert raw["name"] == "test"
+        assert raw["priority"] == 100
+        assert warnings == []
+
+    def test_full_config_preserves_all_fields(self, tmp_path: Path):
+        data = {
+            "name": "heavy",
+            "description": "Heavy armor idles",
+            "priority": 500,
+            "disabled": False,
+            "interruptible": True,
+            "replaceOnLoop": False,
+            "overrideAnimationsFolder": "../shared/",
+            "conditions": [
+                {"condition": "IsFemale", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+            ],
+            "unknownFutureField": "preserved",
+        }
+        f = _write(tmp_path / "config.json", json.dumps(data, indent=2))
+        raw, warnings = parse_config(f)
+        assert raw == data
+        assert warnings == []
+
+    def test_user_json_parsed_same_as_config(self, tmp_path: Path):
+        data = {"priority": 200, "name": "modified", "conditions": []}
+        f = _write(tmp_path / "user.json", json.dumps(data))
+        raw, warnings = parse_config(f)
+        assert raw["priority"] == 200
+        assert warnings == []
+
+    def test_integer_priority_types(self, tmp_path: Path):
+        """Large OAR priorities (10-12 digits) are parsed as int, not float."""
+        f = _write(tmp_path / "config.json", json.dumps({
+            "name": "big", "priority": 2099200278,
+        }))
+        raw, _ = parse_config(f)
+        assert isinstance(raw["priority"], int)
+        assert raw["priority"] == 2099200278
+
+
+class TestTrailingCommaRepair:
+    """Parser repairs trailing commas — a common hand-edit artifact."""
+
+    def test_trailing_comma_in_object(self, tmp_path: Path):
+        text = '{"name": "test", "priority": 100,}'
+        f = _write(tmp_path / "config.json", text)
+        raw, warnings = parse_config(f)
+        assert raw["name"] == "test"
+        assert raw["priority"] == 100
+        assert warnings == []
+
+    def test_trailing_comma_in_array(self, tmp_path: Path):
+        text = '{"name": "test", "priority": 100, "conditions": ["a", "b",]}'
+        f = _write(tmp_path / "config.json", text)
+        raw, warnings = parse_config(f)
+        assert raw["conditions"] == ["a", "b"]
+
+    def test_nested_trailing_commas(self, tmp_path: Path):
+        text = '{"name": "test", "priority": 100, "conditions": [{"a": 1,},]}'
+        f = _write(tmp_path / "config.json", text)
+        raw, warnings = parse_config(f)
+        assert raw["conditions"][0]["a"] == 1
+
+
+class TestMalformedInput:
+    """Parser returns empty dict + warnings for unrecoverable input."""
+
+    def test_completely_invalid_json(self, tmp_path: Path):
+        f = _write(tmp_path / "config.json", "not json at all {{{")
+        raw, warnings = parse_config(f)
+        assert raw == {}
+        assert len(warnings) > 0
+        assert any("parse" in w.lower() or "json" in w.lower() for w in warnings)
+
+    def test_empty_file(self, tmp_path: Path):
+        f = _write(tmp_path / "config.json", "")
+        raw, warnings = parse_config(f)
+        assert raw == {}
+        assert len(warnings) > 0
+
+    def test_file_not_found(self, tmp_path: Path):
+        raw, warnings = parse_config(tmp_path / "nonexistent.json")
+        assert raw == {}
+        assert len(warnings) > 0
+        assert any("not found" in w.lower() or "no such" in w.lower() for w in warnings)
+
+    def test_not_a_dict(self, tmp_path: Path):
+        """JSON that parses but isn't an object is a warning."""
+        f = _write(tmp_path / "config.json", "[1, 2, 3]")
+        raw, warnings = parse_config(f)
+        assert raw == {}
+        assert len(warnings) > 0
+
+
+class TestKeyOrdering:
+    """Parser preserves the original key ordering for round-trip."""
+
+    def test_key_order_preserved(self, tmp_path: Path):
+        text = '{"zeta": 1, "alpha": 2, "middle": 3}'
+        f = _write(tmp_path / "config.json", text)
+        raw, _ = parse_config(f)
+        assert list(raw.keys()) == ["zeta", "alpha", "middle"]

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from oar_priority_manager.core.parser import parse_config
 
 

--- a/tests/unit/test_priority_resolver.py
+++ b/tests/unit/test_priority_resolver.py
@@ -12,7 +12,8 @@ import pytest
 from oar_priority_manager.core.models import OverrideSource, SubMod
 from oar_priority_manager.core.priority_resolver import (
     INT32_MAX,
-    OverflowError as PriorityOverflowError,
+    INT32_MIN,
+    PriorityOverflowError,
     build_stacks,
     move_to_top,
     set_exact,
@@ -138,6 +139,17 @@ class TestOverflowGuard:
         conflict_map = {"idle.hkx": [competitor, target]}
         with pytest.raises(PriorityOverflowError):
             move_to_top(target, conflict_map, scope="submod")
+
+    def test_rejects_negative_overflow_set_exact(self):
+        target = _sm("you", 100, animations=["idle.hkx"])
+        with pytest.raises(PriorityOverflowError):
+            set_exact(target, INT32_MIN - 1)
+
+    def test_rejects_negative_overflow_shift(self):
+        sub_a = _sm("a", 0, animations=["idle.hkx"])
+        sub_b = _sm("b", 100, animations=["idle.hkx"])
+        with pytest.raises(PriorityOverflowError):
+            shift([sub_a, sub_b], floor_priority=INT32_MIN - 1)
 
 
 class TestSetExact:

--- a/tests/unit/test_priority_resolver.py
+++ b/tests/unit/test_priority_resolver.py
@@ -1,0 +1,178 @@
+"""Tests for core/priority_resolver.py — stack building and mutation operations.
+
+See spec §6.2 (priority_resolver), §5.4 (PriorityStack).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.priority_resolver import (
+    INT32_MAX,
+    OverflowError as PriorityOverflowError,
+    build_stacks,
+    move_to_top,
+    set_exact,
+    shift,
+)
+
+
+def _sm(
+    name: str,
+    priority: int,
+    mo2_mod: str = "Mod",
+    replacer: str = "Rep",
+    animations: list[str] | None = None,
+) -> SubMod:
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=False,
+        config_path=Path(f"C:/fake/{mo2_mod}/{replacer}/{name}/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": name, "priority": priority},
+        animations=animations or [],
+        conditions={},
+        warnings=[],
+    )
+
+
+class TestBuildStacks:
+    def test_builds_from_conflict_map(self):
+        conflict_map = {
+            "mt_idle.hkx": [
+                _sm("high", 500, animations=["mt_idle.hkx"]),
+                _sm("low", 100, animations=["mt_idle.hkx"]),
+            ],
+        }
+        stacks = build_stacks(conflict_map)
+        assert len(stacks) == 1
+        assert stacks[0].animation_filename == "mt_idle.hkx"
+        assert len(stacks[0].competitors) == 2
+        assert stacks[0].competitors[0].priority == 500
+
+    def test_stacks_sorted_alphabetically(self):
+        conflict_map = {
+            "mt_walkforward.hkx": [_sm("a", 100, animations=["mt_walkforward.hkx"])],
+            "mt_idle.hkx": [_sm("b", 200, animations=["mt_idle.hkx"])],
+        }
+        stacks = build_stacks(conflict_map)
+        names = [s.animation_filename for s in stacks]
+        assert names == ["mt_idle.hkx", "mt_walkforward.hkx"]
+
+
+class TestMoveToTopSubmod:
+    def test_single_submod_gets_max_plus_one(self):
+        target = _sm("you", 100, animations=["mt_idle.hkx"])
+        competitor = _sm("other", 500, animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [competitor, target]}
+
+        new_priorities = move_to_top(target, conflict_map, scope="submod")
+        assert new_priorities == {target: 501}
+
+    def test_already_winning_stays_same(self):
+        target = _sm("you", 500, animations=["mt_idle.hkx"])
+        competitor = _sm("other", 100, animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [target, competitor]}
+
+        new_priorities = move_to_top(target, conflict_map, scope="submod")
+        # Already #1 everywhere — no change needed
+        assert new_priorities == {}
+
+    def test_multiple_stacks_uses_global_max(self):
+        target = _sm("you", 100, animations=["a.hkx", "b.hkx"])
+        comp_a = _sm("ca", 300, animations=["a.hkx"])
+        comp_b = _sm("cb", 700, animations=["b.hkx"])
+        conflict_map = {
+            "a.hkx": [comp_a, target],
+            "b.hkx": [comp_b, target],
+        }
+        new_priorities = move_to_top(target, conflict_map, scope="submod")
+        assert new_priorities[target] == 701
+
+
+class TestMoveToTopReplacerScope:
+    def test_preserves_relative_ordering(self):
+        """Floor-anchored shift: (global_max+1) + (old - min(old_in_scope))"""
+        sub_a = _sm("a", 100, mo2_mod="MyMod", replacer="Rep", animations=["idle.hkx"])
+        sub_b = _sm("b", 200, mo2_mod="MyMod", replacer="Rep", animations=["idle.hkx"])
+        competitor = _sm("ext", 500, mo2_mod="Other", animations=["idle.hkx"])
+        conflict_map = {"idle.hkx": [competitor, sub_b, sub_a]}
+
+        new_priorities = move_to_top(sub_a, conflict_map, scope="replacer")
+        # global_max of external competitors = 500
+        # min(old_in_scope) = 100, so:
+        # sub_a: 501 + (100-100) = 501
+        # sub_b: 501 + (200-100) = 601
+        assert new_priorities[sub_a] == 501
+        assert new_priorities[sub_b] == 601
+
+
+class TestMoveToTopModScope:
+    def test_mod_scope_includes_all_replacers(self):
+        sub_a = _sm("a", 100, mo2_mod="MyMod", replacer="Rep1", animations=["idle.hkx"])
+        sub_b = _sm("b", 300, mo2_mod="MyMod", replacer="Rep2", animations=["idle.hkx"])
+        competitor = _sm("ext", 500, mo2_mod="Other", animations=["idle.hkx"])
+        conflict_map = {"idle.hkx": [competitor, sub_b, sub_a]}
+
+        new_priorities = move_to_top(sub_a, conflict_map, scope="mod")
+        # Both submods from MyMod get shifted
+        assert sub_a in new_priorities
+        assert sub_b in new_priorities
+        assert new_priorities[sub_a] == 501  # 501 + (100-100)
+        assert new_priorities[sub_b] == 701  # 501 + (300-100)
+
+
+class TestOverflowGuard:
+    def test_rejects_overflow(self):
+        target = _sm("you", 100, animations=["idle.hkx"])
+        competitor = _sm("other", INT32_MAX, animations=["idle.hkx"])
+        conflict_map = {"idle.hkx": [competitor, target]}
+        with pytest.raises(PriorityOverflowError):
+            move_to_top(target, conflict_map, scope="submod")
+
+
+class TestSetExact:
+    def test_sets_specific_priority(self):
+        target = _sm("you", 100, animations=["idle.hkx"])
+        result = set_exact(target, 999)
+        assert result == {target: 999}
+
+    def test_rejects_overflow(self):
+        target = _sm("you", 100, animations=["idle.hkx"])
+        with pytest.raises(PriorityOverflowError):
+            set_exact(target, INT32_MAX + 1)
+
+
+class TestShift:
+    def test_floor_anchored_shift(self):
+        sub_a = _sm("a", 100, mo2_mod="MyMod", replacer="Rep", animations=["idle.hkx"])
+        sub_b = _sm("b", 200, mo2_mod="MyMod", replacer="Rep", animations=["idle.hkx"])
+        new_priorities = shift([sub_a, sub_b], floor_priority=500)
+        # min = 100, so a -> 500+(100-100)=500, b -> 500+(200-100)=600
+        assert new_priorities[sub_a] == 500
+        assert new_priorities[sub_b] == 600
+
+    def test_shift_preserves_gaps(self):
+        sub_a = _sm("a", 100, animations=["idle.hkx"])
+        sub_b = _sm("b", 150, animations=["idle.hkx"])
+        sub_c = _sm("c", 300, animations=["idle.hkx"])
+        new_priorities = shift([sub_a, sub_b, sub_c], floor_priority=1000)
+        # Gaps: 100->150 is 50, 150->300 is 150. Preserved.
+        assert new_priorities[sub_a] == 1000
+        assert new_priorities[sub_b] == 1050
+        assert new_priorities[sub_c] == 1200
+
+    def test_rejects_overflow(self):
+        sub_a = _sm("a", 0, animations=["idle.hkx"])
+        sub_b = _sm("b", INT32_MAX, animations=["idle.hkx"])
+        with pytest.raises(PriorityOverflowError):
+            shift([sub_a, sub_b], floor_priority=1)

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from oar_priority_manager.core.models import OverrideSource
 from oar_priority_manager.core.scanner import scan_mods
 from tests.conftest import OAR_REL, make_config_json, make_submod_dir

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -1,0 +1,211 @@
+"""Tests for core/scanner.py — MO2 mod directory discovery and override precedence.
+
+See spec §5.3 (override precedence), §6.2 (scanner), §4 (user.json data replacement).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.models import OverrideSource
+from oar_priority_manager.core.scanner import scan_mods
+from tests.conftest import OAR_REL, make_config_json, make_submod_dir
+
+
+class TestDiscovery:
+    """Scanner discovers submods across MO2 mod directories."""
+
+    def test_single_submod(self, tmp_instance: Path):
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "ReplacerA", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+            animations=["mt_idle.hkx"],
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert len(submods) == 1
+        assert submods[0].name == "sub1"
+        assert submods[0].mo2_mod == "ModA"
+        assert submods[0].replacer == "ReplacerA"
+        assert submods[0].priority == 100
+
+    def test_multiple_mods_and_submods(self, tmp_instance: Path):
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep1", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep1", "sub2",
+            config=make_config_json(name="sub2", priority=200),
+        )
+        make_submod_dir(
+            tmp_instance / "mods", "ModB", "Rep2", "sub3",
+            config=make_config_json(name="sub3", priority=300),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert len(submods) == 3
+        names = {s.name for s in submods}
+        assert names == {"sub1", "sub2", "sub3"}
+
+    def test_missing_config_json_produces_warning(self, tmp_instance: Path):
+        """A submod-looking folder without config.json loads with a warning."""
+        submod_dir = tmp_instance / "mods" / "ModA" / OAR_REL / "Rep" / "sub1"
+        submod_dir.mkdir(parents=True)
+        # No config.json created
+        (submod_dir / "mt_idle.hkx").touch()
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert len(submods) == 1
+        assert submods[0].has_warnings
+
+    def test_no_oar_mods_returns_empty(self, tmp_instance: Path):
+        """A mods/ dir with no OAR structure returns empty list."""
+        (tmp_instance / "mods" / "SomeNonOARMod" / "textures").mkdir(parents=True)
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert submods == []
+
+    def test_disabled_submod_has_disabled_flag(self, tmp_instance: Path):
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=make_config_json(name="sub1", priority=100, disabled=True),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert submods[0].disabled is True
+
+
+class TestOverridePrecedence:
+    """Scanner reads raw_dict from the winning file in the precedence chain."""
+
+    def test_config_json_only(self, tmp_instance: Path):
+        """No overrides: SOURCE, raw_dict from config.json."""
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert submods[0].override_source == OverrideSource.SOURCE
+        assert submods[0].priority == 100
+        assert submods[0].source_priority == 100
+
+    def test_source_user_json_overrides_config(self, tmp_instance: Path):
+        """Source user.json wins over config.json. raw_dict comes from user.json.
+
+        CRITICAL: user.json is a complete data replacement (spec §4).
+        raw_dict MUST come from user.json, not config.json.
+        """
+        config = make_config_json(
+            name="sub1", priority=100,
+            conditions=[{"condition": "IsFemale"}],
+        )
+        user_data = {
+            "priority": 200,
+            "name": "sub1",
+            "conditions": [{"condition": "IsInCombat"}],  # Different conditions!
+        }
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=config,
+            user_json=user_data,
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        sm = submods[0]
+        assert sm.override_source == OverrideSource.USER_JSON
+        assert sm.priority == 200
+        assert sm.source_priority == 100
+        # raw_dict must come from user.json, NOT config.json
+        assert sm.raw_dict["conditions"] == [{"condition": "IsInCombat"}]
+
+    def test_overwrite_user_json_wins_over_source(self, tmp_instance: Path):
+        """Overwrite user.json wins over source user.json and config.json."""
+        config = make_config_json(name="sub1", priority=100)
+        source_user = {"priority": 200, "name": "sub1"}
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=config,
+            user_json=source_user,
+        )
+        # Write Overwrite user.json at mirrored path
+        ow_path = (
+            tmp_instance / "overwrite" / OAR_REL / "Rep" / "sub1" / "user.json"
+        )
+        ow_path.parent.mkdir(parents=True)
+        ow_data = {
+            "priority": 500,
+            "name": "sub1",
+            "_oarPriorityManager": {
+                "toolVersion": "0.1.0",
+                "writtenAt": "2026-04-11T00:00:00Z",
+                "previousPriority": 200,
+            },
+        }
+        ow_path.write_text(json.dumps(ow_data), encoding="utf-8")
+
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        sm = submods[0]
+        assert sm.override_source == OverrideSource.OVERWRITE
+        assert sm.priority == 500
+        assert sm.override_is_ours is True
+
+    def test_overwrite_without_metadata_is_external(self, tmp_instance: Path):
+        """Overwrite user.json without _oarPriorityManager is an external override."""
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        ow_path = (
+            tmp_instance / "overwrite" / OAR_REL / "Rep" / "sub1" / "user.json"
+        )
+        ow_path.parent.mkdir(parents=True)
+        ow_path.write_text(json.dumps({"priority": 300, "name": "sub1"}))
+
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        sm = submods[0]
+        assert sm.override_source == OverrideSource.OVERWRITE
+        assert sm.override_is_ours is False
+
+    def test_raw_dict_from_user_json_not_config_json(self, tmp_instance: Path):
+        """CRITICAL TEST (spec §11.1): When source user.json exists,
+        raw_dict must come from user.json, and writing an override must
+        preserve user.json's conditions, not config.json's conditions.
+        """
+        config = make_config_json(
+            name="sub1", priority=100,
+            conditions=[{"condition": "ConditionA"}],
+            extra_fields={"interruptible": True},
+        )
+        user_data = {
+            "priority": 200,
+            "name": "sub1",
+            "conditions": [{"condition": "ConditionB"}],
+            "interruptible": False,
+        }
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=config,
+            user_json=user_data,
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        sm = submods[0]
+        # raw_dict must be from user.json
+        assert sm.raw_dict["conditions"] == [{"condition": "ConditionB"}]
+        assert sm.raw_dict["interruptible"] is False
+        # name still comes from config.json (kInfoOnly per OAR behavior)
+        assert sm.name == "sub1"
+
+
+class TestNameAndDescription:
+    """Name and description always come from config.json (OAR kInfoOnly behavior)."""
+
+    def test_name_from_config_even_when_user_json_exists(self, tmp_instance: Path):
+        config = make_config_json(name="config_name", description="config_desc", priority=100)
+        user_data = {"priority": 200, "name": "user_name"}
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "Rep", "sub1",
+            config=config,
+            user_json=user_data,
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        # Name/description come from config.json per OAR §4
+        assert submods[0].name == "config_name"
+        assert submods[0].description == "config_desc"

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -1,0 +1,156 @@
+"""Tests for core/serializer.py — JSON writer with mutable-field allowlist.
+
+See spec §3.3 (architectural enforcement), §6.2 (serializer), §8.1.2 (round-trip).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from oar_priority_manager.core.models import IllegalMutationError
+from oar_priority_manager.core.serializer import serialize_raw_dict
+
+
+class TestAllowlistEnforcement:
+    """Serializer rejects mutations to non-allowlisted fields."""
+
+    def test_priority_change_allowed(self, tmp_path: Path):
+        original = {"name": "heavy", "priority": 100, "conditions": []}
+        modified = {"name": "heavy", "priority": 500, "conditions": []}
+        out = tmp_path / "user.json"
+        serialize_raw_dict(modified, original, out)
+        result = json.loads(out.read_text(encoding="utf-8"))
+        assert result["priority"] == 500
+
+    def test_conditions_change_rejected(self, tmp_path: Path):
+        original = {"name": "heavy", "priority": 100, "conditions": [{"type": "IsFemale"}]}
+        modified = {"name": "heavy", "priority": 100, "conditions": [{"type": "IsInCombat"}]}
+        out = tmp_path / "user.json"
+        with pytest.raises(IllegalMutationError) as exc_info:
+            serialize_raw_dict(modified, original, out)
+        assert "conditions" in str(exc_info.value)
+
+    def test_name_change_rejected(self, tmp_path: Path):
+        original = {"name": "heavy", "priority": 100}
+        modified = {"name": "CHANGED", "priority": 100}
+        out = tmp_path / "user.json"
+        with pytest.raises(IllegalMutationError):
+            serialize_raw_dict(modified, original, out)
+
+    def test_disabled_change_rejected(self, tmp_path: Path):
+        original = {"name": "heavy", "priority": 100, "disabled": False}
+        modified = {"name": "heavy", "priority": 100, "disabled": True}
+        out = tmp_path / "user.json"
+        with pytest.raises(IllegalMutationError):
+            serialize_raw_dict(modified, original, out)
+
+    def test_new_field_added_rejected(self, tmp_path: Path):
+        """Adding a field not in original is rejected (except _oarPriorityManager)."""
+        original = {"name": "heavy", "priority": 100}
+        modified = {"name": "heavy", "priority": 100, "sneaky": True}
+        out = tmp_path / "user.json"
+        with pytest.raises(IllegalMutationError):
+            serialize_raw_dict(modified, original, out)
+
+    def test_field_removed_rejected(self, tmp_path: Path):
+        """Removing a field from original is rejected."""
+        original = {"name": "heavy", "priority": 100, "conditions": []}
+        modified = {"name": "heavy", "priority": 100}
+        out = tmp_path / "user.json"
+        with pytest.raises(IllegalMutationError):
+            serialize_raw_dict(modified, original, out)
+
+
+class TestMetadataInjection:
+    """Serializer injects _oarPriorityManager metadata."""
+
+    def test_metadata_present_in_output(self, tmp_path: Path):
+        original = {"name": "heavy", "priority": 100}
+        modified = {"name": "heavy", "priority": 500}
+        out = tmp_path / "user.json"
+        serialize_raw_dict(modified, original, out, previous_priority=100)
+        result = json.loads(out.read_text(encoding="utf-8"))
+        meta = result["_oarPriorityManager"]
+        assert meta["previousPriority"] == 100
+        assert "toolVersion" in meta
+        assert "writtenAt" in meta
+
+    def test_metadata_not_counted_as_mutation(self, tmp_path: Path):
+        """_oarPriorityManager metadata is exempt from the allowlist check."""
+        original = {"name": "heavy", "priority": 100}
+        modified = {"name": "heavy", "priority": 500}
+        out = tmp_path / "user.json"
+        # Should not raise even though _oarPriorityManager is a new key
+        serialize_raw_dict(modified, original, out, previous_priority=100)
+
+    def test_existing_metadata_updated(self, tmp_path: Path):
+        """If original already has _oarPriorityManager, it gets updated."""
+        original = {
+            "name": "heavy",
+            "priority": 300,
+            "_oarPriorityManager": {
+                "toolVersion": "0.1.0",
+                "writtenAt": "2026-01-01T00:00:00Z",
+                "previousPriority": 100,
+            },
+        }
+        modified = {"name": "heavy", "priority": 500, "_oarPriorityManager": original["_oarPriorityManager"]}
+        out = tmp_path / "user.json"
+        serialize_raw_dict(modified, original, out, previous_priority=300)
+        result = json.loads(out.read_text(encoding="utf-8"))
+        assert result["_oarPriorityManager"]["previousPriority"] == 300
+
+
+class TestRoundTrip:
+    """Serializer preserves all non-mutable fields exactly."""
+
+    def test_key_order_preserved(self, tmp_path: Path):
+        original = {"zeta": 1, "alpha": 2, "name": "test", "priority": 100}
+        modified = {"zeta": 1, "alpha": 2, "name": "test", "priority": 200}
+        out = tmp_path / "user.json"
+        serialize_raw_dict(modified, original, out)
+        result = json.loads(out.read_text(encoding="utf-8"))
+        # _oarPriorityManager is appended at end, but original keys keep order
+        original_keys = list(original.keys())
+        result_keys = [k for k in result.keys() if k != "_oarPriorityManager"]
+        assert result_keys == original_keys
+
+    def test_nested_structures_preserved(self, tmp_path: Path):
+        conditions = [
+            {
+                "condition": "IsFemale",
+                "negated": False,
+                "requiredVersion": "1.0",
+            },
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            },
+        ]
+        original = {"name": "test", "priority": 100, "conditions": conditions}
+        modified = {"name": "test", "priority": 200, "conditions": conditions}
+        out = tmp_path / "user.json"
+        serialize_raw_dict(modified, original, out)
+        result = json.loads(out.read_text(encoding="utf-8"))
+        assert result["conditions"] == conditions
+
+    def test_consistent_indentation(self, tmp_path: Path):
+        """Output uses 2-space indentation (spec §8.1.2)."""
+        original = {"name": "test", "priority": 100}
+        modified = {"name": "test", "priority": 200}
+        out = tmp_path / "user.json"
+        serialize_raw_dict(modified, original, out)
+        text = out.read_text(encoding="utf-8")
+        assert '  "name"' in text  # 2-space indent
+
+    def test_creates_parent_directories(self, tmp_path: Path):
+        original = {"name": "test", "priority": 100}
+        modified = {"name": "test", "priority": 200}
+        out = tmp_path / "deep" / "nested" / "path" / "user.json"
+        serialize_raw_dict(modified, original, out)
+        assert out.exists()

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -97,7 +97,11 @@ class TestMetadataInjection:
                 "previousPriority": 100,
             },
         }
-        modified = {"name": "heavy", "priority": 500, "_oarPriorityManager": original["_oarPriorityManager"]}
+        modified = {
+            "name": "heavy",
+            "priority": 500,
+            "_oarPriorityManager": original["_oarPriorityManager"],
+        }
         out = tmp_path / "user.json"
         serialize_raw_dict(modified, original, out, previous_priority=300)
         result = json.loads(out.read_text(encoding="utf-8"))
@@ -115,7 +119,7 @@ class TestRoundTrip:
         result = json.loads(out.read_text(encoding="utf-8"))
         # _oarPriorityManager is appended at end, but original keys keep order
         original_keys = list(original.keys())
-        result_keys = [k for k in result.keys() if k != "_oarPriorityManager"]
+        result_keys = [k for k in result if k != "_oarPriorityManager"]
         assert result_keys == original_keys
 
     def test_nested_structures_preserved(self, tmp_path: Path):

--- a/tests/unit/test_tree_model.py
+++ b/tests/unit/test_tree_model.py
@@ -3,10 +3,12 @@
 See spec §6.2 (tree_model), §7.3 (tree sort order).
 """
 from __future__ import annotations
+
 from pathlib import Path
-import pytest
+
 from oar_priority_manager.core.models import OverrideSource, SubMod
-from oar_priority_manager.ui.tree_model import SearchIndex, TreeNode, build_tree
+from oar_priority_manager.ui.tree_model import SearchIndex, build_tree
+
 
 def _sm(
     name: str,

--- a/tests/unit/test_tree_model.py
+++ b/tests/unit/test_tree_model.py
@@ -1,0 +1,129 @@
+"""Tests for ui/tree_model.py — hierarchy construction and search index.
+
+See spec §6.2 (tree_model), §7.3 (tree sort order).
+"""
+from __future__ import annotations
+from pathlib import Path
+import pytest
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.ui.tree_model import SearchIndex, TreeNode, build_tree
+
+def _sm(
+    name: str,
+    mo2_mod: str = "ModA",
+    replacer: str = "Rep",
+    priority: int = 100,
+    disabled: bool = False,
+    animations: list[str] | None = None,
+) -> SubMod:
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=disabled,
+        config_path=Path(f"C:/mods/{mo2_mod}/{replacer}/{name}/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": name, "priority": priority},
+        animations=animations or [],
+        conditions={},
+        warnings=[],
+    )
+
+class TestBuildTree:
+    def test_single_submod(self):
+        submods = [_sm("sub1", mo2_mod="ModA", replacer="Rep1")]
+        root = build_tree(submods)
+        assert len(root.children) == 1
+        mod = root.children[0]
+        assert mod.display_name == "ModA"
+        assert len(mod.children) == 1
+        rep = mod.children[0]
+        assert rep.display_name == "Rep1"
+        assert len(rep.children) == 1
+        assert rep.children[0].display_name == "sub1"
+
+    def test_mods_sorted_alphabetically(self):
+        submods = [
+            _sm("s1", mo2_mod="Zebra"),
+            _sm("s2", mo2_mod="Alpha"),
+            _sm("s3", mo2_mod="Middle"),
+        ]
+        root = build_tree(submods)
+        names = [c.display_name for c in root.children]
+        assert names == ["Alpha", "Middle", "Zebra"]
+
+    def test_submods_sorted_by_priority_descending(self):
+        submods = [
+            _sm("low", mo2_mod="Mod", replacer="Rep", priority=100),
+            _sm("high", mo2_mod="Mod", replacer="Rep", priority=500),
+            _sm("mid", mo2_mod="Mod", replacer="Rep", priority=300),
+        ]
+        root = build_tree(submods)
+        rep = root.children[0].children[0]
+        priorities = [c.submod.priority for c in rep.children]
+        assert priorities == [500, 300, 100]
+
+    def test_multiple_replacers_under_mod(self):
+        submods = [
+            _sm("s1", mo2_mod="Mod", replacer="RepB"),
+            _sm("s2", mo2_mod="Mod", replacer="RepA"),
+        ]
+        root = build_tree(submods)
+        rep_names = [c.display_name for c in root.children[0].children]
+        assert rep_names == ["RepA", "RepB"]
+
+    def test_auto_expand_single_replacer(self):
+        submods = [_sm("s1", mo2_mod="Mod", replacer="OnlyRep")]
+        root = build_tree(submods)
+        mod = root.children[0]
+        assert len(mod.children) == 1
+        assert mod.children[0].auto_expand is True
+
+    def test_no_auto_expand_multiple_replacers(self):
+        submods = [
+            _sm("s1", mo2_mod="Mod", replacer="Rep1"),
+            _sm("s2", mo2_mod="Mod", replacer="Rep2"),
+        ]
+        root = build_tree(submods)
+        mod = root.children[0]
+        assert not any(c.auto_expand for c in mod.children)
+
+class TestSearchIndex:
+    def test_indexes_mod_names(self):
+        submods = [_sm("s1", mo2_mod="Female Combat Pack")]
+        root = build_tree(submods)
+        index = SearchIndex(root, {})
+        results = index.search("Female")
+        assert any("Female Combat Pack" in r.display_text for r in results)
+
+    def test_indexes_submod_names(self):
+        submods = [_sm("heavy", mo2_mod="Mod")]
+        root = build_tree(submods)
+        index = SearchIndex(root, {})
+        results = index.search("heavy")
+        assert any("heavy" in r.display_text for r in results)
+
+    def test_indexes_animation_filenames(self):
+        submods = [_sm("s1", animations=["mt_walkforward.hkx"])]
+        conflict_map = {"mt_walkforward.hkx": submods}
+        root = build_tree(submods)
+        index = SearchIndex(root, conflict_map)
+        results = index.search("walkforward")
+        assert len(results) > 0
+
+    def test_empty_query_returns_empty(self):
+        submods = [_sm("s1")]
+        root = build_tree(submods)
+        index = SearchIndex(root, {})
+        assert index.search("") == []
+
+    def test_case_insensitive(self):
+        submods = [_sm("Heavy", mo2_mod="Mod")]
+        root = build_tree(submods)
+        index = SearchIndex(root, {})
+        results = index.search("heavy")
+        assert len(results) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,304 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/1e/2ec7afcebcf3efea593d13aee18bbcfdd3a243043d848ebf385055e9f636/librt-0.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90904fac73c478f4b83f4ed96c99c8208b75e6f9a8a1910548f69a00f1eaa671", size = 67155, upload-time = "2026-04-09T16:04:42.933Z" },
+    { url = "https://files.pythonhosted.org/packages/18/77/72b85afd4435268338ad4ec6231b3da8c77363f212a0227c1ff3b45e4d35/librt-0.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:789fff71757facc0738e8d89e3b84e4f0251c1c975e85e81b152cdaca927cc2d", size = 69916, upload-time = "2026-04-09T16:04:44.042Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/948ea0204fbe2e78add6d46b48330e58d39897e425560674aee302dca81c/librt-0.9.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1bf465d1e5b0a27713862441f6467b5ab76385f4ecf8f1f3a44f8aa3c695b4b6", size = 199635, upload-time = "2026-04-09T16:04:45.5Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/cd/894a29e251b296a27957856804cfd21e93c194aa131de8bb8032021be07e/librt-0.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f819e0c6413e259a17a7c0d49f97f405abadd3c2a316a3b46c6440b7dbbedbb1", size = 211051, upload-time = "2026-04-09T16:04:47.016Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8f/dcaed0bc084a35f3721ff2d081158db569d2c57ea07d35623ddaca5cfc8e/librt-0.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0785c2fb4a81e1aece366aa3e2e039f4a4d7d21aaaded5227d7f3c703427882", size = 224031, upload-time = "2026-04-09T16:04:48.207Z" },
+    { url = "https://files.pythonhosted.org/packages/03/44/88f6c1ed1132cd418601cc041fbd92fed28b3a09f39de81978e0822d13ff/librt-0.9.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:80b25c7b570a86c03b5da69e665809deb39265476e8e21d96a9328f9762f9990", size = 218069, upload-time = "2026-04-09T16:04:50.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/90/7d02e981c2db12188d82b4410ff3e35bfdb844b26aecd02233626f46af2b/librt-0.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d4d16b608a1c43d7e33142099a75cd93af482dadce0bf82421e91cad077157f4", size = 224857, upload-time = "2026-04-09T16:04:51.684Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/c77e706b7215ca32e928d47535cf13dbc3d25f096f84ddf8fbc06693e229/librt-0.9.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:194fc1a32e1e21fe809d38b5faea66cc65eaa00217c8901fbdb99866938adbdb", size = 219865, upload-time = "2026-04-09T16:04:52.949Z" },
+    { url = "https://files.pythonhosted.org/packages/52/d1/32b0c1a0eb8461c70c11656c46a29f760b7c7edf3c36d6f102470c17170f/librt-0.9.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8c6bc1384d9738781cfd41d09ad7f6e8af13cfea2c75ece6bd6d2566cdea2076", size = 218451, upload-time = "2026-04-09T16:04:54.174Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d1/adfd0f9c44761b1d49b1bec66173389834c33ee2bd3c7fd2e2367f1942d4/librt-0.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15cb151e52a044f06e54ac7f7b47adbfc89b5c8e2b63e1175a9d587c43e8942a", size = 241300, upload-time = "2026-04-09T16:04:55.452Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b0/9074b64407712f0003c27f5b1d7655d1438979155f049720e8a1abd9b1a1/librt-0.9.0-cp311-cp311-win32.whl", hash = "sha256:f100bfe2acf8a3689af9d0cc660d89f17286c9c795f9f18f7b62dd1a6b247ae6", size = 55668, upload-time = "2026-04-09T16:04:56.689Z" },
+    { url = "https://files.pythonhosted.org/packages/24/19/40b77b77ce80b9389fb03971431b09b6b913911c38d412059e0b3e2a9ef2/librt-0.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:0b73e4266307e51c95e09c0750b7ec383c561d2e97d58e473f6f6a209952fbb8", size = 62976, upload-time = "2026-04-09T16:04:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9d/9fa7a64041e29035cb8c575af5f0e3840be1b97b4c4d9061e0713f171849/librt-0.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc5518873822d2faa8ebdd2c1a4d7c8ef47b01a058495ab7924cb65bdbf5fc9a", size = 53502, upload-time = "2026-04-09T16:04:58.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/1c/74cb1d9993236910286865679d1c616b136b2eae468493aa939431eda410/mypy-1.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4525e7010b1b38334516181c5b81e16180b8e149e6684cee5a727c78186b4e3b", size = 14343972, upload-time = "2026-03-31T16:49:04.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/01399515eca280386e308cf57901e68d3a52af18691941b773b3380c1df8/mypy-1.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a17c5d0bdcca61ce24a35beb828a2d0d323d3fcf387d7512206888c900193367", size = 13225007, upload-time = "2026-03-31T16:50:08.151Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ac/b4ba5094fb2d7fe9d2037cd8d18bbe02bcf68fd22ab9ff013f55e57ba095/mypy-1.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f75ff57defcd0f1d6e006d721ccdec6c88d4f6a7816eb92f1c4890d979d9ee62", size = 13663752, upload-time = "2026-03-31T16:49:26.064Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/460678d3cf7da252d2288dad0c602294b6ec22a91932ec368cc11e44bb6e/mypy-1.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b503ab55a836136b619b5fc21c8803d810c5b87551af8600b72eecafb0059cb0", size = 14532265, upload-time = "2026-03-31T16:53:55.077Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3e/051cca8166cf0438ae3ea80e0e7c030d7a8ab98dffc93f80a1aa3f23c1a2/mypy-1.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1973868d2adbb4584a3835780b27436f06d1dc606af5be09f187aaa25be1070f", size = 14768476, upload-time = "2026-03-31T16:50:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/be/66/8e02ec184f852ed5c4abb805583305db475930854e09964b55e107cdcbc4/mypy-1.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:2fcedb16d456106e545b2bfd7ef9d24e70b38ec252d2a629823a4d07ebcdb69e", size = 10818226, upload-time = "2026-03-31T16:53:15.624Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4b/383ad1924b28f41e4879a74151e7a5451123330d45652da359f9183bcd45/mypy-1.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:379edf079ce44ac8d2805bcf9b3dd7340d4f97aad3a5e0ebabbf9d125b84b442", size = 9750091, upload-time = "2026-03-31T16:54:12.162Z" },
+    { url = "https://files.pythonhosted.org/packages/be/dd/3afa29b58c2e57c79116ed55d700721c3c3b15955e2b6251dd165d377c0e/mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214", size = 14509525, upload-time = "2026-03-31T16:55:01.824Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/227b516ab8cad9f2a13c5e7a98d28cd6aa75e9c83e82776ae6c1c4c046c7/mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e", size = 13326469, upload-time = "2026-03-31T16:51:41.23Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d4/1ddb799860c1b5ac6117ec307b965f65deeb47044395ff01ab793248a591/mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651", size = 13705953, upload-time = "2026-03-31T16:48:55.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b7/54a720f565a87b893182a2a393370289ae7149e4715859e10e1c05e49154/mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5", size = 14710363, upload-time = "2026-03-31T16:53:26.948Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/74810274848d061f8a8ea4ac23aaad43bd3d8c1882457999c2e568341c57/mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78", size = 14947005, upload-time = "2026-03-31T16:50:17.591Z" },
+    { url = "https://files.pythonhosted.org/packages/77/91/21b8ba75f958bcda75690951ce6fa6b7138b03471618959529d74b8544e2/mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489", size = 10880616, upload-time = "2026-03-31T16:52:19.986Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/15/3d8198ef97c1ca03aea010cce4f1d4f3bc5d9849e8c0140111ca2ead9fdd/mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33", size = 9813091, upload-time = "2026-03-31T16:53:44.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
+    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/9b/549228d88f574d04117e736f55958bd4908f980f9f5700a07aeb85df005b/mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69", size = 10888526, upload-time = "2026-03-31T16:50:59.827Z" },
+    { url = "https://files.pythonhosted.org/packages/91/17/15095c0e54a8bc04d22d4ff06b2139d5f142c2e87520b4e39010c4862771/mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e", size = 9816456, upload-time = "2026-03-31T16:49:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/59/98/1da9977016678c0b99d43afe52ed00bb3c1a0c4c995d3e6acca1a6ebb9b4/mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732", size = 11050925, upload-time = "2026-03-31T16:51:30.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e3/ba0b7a3143e49a9c4f5967dde6ea4bf8e0b10ecbbcca69af84027160ee89/mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef", size = 10001089, upload-time = "2026-03-31T16:49:43.632Z" },
+    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
+    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/76/53e893a498138066acd28192b77495c9357e5a58cc4be753182846b43315/mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb", size = 12572380, upload-time = "2026-03-31T16:49:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9c/6dbdae21f01b7aacddc2c0bbf3c5557aa547827fdf271770fe1e521e7093/mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd", size = 10381174, upload-time = "2026-03-31T16:51:20.179Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "oar-priority-manager"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyside6-essentials" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-qt" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "pyside6-essentials", specifier = ">=6.6,<6.9" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-qt", marker = "extra == 'dev'", specifier = ">=4.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.8.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/74/082381f996baea3d6716d542c2184cb031e63f1cb6d4edca871fe82dd787/PySide6_Essentials-6.8.3-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:aa56c135db924ecfaf50088baf32f737d28027419ca5fee67c0c7141b29184e3", size = 134189733, upload-time = "2025-03-27T12:14:00.369Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b2/3205336262bf88d57f01503df81ede2a0b1eecbb2a7d58978a5e5625f7c1/PySide6_Essentials-6.8.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:fd57fa0c886ef99b3844173322c0023ec77cc946a0c9a0cdfbc2ac5c511053c1", size = 95088226, upload-time = "2025-03-27T12:14:25.965Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e9/c5c48563c0436465356dbef44ef0396713c1194c37c7bb4d75c83414b90c/PySide6_Essentials-6.8.3-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:b4f4823f870b5bed477d6f7b6a3041839b859f70abfd703cf53208c73c2fe4cd", size = 92966444, upload-time = "2025-03-27T12:14:50.946Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0f/5d8c6da7586e57ee032643e0c0e62335ef1a1add1a980160ddd1654f1d8d/PySide6_Essentials-6.8.3-cp39-abi3-win_amd64.whl", hash = "sha256:3c0fae5550aff69f2166f46476c36e0ef56ce73d84829eac4559770b0c034b07", size = 72191029, upload-time = "2025-03-27T12:15:10.425Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-qt"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.8.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/89/162c763f2799786e16f9045aa599dcf126e0f5f6a517f1e0251ba0be17e6/shiboken6-6.8.3-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:483efc7dd53c69147b8a8ade71f7619c79ffc683efcb1dc4f4cb6c40bb23d29b", size = 402402, upload-time = "2025-03-27T12:07:27.796Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a1/f1958c9d00176044ab00464cd89b6969ef3a7d2ed12d316ff1eda3dec88f/shiboken6-6.8.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:295a003466ca2cccf6660e2f2ceb5e6cef4af192a48a196a32d46b6f0c9ec5cb", size = 204730, upload-time = "2025-03-27T12:07:29.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8d/48ba0b33953592e54b688f2dceb06274f419f7743a3ea0f4e48faf837652/shiboken6-6.8.3-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:2b1a41348102952d2a5fbf3630bddd4d44112e18058b5e4cf505e51f2812429d", size = 201025, upload-time = "2025-03-27T12:07:31.272Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/e77f3fba5337f2d98f977eece0fd24cda6cf7d83be2699514d2ca1d34f6c/shiboken6-6.8.3-cp39-abi3-win_amd64.whl", hash = "sha256:bca3a94513ce9242f7d4bbdca902072a1631888e0aa3a8711a52cc5dbe93588f", size = 1150998, upload-time = "2025-03-27T12:07:33.38Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary

Complete Tier 1 MVP implementation of the OAR Priority Manager — a PySide6 desktop tool for Skyrim modders to manage OAR submod priorities via MO2's Overwrite folder.

**12 commits, 43 files, ~3,968 lines across 16 tasks:**

- **Core engine** (Tasks 1–8): lenient JSON parser, MO2 scanner with override precedence, animation scanner with `overrideAnimationsFolder`, serializer with mutable-field allowlist guardrail, override manager (write/clear to Overwrite), priority resolver (move_to_top, set_exact, shift)
- **Filter engine** (Task 9): condition tree walker extracting present/negated type sets, `FilterQuery` with text + condition type matching
- **App config** (Task 10): `AppConfig` dataclass, 4-step instance root detection fallback, graceful config CRUD
- **Entry point** (Task 11): CLI arg parsing, full scan pipeline orchestration
- **Tree model** (Task 12): Mod→Replacer→Submod hierarchy builder, `SearchIndex` for case-insensitive search
- **UI shell** (Task 13): `MainWindow` with three-pane QSplitter, tree panel with status icons, stacks panel with rank badges and action buttons, details/conditions/search panels
- **Backend review fixes**: 14 findings resolved (atomic writes, deep copy guardrail, Windows path case sensitivity, centralized constants, `SubMod` identity via `__eq__`/`__hash__`)
- **Smoke tests** (Task 14): 3 PySide6 smoke tests with `QT_QPA_PLATFORM=offscreen`
- **CI** (Task 15): GitHub Actions on Windows with ruff + mypy + pytest
- **README** (Task 16): MO2 setup, dev instructions, architecture overview

## Key architectural guardrails

- **Mutable-field allowlist**: only `priority` may be modified — `IllegalMutationError` enforced by serializer prevents scope creep into condition editing
- **Overwrite-only writes**: never touches source mod files, always writes to MO2 Overwrite at mirrored paths
- **Atomic writes**: temp file + rename for crash-safe serialization on NTFS

## Test plan

- [x] 118 tests passing (78 unit + 4 integration + 3 smoke + 33 additional)
- [x] All tests run on Windows with `QT_QPA_PLATFORM=offscreen`
- [ ] CI workflow validates on push (ruff, mypy, pytest)
- [ ] Manual smoke test: launch with `--mods-path` pointing at real MO2 mods folder

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*