### PR TITLE
feat: Alpha 1 — UI Completion (11 issues)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ env/
 *.onefile-build/
 
 # IDE / editor
-.vscode/
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.debugpy",
+    "charliermarsh.ruff"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,53 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch App (real mods)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "oar_priority_manager",
+      "args": [
+        "--mods-path", "${input:modsPath}"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Launch App (debug)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "oar_priority_manager",
+      "args": [
+        "--mods-path", "${input:modsPath}",
+        "--debug"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Debug Current Test File",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "${file}",
+        "-v",
+        "--tb=long",
+        "-x"
+      ],
+      "console": "integratedTerminal",
+      "env": {
+        "QT_QPA_PLATFORM": "offscreen"
+      },
+      "justMyCode": false
+    }
+  ],
+  "inputs": [
+    {
+      "id": "modsPath",
+      "type": "promptString",
+      "description": "Path to your MO2 mods directory",
+      "default": ""
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe",
+  "python.terminal.activateEnvInCurrentTerminal": true,
+
+  // Linting — ruff handles everything
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+
+  // Testing
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests",
+    "-v",
+    "--tb=short"
+  ],
+
+  // Type checking
+  "python.analysis.typeCheckingMode": "basic",
+
+  // Terminal env for PySide6 headless testing
+  "terminal.integrated.env.windows": {
+    "QT_QPA_PLATFORM": "offscreen"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,109 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Test: All",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/python.exe",
+      "args": ["-m", "pytest", "tests", "-v", "--tb=short"],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "options": {
+        "env": { "QT_QPA_PLATFORM": "offscreen" }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: Unit Only",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/python.exe",
+      "args": ["-m", "pytest", "tests/unit", "-v", "--tb=short"],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: Integration Only",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/python.exe",
+      "args": ["-m", "pytest", "tests/integration", "-v", "--tb=short"],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Test: Smoke Only",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/python.exe",
+      "args": ["-m", "pytest", "tests/smoke", "-v", "--tb=short"],
+      "group": "test",
+      "options": {
+        "env": { "QT_QPA_PLATFORM": "offscreen" }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Lint: Ruff Check",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/ruff.exe",
+      "args": ["check", "src/", "tests/"],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Lint: Ruff Fix",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/ruff.exe",
+      "args": ["check", "src/", "tests/", "--fix"],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Type Check: mypy",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/Scripts/mypy.exe",
+      "args": ["src/"],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "CI: Full Check (lint + types + tests)",
+      "dependsOn": ["Lint: Ruff Check", "Type Check: mypy", "Test: All"],
+      "dependsOrder": "sequence",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "oar-priority-manager"
 version = "0.1.0"
 description = "OAR priority management tool for Skyrim modders using MO2"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.15"
 dependencies = [
-    "PySide6-Essentials>=6.6,<6.9",
+    "PySide6-Essentials>=6.6,<7",
 ]
 
 [project.optional-dependencies]

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -122,6 +122,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     exit_code = app.exec()
+    window.capture_config()
     save_config(app_config, config_path)
     return exit_code
 

--- a/src/oar_priority_manager/core/anim_scanner.py
+++ b/src/oar_priority_manager/core/anim_scanner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from oar_priority_manager.core.models import SubMod
 
@@ -41,28 +41,34 @@ def _get_animation_dir(submod: SubMod) -> Path:
     return submod_dir
 
 
-def _extract_replacement_anim_data_filenames(
+def _extract_replaced_animations(
     raw_dict: dict,
 ) -> set[str]:
-    """Extract animation filenames declared in replacementAnimDatas config.
+    """Extract vanilla animation names from replacementAnimDatas config.
 
-    OAR submods may declare animations via a ``replacementAnimDatas`` array
-    in their config JSON rather than placing loose .hkx files on disk.  Each
-    entry in the array may target a different skeleton project (e.g.
-    DefaultMale / DefaultFemale) and contains a ``variants`` list whose
-    elements carry a ``filename`` field.
+    Each entry in the ``replacementAnimDatas`` array represents **one vanilla
+    animation slot** being overridden.  The identity of that slot is encoded
+    in the entry's ``path`` field — specifically in the last path segment,
+    which follows the convention ``_variants_<vanillaname>``.
 
-    All variants are included regardless of their ``disabled`` flag — a
-    disabled variant still names a real animation file that participates in
-    priority resolution.
+    For example, an entry whose path ends in ``_variants_sneakmtidle``
+    overrides the vanilla ``sneakmtidle.hkx``.  The variant ``filename``
+    fields inside each entry are the *replacement* .hkx assets used at
+    runtime; they are **not** the vanilla animation identifiers and are
+    intentionally ignored here.
+
+    Derivation rules for each entry's ``path`` last segment:
+    - If it starts with ``_variants_``, strip that prefix to get the name.
+    - Otherwise use the segment as-is.
+    - Lowercase and append ``.hkx`` if not already present.
 
     Args:
         raw_dict: The submod's raw config dictionary (``SubMod.raw_dict``).
 
     Returns:
-        A deduplicated set of lowercased animation filenames found across
-        all ``replacementAnimDatas`` entries.  Returns an empty set when the
-        key is absent or the data is malformed.
+        A deduplicated set of lowercased vanilla animation filenames, one per
+        ``replacementAnimDatas`` entry whose ``path`` can be parsed.  Returns
+        an empty set when the key is absent or the data is malformed.
     """
     filenames: set[str] = set()
     entries = raw_dict.get("replacementAnimDatas", [])
@@ -72,15 +78,23 @@ def _extract_replacement_anim_data_filenames(
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        variants = entry.get("variants", [])
-        if not isinstance(variants, list):
+        path = entry.get("path")
+        if not path or not isinstance(path, str):
             continue
-        for variant in variants:
-            if not isinstance(variant, dict):
-                continue
-            filename = variant.get("filename")
-            if filename and isinstance(filename, str):
-                filenames.add(filename.lower())
+        # Use PureWindowsPath to correctly parse backslash-separated OAR paths.
+        last_segment = PureWindowsPath(path).name
+        if not last_segment:
+            continue
+        if last_segment.startswith("_variants_"):
+            name = last_segment[len("_variants_"):]
+        else:
+            name = last_segment
+        if not name:
+            continue
+        name = name.lower()
+        if not name.endswith(".hkx"):
+            name += ".hkx"
+        filenames.add(name)
 
     return filenames
 
@@ -114,7 +128,7 @@ def scan_animations(submods: list[SubMod]) -> None:
             )
             hkx_files = set()
 
-        config_anims = _extract_replacement_anim_data_filenames(sm.raw_dict)
+        config_anims = _extract_replaced_animations(sm.raw_dict)
         sm.animations = sorted(hkx_files | config_anims)
 
 

--- a/src/oar_priority_manager/core/anim_scanner.py
+++ b/src/oar_priority_manager/core/anim_scanner.py
@@ -41,24 +41,81 @@ def _get_animation_dir(submod: SubMod) -> Path:
     return submod_dir
 
 
+def _extract_replacement_anim_data_filenames(
+    raw_dict: dict,
+) -> set[str]:
+    """Extract animation filenames declared in replacementAnimDatas config.
+
+    OAR submods may declare animations via a ``replacementAnimDatas`` array
+    in their config JSON rather than placing loose .hkx files on disk.  Each
+    entry in the array may target a different skeleton project (e.g.
+    DefaultMale / DefaultFemale) and contains a ``variants`` list whose
+    elements carry a ``filename`` field.
+
+    All variants are included regardless of their ``disabled`` flag — a
+    disabled variant still names a real animation file that participates in
+    priority resolution.
+
+    Args:
+        raw_dict: The submod's raw config dictionary (``SubMod.raw_dict``).
+
+    Returns:
+        A deduplicated set of lowercased animation filenames found across
+        all ``replacementAnimDatas`` entries.  Returns an empty set when the
+        key is absent or the data is malformed.
+    """
+    filenames: set[str] = set()
+    entries = raw_dict.get("replacementAnimDatas", [])
+    if not isinstance(entries, list):
+        return filenames
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        variants = entry.get("variants", [])
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if not isinstance(variant, dict):
+                continue
+            filename = variant.get("filename")
+            if filename and isinstance(filename, str):
+                filenames.add(filename.lower())
+
+    return filenames
+
+
 def scan_animations(submods: list[SubMod]) -> None:
     """Populate each SubMod's animations list with lowercased .hkx filenames.
 
+    Discovers animations from two sources and merges them:
+
+    1. Filesystem: ``.hkx`` files found in the submod's animation directory
+       (or ``overrideAnimationsFolder`` if set).
+    2. Config JSON: filenames declared in ``replacementAnimDatas`` entries
+       within the submod's ``raw_dict``.
+
     Modifies submods in place.
+
+    Args:
+        submods: List of SubMod instances to populate.
     """
     for sm in submods:
         anim_dir = _get_animation_dir(sm)
         try:
-            hkx_files = [
+            hkx_files: set[str] = {
                 f.name.lower()
                 for f in anim_dir.iterdir()
                 if f.is_file() and f.suffix.lower() == ".hkx"
-            ]
+            }
         except OSError as e:
-            sm.warnings.append(f"Cannot read animation directory {anim_dir}: {e}")
-            hkx_files = []
+            sm.warnings.append(
+                f"Cannot read animation directory {anim_dir}: {e}"
+            )
+            hkx_files = set()
 
-        sm.animations = sorted(hkx_files)
+        config_anims = _extract_replacement_anim_data_filenames(sm.raw_dict)
+        sm.animations = sorted(hkx_files | config_anims)
 
 
 def build_conflict_map(submods: list[SubMod]) -> dict[str, list[SubMod]]:

--- a/src/oar_priority_manager/core/anim_scanner.py
+++ b/src/oar_priority_manager/core/anim_scanner.py
@@ -99,15 +99,52 @@ def _extract_replaced_animations(
     return filenames
 
 
+def _discover_variant_folders(submod_dir: Path) -> set[str]:
+    """Discover implicit OAR variant folders in a submod directory.
+
+    OAR auto-discovers subdirectories whose names start with ``_variants_``
+    inside a submod folder, without those directories needing to be declared
+    in config.json.  Each such directory implicitly overrides the vanilla
+    animation whose name matches the suffix after ``_variants_``.
+
+    Derivation rules for each matching subdirectory name:
+    - Strip the ``_variants_`` prefix.
+    - Lowercase the result.
+    - Append ``.hkx``.
+
+    Args:
+        submod_dir: The submod directory to scan (``config_path.parent``).
+
+    Returns:
+        A deduplicated set of lowercased derived animation filenames.
+        Returns an empty set on OSError (e.g. directory does not exist).
+    """
+    filenames: set[str] = set()
+    try:
+        for entry in submod_dir.iterdir():
+            if entry.is_dir() and entry.name.startswith("_variants_"):
+                name = entry.name[len("_variants_"):].lower()
+                if name:
+                    if not name.endswith(".hkx"):
+                        name += ".hkx"
+                    filenames.add(name)
+    except OSError:
+        pass
+    return filenames
+
+
 def scan_animations(submods: list[SubMod]) -> None:
     """Populate each SubMod's animations list with lowercased .hkx filenames.
 
-    Discovers animations from two sources and merges them:
+    Discovers animations from three sources and merges them:
 
     1. Filesystem: ``.hkx`` files found in the submod's animation directory
        (or ``overrideAnimationsFolder`` if set).
     2. Config JSON: filenames declared in ``replacementAnimDatas`` entries
        within the submod's ``raw_dict``.
+    3. Implicit variant folders: subdirectories starting with ``_variants_``
+       in the submod directory, discovered by convention (no config.json entry
+       required).
 
     Modifies submods in place.
 
@@ -129,7 +166,8 @@ def scan_animations(submods: list[SubMod]) -> None:
             hkx_files = set()
 
         config_anims = _extract_replaced_animations(sm.raw_dict)
-        sm.animations = sorted(hkx_files | config_anims)
+        variant_folder_anims = _discover_variant_folders(sm.config_path.parent)
+        sm.animations = sorted(hkx_files | config_anims | variant_folder_anims)
 
 
 def build_conflict_map(submods: list[SubMod]) -> dict[str, list[SubMod]]:

--- a/src/oar_priority_manager/core/models.py
+++ b/src/oar_priority_manager/core/models.py
@@ -65,6 +65,11 @@ class SubMod:
         return len(self.warnings) > 0
 
     @property
+    def is_config_only(self) -> bool:
+        """True if this submod has no animations — it's a pure config/toggle flag."""
+        return len(self.animations) == 0
+
+    @property
     def is_overridden(self) -> bool:
         """True if priority differs from the source config.json value."""
         return self.priority != self.source_priority

--- a/src/oar_priority_manager/ui/details_panel.py
+++ b/src/oar_priority_manager/ui/details_panel.py
@@ -22,7 +22,9 @@ class DetailsPanel(QWidget):
         self._label = QLabel("Select an item in the tree to see details.")
         self._label.setWordWrap(True)
         self._label.setTextFormat(Qt.TextFormat.RichText)
+        self._label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         layout.addWidget(self._label)
+        layout.addStretch()
 
     def update_selection(self, node: TreeNode | None) -> None:
         """Update display based on the selected tree node.

--- a/src/oar_priority_manager/ui/details_panel.py
+++ b/src/oar_priority_manager/ui/details_panel.py
@@ -5,10 +5,11 @@ See spec §7.3. Shows different content for mod/replacer/submod selection levels
 
 from __future__ import annotations
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
-from oar_priority_manager.core.models import SubMod
-from oar_priority_manager.ui.tree_model import NodeType
+from oar_priority_manager.core.models import OverrideSource
+from oar_priority_manager.ui.tree_model import NodeType, TreeNode
 
 
 class DetailsPanel(QWidget):
@@ -20,26 +21,235 @@ class DetailsPanel(QWidget):
         layout.setContentsMargins(4, 4, 4, 4)
         self._label = QLabel("Select an item in the tree to see details.")
         self._label.setWordWrap(True)
+        self._label.setTextFormat(Qt.TextFormat.RichText)
         layout.addWidget(self._label)
 
-    def update_selection(self, node_type: NodeType | None, submod: SubMod | None) -> None:
-        """Update display based on tree selection."""
-        if node_type is None or (node_type == NodeType.SUBMOD and submod is None):
+    def update_selection(self, node: TreeNode | None) -> None:
+        """Update display based on the selected tree node.
+
+        Args:
+            node: The selected TreeNode, or None to clear the panel.
+                  For MOD nodes, aggregates data from child replacer/submod nodes.
+                  For REPLACER nodes, aggregates data from child submod nodes.
+                  For SUBMOD nodes, shows full metadata for the individual submod.
+        """
+        if node is None or node.node_type == NodeType.ROOT:
             self._label.setText("Select an item in the tree to see details.")
             return
 
-        if node_type == NodeType.SUBMOD and submod is not None:
-            lines = [
-                f"<b>{submod.name}</b>",
-                f"<span style='color:gray'>{submod.display_path}</span>",
-                f"Priority: <b>{submod.priority:,}</b>",
-            ]
-            if submod.is_overridden:
-                lines.append(f"<span style='color:#aa4'>was {submod.source_priority:,}</span>")
-            lines.append(f"MO2 source: <code>{submod.mo2_mod}</code>")
-            lines.append(f"Animations: {len(submod.animations)} files")
-            self._label.setText("<br>".join(lines))
-        elif node_type == NodeType.MOD:
-            self._label.setText("<b>Mod</b> — select a submod for details")
-        elif node_type == NodeType.REPLACER:
-            self._label.setText("<b>Replacer</b> — select a submod for details")
+        if node.node_type == NodeType.MOD:
+            self._label.setText(self._render_mod(node))
+        elif node.node_type == NodeType.REPLACER:
+            self._label.setText(self._render_replacer(node))
+        elif node.node_type == NodeType.SUBMOD:
+            if node.submod is None:
+                self._label.setText("Select an item in the tree to see details.")
+            else:
+                self._label.setText(self._render_submod(node))
+
+    # ------------------------------------------------------------------
+    # Per-level renderers
+    # ------------------------------------------------------------------
+
+    def _render_mod(self, node: TreeNode) -> str:
+        """Build rich HTML for a MOD-level node.
+
+        Aggregates counts across all descendant replacer and submod nodes.
+
+        Args:
+            node: A MOD-level TreeNode whose children are REPLACER nodes.
+
+        Returns:
+            An HTML string suitable for a QLabel in RichText mode.
+        """
+        replacer_nodes = node.children
+        submod_nodes = [
+            sub
+            for rep in replacer_nodes
+            for sub in rep.children
+            if sub.submod is not None
+        ]
+        all_submods = [sn.submod for sn in submod_nodes if sn.submod is not None]
+
+        n_replacers = len(replacer_nodes)
+        n_submods = len(all_submods)
+        n_animations = sum(len(sm.animations) for sm in all_submods)
+        n_overridden = sum(1 for sm in all_submods if sm.is_overridden)
+        n_disabled = sum(1 for sm in all_submods if sm.disabled)
+
+        # Attempt to derive the filesystem path from the first submod's config_path.
+        # config_path is e.g. .../mods/<Mo2Mod>/meshes/.../replacer/submod/config.json
+        # We want the MO2 mod folder itself: config_path.parents[len(OAR_REL)+1+1+1]
+        path_str = ""
+        if all_submods:
+            from oar_priority_manager.core.models import OAR_REL
+            # OAR_REL has N parts; submod dir is at offset N+1 from the mod root,
+            # and config.json is one more level down.
+            oar_depth = len(OAR_REL.parts)  # e.g. 4 for meshes/actors/.../OpenAnimationReplacer
+            # config.json -> submod dir -> replacer dir -> OAR_REL (oar_depth parts) -> mod root
+            # That's 1 (config) + 1 (submod) + 1 (replacer) + oar_depth = oar_depth + 3
+            try:
+                mod_root = all_submods[0].config_path.parents[oar_depth + 2]
+                path_str = str(mod_root)
+            except IndexError:
+                path_str = ""
+
+        lines = [
+            f"<b>{node.display_name}</b>",
+        ]
+        if path_str:
+            lines.append(f"<span style='color:gray'>{path_str}</span>")
+        lines.append(
+            f"Replacers: <b>{n_replacers}</b> &nbsp;·&nbsp; "
+            f"Submods: <b>{n_submods}</b> &nbsp;·&nbsp; "
+            f"Animations: <b>{n_animations}</b>"
+        )
+        lines.append(
+            f"Priority overrides: <b>{n_overridden}</b> of {n_submods} submods"
+        )
+        if n_disabled:
+            lines.append(
+                f"<span style='color:red'>Disabled: {n_disabled}</span>"
+            )
+        return "<br>".join(lines)
+
+    def _render_replacer(self, node: TreeNode) -> str:
+        """Build rich HTML for a REPLACER-level node.
+
+        Aggregates counts across all child submod nodes.
+
+        Args:
+            node: A REPLACER-level TreeNode whose children are SUBMOD nodes.
+
+        Returns:
+            An HTML string suitable for a QLabel in RichText mode.
+        """
+        all_submods = [sn.submod for sn in node.children if sn.submod is not None]
+
+        n_submods = len(all_submods)
+        n_animations = sum(len(sm.animations) for sm in all_submods)
+        n_overridden = sum(1 for sm in all_submods if sm.is_overridden)
+
+        parent_name = node.parent.display_name if node.parent else ""
+
+        priority_range_str = ""
+        if all_submods:
+            priorities = [sm.priority for sm in all_submods]
+            p_min, p_max = min(priorities), max(priorities)
+            if p_min == p_max:
+                priority_range_str = f"Priority: <b>{p_min:,}</b>"
+            else:
+                priority_range_str = (
+                    f"Priority range: <b>{p_min:,}</b> – <b>{p_max:,}</b>"
+                )
+
+        lines = [
+            f"<b>{node.display_name}</b>",
+        ]
+        if parent_name:
+            lines.append(f"<span style='color:gray'>in {parent_name}</span>")
+        lines.append(
+            f"Submods: <b>{n_submods}</b> &nbsp;·&nbsp; "
+            f"Animations: <b>{n_animations}</b>"
+        )
+        if priority_range_str:
+            lines.append(priority_range_str)
+        lines.append(
+            f"Priority overrides: <b>{n_overridden}</b> of {n_submods} submods"
+        )
+        return "<br>".join(lines)
+
+    def _render_submod(self, node: TreeNode) -> str:
+        """Build rich HTML for a SUBMOD-level node.
+
+        Shows full metadata for the individual submod including override
+        provenance, condition summary, and warning badges.
+
+        Args:
+            node: A SUBMOD-level TreeNode with a non-None submod field.
+
+        Returns:
+            An HTML string suitable for a QLabel in RichText mode.
+        """
+        submod = node.submod
+        assert submod is not None  # caller guarantees this
+
+        lines = [
+            f"<b>{submod.name}</b>",
+        ]
+
+        # Filesystem path (parent of config.json = submod directory)
+        lines.append(
+            f"<span style='color:gray'>{submod.config_path.parent}</span>"
+        )
+
+        # Enabled / Disabled badge
+        if submod.disabled:
+            lines.append("<span style='color:red'><b>DISABLED</b></span>")
+
+        # Overridden badge
+        if submod.is_overridden:
+            lines.append("<span style='color:#ccaa00'><b>OVERRIDDEN</b></span>")
+
+        # Description (optional)
+        if submod.description:
+            lines.append(
+                f"<i><span style='color:gray'>{submod.description}</span></i>"
+            )
+
+        # MO2 source
+        lines.append(f"MO2 source: <code>{submod.mo2_mod}</code>")
+
+        # Priority (with "was X" if overridden)
+        priority_line = f"Priority: <b>{submod.priority:,}</b>"
+        if submod.is_overridden:
+            priority_line += (
+                f" &nbsp;<span style='color:#aa4'>(was {submod.source_priority:,})</span>"
+            )
+        lines.append(priority_line)
+
+        # Animation count
+        lines.append(f"Animations: {len(submod.animations)} files")
+
+        # Condition summary
+        n_conditions = len(submod.conditions) if isinstance(submod.conditions, list) else (
+            len(submod.conditions) if submod.conditions else 0
+        )
+        n_types = len(submod.condition_types_present)
+        lines.append(f"Conditions: {n_conditions} entries · {n_types} types")
+
+        # Override source label
+        source_label = _override_source_label(submod.override_source)
+        lines.append(f"<span style='color:gray'>{source_label}</span>")
+
+        # External override badge
+        if (
+            submod.override_source == OverrideSource.OVERWRITE
+            and not submod.override_is_ours
+        ):
+            lines.append(
+                "<span style='color:orange'><b>&#9888; EXTERNAL OVERRIDE</b></span>"
+            )
+
+        return "<br>".join(lines)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _override_source_label(source: OverrideSource) -> str:
+    """Map an OverrideSource enum value to a human-readable label.
+
+    Args:
+        source: The OverrideSource enum value to map.
+
+    Returns:
+        A human-readable string describing where the effective priority
+        was read from.
+    """
+    if source == OverrideSource.OVERWRITE:
+        return "Override source: MO2 Overwrite"
+    if source == OverrideSource.USER_JSON:
+        return "Override source: user.json in source"
+    return "Override source: config.json"

--- a/src/oar_priority_manager/ui/details_panel.py
+++ b/src/oar_priority_manager/ui/details_panel.py
@@ -213,6 +213,13 @@ class DetailsPanel(QWidget):
         # Animation count
         lines.append(f"Animations: {len(submod.animations)} files")
 
+        # Config-only indicator (no animations — pure toggle/flag submod)
+        if submod.is_config_only:
+            lines.append(
+                "<span style='color:#6af'><b>CONFIG-ONLY</b>"
+                " \u2014 toggle flag, no animations to replace</span>"
+            )
+
         # Condition summary
         n_conditions = len(submod.conditions) if isinstance(submod.conditions, list) else (
             len(submod.conditions) if submod.conditions else 0

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -21,6 +21,7 @@ from oar_priority_manager.ui.conditions_panel import ConditionsPanel
 from oar_priority_manager.ui.details_panel import DetailsPanel
 from oar_priority_manager.ui.search_bar import SearchBar
 from oar_priority_manager.ui.stacks_panel import StacksPanel
+from oar_priority_manager.ui.tree_model import SearchIndex
 from oar_priority_manager.ui.tree_panel import TreePanel
 
 
@@ -91,16 +92,39 @@ class MainWindow(QMainWindow):
         shortcut = QShortcut(QKeySequence("Ctrl+F"), self)
         shortcut.activated.connect(self._search_bar.focus_search)
 
+        # Search bar gets keyboard focus on launch (spec §7.2)
+        self._search_bar.focus_search()
+
     def _connect_signals(self) -> None:
         self._tree_panel.selection_changed.connect(self._on_tree_selection)
+        self._search_bar.search_changed.connect(self._on_search)
         self._search_bar.refresh_requested.connect(self._on_refresh)
         self._stacks_panel.action_triggered.connect(self._on_action)
+        self._stacks_panel.competitor_focused.connect(self._on_competitor_focused)
 
-    def _on_tree_selection(self, node_type, submod) -> None:
-        self._details_panel.update_selection(node_type, submod)
-        self._stacks_panel.update_selection(submod)
+    def _on_tree_selection(self, node) -> None:
+        self._details_panel.update_selection(node)
+        submod = node.submod if node else None
+        if submod:
+            self._stacks_panel.update_selection(submod)
+            self._conditions_panel.update_focus(submod)
+
+    def _on_competitor_focused(self, submod: SubMod) -> None:
+        """Update conditions panel when a competitor row is clicked (spec §7.5)."""
         if submod:
             self._conditions_panel.update_focus(submod)
+
+    def _on_search(self, query: str) -> None:
+        """Filter tree based on search query (spec §7.2)."""
+        if not query.strip():
+            self._tree_panel.filter_tree(None)
+            return
+
+        # Build search index on each search (fast enough for typical mod counts)
+        index = SearchIndex(self._tree_panel.tree_root, self._conflict_map)
+        results = index.search(query)
+        matching = {id(r.node) for r in results}
+        self._tree_panel.filter_tree(matching)
 
     def _on_action(self, action: str, submod: SubMod, value: object) -> None:
         """Handle priority mutation actions from the stacks panel (spec §6.3 step 5)."""

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QKeySequence, QShortcut
-from PySide6.QtWidgets import QMainWindow, QSplitter, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QHBoxLayout, QMainWindow, QPushButton, QSplitter, QVBoxLayout, QWidget
 
 from oar_priority_manager.app.config import AppConfig
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
@@ -49,6 +49,7 @@ class MainWindow(QMainWindow):
 
         self._setup_ui()
         self._connect_signals()
+        self._apply_config()
 
     def _setup_ui(self) -> None:
         central = QWidget()
@@ -56,10 +57,25 @@ class MainWindow(QMainWindow):
         main_layout = QVBoxLayout(central)
         main_layout.setContentsMargins(4, 4, 4, 4)
 
-        # Top bar: search + advanced + refresh (fixed height, no stretch)
+        # Top bar: search bar + Clear Overrides button (fixed height, no stretch)
         self._search_bar = SearchBar()
         self._search_bar.setFixedHeight(40)
-        main_layout.addWidget(self._search_bar, stretch=0)
+
+        self._clear_overrides_btn = QPushButton("Clear Overrides")
+        self._clear_overrides_btn.setToolTip(
+            "Delete all tool-written overrides for the selected mod"
+            " (reverts to source priorities)"
+        )
+        self._clear_overrides_btn.clicked.connect(self._on_clear_overrides)
+
+        top_bar = QWidget()
+        top_bar.setFixedHeight(40)
+        top_layout = QHBoxLayout(top_bar)
+        top_layout.setContentsMargins(0, 0, 0, 0)
+        top_layout.addWidget(self._search_bar, stretch=1)
+        top_layout.addWidget(self._clear_overrides_btn)
+
+        main_layout.addWidget(top_bar, stretch=0)
 
         # Three-pane splitter (takes all remaining space)
         self._main_splitter = QSplitter(Qt.Orientation.Horizontal)
@@ -138,6 +154,10 @@ class MainWindow(QMainWindow):
         try:
             if action == "move_to_top":
                 new_priorities = move_to_top(submod, self._conflict_map, scope="submod")
+            elif action == "move_to_top_replacer":
+                new_priorities = move_to_top(submod, self._conflict_map, scope="replacer")
+            elif action == "move_to_top_mod":
+                new_priorities = move_to_top(submod, self._conflict_map, scope="mod")
             elif action == "set_exact" and isinstance(value, int):
                 new_priorities = set_exact(submod, value)
             else:
@@ -154,9 +174,80 @@ class MainWindow(QMainWindow):
             self._stacks_panel.update_selection(submod)
             self._tree_panel.refresh(self._submods)
 
+            # Show toast notification (issue #37, spec §7.4)
+            self._stacks_panel.show_toast(
+                "Priority updated — you're now #1. Changes take effect the next time"
+                " Skyrim loads this animation."
+            )
+
         except PriorityOverflowError as e:
             from PySide6.QtWidgets import QMessageBox
             QMessageBox.warning(self, "Priority Overflow", str(e))
+
+    def _on_clear_overrides(self) -> None:
+        """Clear all tool-written overrides for the selected mod (spec §8.2).
+
+        Collects all submods in the current tree selection scope (submod,
+        replacer, or mod), filters to those with an Overwrite-layer override,
+        confirms with the user, deletes the override files, then refreshes.
+        """
+        from PySide6.QtWidgets import QMessageBox
+
+        from oar_priority_manager.core.models import OverrideSource
+        from oar_priority_manager.core.override_manager import clear_override
+        from oar_priority_manager.ui.tree_model import NodeType
+
+        current_item = self._tree_panel._tree.currentItem()
+        if current_item is None:
+            QMessageBox.information(
+                self, "Clear Overrides", "Select a mod, replacer, or submod first."
+            )
+            return
+
+        node = self._tree_panel._item_map.get(id(current_item))
+        if node is None:
+            return
+
+        # Collect all submods in scope based on what level is selected
+        submods_in_scope: list[SubMod] = []
+        if node.node_type == NodeType.SUBMOD and node.submod:
+            submods_in_scope = [node.submod]
+        elif node.node_type == NodeType.REPLACER:
+            submods_in_scope = [sn.submod for sn in node.children if sn.submod]
+        elif node.node_type == NodeType.MOD:
+            submods_in_scope = [
+                sn.submod
+                for rep in node.children
+                for sn in rep.children
+                if sn.submod
+            ]
+
+        # Filter to only those with an Overwrite-layer override present
+        overridden = [
+            sm for sm in submods_in_scope if sm.override_source == OverrideSource.OVERWRITE
+        ]
+
+        if not overridden:
+            QMessageBox.information(
+                self, "Clear Overrides", "No overrides to clear for this selection."
+            )
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Clear Overrides",
+            f"Remove {len(overridden)} override(s) for the selected scope? "
+            "This will revert to source priorities.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        overwrite_dir = self._instance_root / "overwrite"
+        for sm in overridden:
+            clear_override(sm, overwrite_dir)
+
+        self._on_refresh()
 
     def _on_refresh(self) -> None:
         """Re-scan the VFS and rebuild all models (spec §6.3 step 6)."""
@@ -175,3 +266,45 @@ class MainWindow(QMainWindow):
 
         self._tree_panel.refresh(self._submods)
         self._stacks_panel.refresh(self._conflict_map)
+
+    def _apply_config(self) -> None:
+        """Apply persisted config values to UI widgets (spec §8.3)."""
+        cfg = self._config
+
+        # Relative/Absolute toggle
+        if cfg.relative_or_absolute == "absolute":
+            self._stacks_panel.set_relative_mode(False)
+
+        # Window geometry
+        if cfg.window_geometry:
+            from PySide6.QtCore import QByteArray
+            geo = QByteArray.fromBase64(cfg.window_geometry.encode())
+            self.restoreGeometry(geo)
+
+        # Splitter positions: [main0, main1, main2, left0, left1]
+        if cfg.splitter_positions and len(cfg.splitter_positions) >= 3:
+            main_sizes = cfg.splitter_positions[:3]
+            self._main_splitter.setSizes(main_sizes)
+        if cfg.splitter_positions and len(cfg.splitter_positions) >= 5:
+            left_sizes = cfg.splitter_positions[3:5]
+            self._left_splitter.setSizes(left_sizes)
+
+    def capture_config(self) -> None:
+        """Capture current UI state into the AppConfig (spec §8.3).
+
+        Called before shutdown to persist user preferences.
+        """
+        cfg = self._config
+
+        # Relative/Absolute mode
+        cfg.relative_or_absolute = (
+            "relative" if self._stacks_panel._relative_mode else "absolute"
+        )
+
+        # Window geometry (base64 encoded QByteArray)
+        cfg.window_geometry = self.saveGeometry().toBase64().data().decode()
+
+        # Splitter positions: [main0, main1, main2, left0, left1]
+        cfg.splitter_positions = list(self._main_splitter.sizes()) + list(
+            self._left_splitter.sizes()
+        )

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -7,12 +7,15 @@ Issues addressed:
   #34 — Rank badge colours (green for #1, grey for rest; red bg for losing rows)
   #35 — Expand/collapse animation sections
   #36 — Clickable competitor rows emitting competitor_focused signal
+  #68 — Action buttons moved to toolbar row
+  #69 — Relative/Absolute replaced with segmented toggle control
 """
 
 from __future__ import annotations
 
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (
+    QButtonGroup,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -33,7 +36,7 @@ from oar_priority_manager.core.models import SubMod
 class _StackSection(QWidget):
     """A single animation's priority stack — collapsible via header click."""
 
-    def __init__(self, header_html: str, parent: QWidget | None = None) -> None:
+    def __init__(self, header_text: str, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._expanded = True
 
@@ -65,7 +68,7 @@ class _StackSection(QWidget):
         outer.addWidget(self._content)
 
         # Store the base header text (without arrow prefix) so we can rebuild it
-        self._header_html = header_html
+        self._header_text = header_text
         self._update_header()
 
     # ------------------------------------------------------------------
@@ -87,7 +90,7 @@ class _StackSection(QWidget):
 
     def _update_header(self) -> None:
         arrow = "▾" if self._expanded else "▸"
-        self._header_btn.setText(f"{arrow} {self._header_html}")
+        self._header_btn.setText(f"{arrow} {self._header_text}")
 
 
 # ---------------------------------------------------------------------------
@@ -193,32 +196,117 @@ class StacksPanel(QWidget):
     # ------------------------------------------------------------------
 
     def _setup_ui(self) -> None:
+        """Build the panel layout.
+
+        Layout (top to bottom):
+          1. Toolbar: segmented Relative|Absolute toggle, spacer, action buttons
+          2. Toast label (hidden by default)
+          3. Header label
+          4. Scroll area with collapsible stack sections
+        """
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # ---- Toolbar: Relative / Absolute toggle (issue #33) ----
+        # ---- Toolbar row (issues #33, #68, #69) ----
         toolbar_widget = QWidget()
         toolbar = QHBoxLayout(toolbar_widget)
         toolbar.setContentsMargins(4, 4, 4, 2)
+        toolbar.setSpacing(4)
+
+        # -- Segmented Relative | Absolute toggle (issue #69) --
+        # Two checkable QPushButtons styled to sit flush with radius only on
+        # outside corners, giving the appearance of a single segmented control.
+        _seg_checked = (
+            "QPushButton:checked {"
+            "  background: #3a3a5a;"
+            "  font-weight: bold;"
+            "  border: 1px solid #5a5a8a;"
+            "}"
+        )
+        _seg_unchecked = (
+            "QPushButton {"
+            "  background: #2a2a2a;"
+            "  border: 1px solid #444;"
+            "  padding: 3px 10px;"
+            "}"
+            "QPushButton:hover { background: #333; }"
+        )
 
         self._rel_btn = QPushButton("Relative")
-        self._abs_btn = QPushButton("Absolute")
         self._rel_btn.setCheckable(True)
+        self._rel_btn.setChecked(True)
+        self._rel_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-left-radius: 4px;"
+            "  border-bottom-left-radius: 4px;"
+            "  border-right: none; }"
+        )
+
+        self._abs_btn = QPushButton("Absolute")
         self._abs_btn.setCheckable(True)
-        self._rel_btn.setChecked(True)   # default: relative mode
         self._abs_btn.setChecked(False)
+        self._abs_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-right-radius: 4px;"
+            "  border-bottom-right-radius: 4px; }"
+        )
+
+        # QButtonGroup enforces mutual exclusivity (issue #69)
+        self._mode_group = QButtonGroup(self)
+        self._mode_group.setExclusive(True)
+        self._mode_group.addButton(self._rel_btn)
+        self._mode_group.addButton(self._abs_btn)
+
         self._rel_btn.clicked.connect(lambda: self._set_mode(True))
         self._abs_btn.clicked.connect(lambda: self._set_mode(False))
+
         toolbar.addWidget(self._rel_btn)
         toolbar.addWidget(self._abs_btn)
-        toolbar.addStretch()
+
+        # Spacer between toggle and action buttons
+        toolbar.addSpacing(12)
+
+        # -- Action buttons inlined into toolbar (issue #68) --
+        self._move_to_top_btn = QPushButton("Move to Top")
+        self._move_to_top_btn.clicked.connect(
+            lambda: self.action_triggered.emit(
+                "move_to_top", self._current_submod, None
+            )
+        )
+        toolbar.addWidget(self._move_to_top_btn)
+
+        self._set_exact_btn = QPushButton("Set Exact…")
+        self._set_exact_btn.clicked.connect(self._on_set_exact)
+        toolbar.addWidget(self._set_exact_btn)
+
+        self._move_rep_btn = QPushButton("Move Replacer to Top")
+        self._move_rep_btn.clicked.connect(
+            lambda: self.action_triggered.emit(
+                "move_to_top_replacer", self._current_submod, None
+            )
+        )
+        toolbar.addWidget(self._move_rep_btn)
+
+        self._move_mod_btn = QPushButton("Move Mod to Top")
+        self._move_mod_btn.clicked.connect(
+            lambda: self.action_triggered.emit(
+                "move_to_top_mod", self._current_submod, None
+            )
+        )
+        toolbar.addWidget(self._move_mod_btn)
+
+        # No trailing stretch — toolbar fills naturally; action btns are right
+        # of the spacer and the segmented toggle anchors to the left.
         layout.addWidget(toolbar_widget)
 
         # ---- Toast notification (issue #37, spec §7.4) ----
         self._toast = QLabel()
         self._toast.setContentsMargins(8, 4, 8, 4)
         self._toast.setStyleSheet(
-            "background: #1a3a1a; color: #4a9; padding: 4px 8px; border-radius: 4px;"
+            "background: #1a3a1a; color: #4a9;"
+            " padding: 4px 8px; border-radius: 4px;"
         )
         self._toast.setWordWrap(True)
         self._toast.hide()
@@ -237,9 +325,6 @@ class StacksPanel(QWidget):
         self._content_layout.setContentsMargins(4, 4, 4, 4)
         self._scroll.setWidget(self._content)
         layout.addWidget(self._scroll)
-
-        # ---- Action buttons ----
-        layout.addWidget(self._build_action_bar())
 
     # ------------------------------------------------------------------
     # Public API (preserved from original)
@@ -334,17 +419,13 @@ class StacksPanel(QWidget):
         """
         rank = next((i for i, c in enumerate(competitors) if c is selected), -1)
 
-        # Build status HTML
+        # Build status text (plain text — QPushButton does not render rich text)
         if rank == 0:
-            status = "<span style='color:#4a9'>you're #1</span>"
+            status = "you're #1"
         elif rank > 0 and competitors:
             delta = competitors[0].priority - selected.priority
             target = competitors[0].priority + 1
-            status = (
-                f"<span style='color:#e66'>"
-                f"losing by {delta} · set to {target:,} to win"
-                f"</span>"
-            )
+            status = f"losing by {delta:,} · set to {target:,} to win"
         else:
             status = ""
 
@@ -357,12 +438,10 @@ class StacksPanel(QWidget):
                 if c.priority == selected.priority and c is not selected
             ]
             if tied_with:
-                status += " <span style='color:#aa4'>⚠ TIED</span>"
+                status += " \u26a0 TIED"
 
-        header_html = (
-            f"<b>{anim}</b> · {len(competitors)} competitors · {status}"
-        )
-        section = _StackSection(header_html)
+        header_text = f"{anim} · {len(competitors)} competitors · {status}"
+        section = _StackSection(header_text)
 
         # Restore collapsed state (issue #35)
         if self._collapsed.get(anim, False):
@@ -375,7 +454,7 @@ class StacksPanel(QWidget):
         _anim = anim  # capture for closure
         _orig_toggle = section._toggle
 
-        def _patched_toggle(s=section, a=_anim, orig=_orig_toggle):
+        def _patched_toggle(checked=False, *, s=section, a=_anim, orig=_orig_toggle):
             orig()
             self._collapsed[a] = not s._expanded
 
@@ -389,7 +468,7 @@ class StacksPanel(QWidget):
 
             if self._relative_mode:
                 delta = comp.priority - competitors[0].priority if competitors else 0
-                val_text = f"+{delta}" if delta >= 0 else str(delta)
+                val_text = f"+{delta:,}" if delta >= 0 else f"{delta:,}"
             else:
                 val_text = f"{comp.priority:,}"
 
@@ -412,48 +491,8 @@ class StacksPanel(QWidget):
         return section
 
     # ------------------------------------------------------------------
-    # Action bar
+    # Set Exact dialog
     # ------------------------------------------------------------------
-
-    def _build_action_bar(self) -> QWidget:
-        """Build Move to Top / Set Exact / scope-aware action buttons.
-
-        Includes three Move to Top variants (submod, replacer, mod scope) per
-        spec §7.8 and issue #39.
-        """
-        bar = QWidget()
-        layout = QHBoxLayout(bar)
-        layout.setContentsMargins(4, 4, 4, 4)
-
-        self._move_to_top_btn = QPushButton("Move to Top")
-        self._move_to_top_btn.clicked.connect(
-            lambda: self.action_triggered.emit("move_to_top", self._current_submod, None)
-        )
-        layout.addWidget(self._move_to_top_btn)
-
-        self._set_exact_btn = QPushButton("Set Exact…")
-        self._set_exact_btn.clicked.connect(self._on_set_exact)
-        layout.addWidget(self._set_exact_btn)
-
-        # Scope-aware Move to Top variants (issue #39)
-        self._move_rep_btn = QPushButton("Move Replacer to Top")
-        self._move_rep_btn.clicked.connect(
-            lambda: self.action_triggered.emit(
-                "move_to_top_replacer", self._current_submod, None
-            )
-        )
-        layout.addWidget(self._move_rep_btn)
-
-        self._move_mod_btn = QPushButton("Move Mod to Top")
-        self._move_mod_btn.clicked.connect(
-            lambda: self.action_triggered.emit(
-                "move_to_top_mod", self._current_submod, None
-            )
-        )
-        layout.addWidget(self._move_mod_btn)
-
-        layout.addStretch()
-        return bar
 
     def _on_set_exact(self) -> None:
         from PySide6.QtWidgets import QInputDialog

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -28,7 +28,6 @@ from PySide6.QtWidgets import (
 
 from oar_priority_manager.core.models import SubMod
 
-
 # ---------------------------------------------------------------------------
 # Helper widget: collapsible stack section (issue #35)
 # ---------------------------------------------------------------------------

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -11,7 +11,7 @@ Issues addressed:
 
 from __future__ import annotations
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
@@ -214,6 +214,16 @@ class StacksPanel(QWidget):
         toolbar.addStretch()
         layout.addWidget(toolbar_widget)
 
+        # ---- Toast notification (issue #37, spec §7.4) ----
+        self._toast = QLabel()
+        self._toast.setContentsMargins(8, 4, 8, 4)
+        self._toast.setStyleSheet(
+            "background: #1a3a1a; color: #4a9; padding: 4px 8px; border-radius: 4px;"
+        )
+        self._toast.setWordWrap(True)
+        self._toast.hide()
+        layout.addWidget(self._toast)
+
         # ---- Header label ----
         self._header = QLabel("Select a submod to see priority stacks.")
         self._header.setContentsMargins(4, 0, 4, 4)
@@ -236,9 +246,30 @@ class StacksPanel(QWidget):
     # ------------------------------------------------------------------
 
     def update_selection(self, submod: SubMod | None) -> None:
-        """Update stacks display for the selected submod."""
+        """Update stacks display for the selected submod.
+
+        Disables action buttons when the submod has warnings (spec §9) or
+        when no submod is selected.
+        """
         self._current_submod = submod
+        # Disable action buttons when submod has warnings (spec §9)
+        has_warnings = submod.has_warnings if submod else True
+        enabled = not has_warnings and submod is not None
+        self._move_to_top_btn.setEnabled(enabled)
+        self._set_exact_btn.setEnabled(enabled)
+        self._move_rep_btn.setEnabled(enabled)
+        self._move_mod_btn.setEnabled(enabled)
         self._refresh_display()
+
+    def show_toast(self, message: str) -> None:
+        """Show a brief inline toast message that auto-dismisses after 5 seconds.
+
+        Args:
+            message: The text to display in the toast notification.
+        """
+        self._toast.setText(message)
+        self._toast.show()
+        QTimer.singleShot(5000, self._toast.hide)
 
     def set_relative_mode(self, relative: bool) -> None:
         """Switch between relative (delta) and absolute priority display."""
@@ -385,7 +416,11 @@ class StacksPanel(QWidget):
     # ------------------------------------------------------------------
 
     def _build_action_bar(self) -> QWidget:
-        """Build Move to Top / Set Exact action buttons."""
+        """Build Move to Top / Set Exact / scope-aware action buttons.
+
+        Includes three Move to Top variants (submod, replacer, mod scope) per
+        spec §7.8 and issue #39.
+        """
         bar = QWidget()
         layout = QHBoxLayout(bar)
         layout.setContentsMargins(4, 4, 4, 4)
@@ -399,6 +434,23 @@ class StacksPanel(QWidget):
         self._set_exact_btn = QPushButton("Set Exact…")
         self._set_exact_btn.clicked.connect(self._on_set_exact)
         layout.addWidget(self._set_exact_btn)
+
+        # Scope-aware Move to Top variants (issue #39)
+        self._move_rep_btn = QPushButton("Move Replacer to Top")
+        self._move_rep_btn.clicked.connect(
+            lambda: self.action_triggered.emit(
+                "move_to_top_replacer", self._current_submod, None
+            )
+        )
+        layout.addWidget(self._move_rep_btn)
+
+        self._move_mod_btn = QPushButton("Move Mod to Top")
+        self._move_mod_btn.clicked.connect(
+            lambda: self.action_triggered.emit(
+                "move_to_top_mod", self._current_submod, None
+            )
+        )
+        layout.addWidget(self._move_mod_btn)
 
         layout.addStretch()
         return bar

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -1,22 +1,172 @@
 """Priority stacks panel — shows animation competition for the selected submod.
 
 See spec §7.4. Center pane of the main layout.
+
+Issues addressed:
+  #33 — Relative/Absolute mode toolbar toggle
+  #34 — Rank badge colours (green for #1, grey for rest; red bg for losing rows)
+  #35 — Expand/collapse animation sections
+  #36 — Clickable competitor rows emitting competitor_focused signal
 """
 
 from __future__ import annotations
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
+    QFrame,
     QHBoxLayout,
     QLabel,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
 
 from oar_priority_manager.core.models import SubMod
 
+
+# ---------------------------------------------------------------------------
+# Helper widget: collapsible stack section (issue #35)
+# ---------------------------------------------------------------------------
+
+class _StackSection(QWidget):
+    """A single animation's priority stack — collapsible via header click."""
+
+    def __init__(self, header_html: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._expanded = True
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        # Flat button acts as a toggle header (issue #35)
+        self._header_btn = QPushButton()
+        self._header_btn.setFlat(True)
+        self._header_btn.setStyleSheet("text-align: left; padding: 2px 6px;")
+        self._header_btn.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._header_btn.clicked.connect(self._toggle)
+        outer.addWidget(self._header_btn)
+
+        # Separator line for visual grouping
+        line = QFrame()
+        line.setFrameShape(QFrame.Shape.HLine)
+        line.setFrameShadow(QFrame.Shadow.Sunken)
+        outer.addWidget(line)
+
+        # Collapsible content area
+        self._content = QWidget()
+        self._content_layout = QVBoxLayout(self._content)
+        self._content_layout.setContentsMargins(8, 2, 4, 4)
+        self._content_layout.setSpacing(1)
+        outer.addWidget(self._content)
+
+        # Store the base header text (without arrow prefix) so we can rebuild it
+        self._header_html = header_html
+        self._update_header()
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def add_row(self, row_widget: QWidget) -> None:
+        """Append a competitor row to the content area."""
+        self._content_layout.addWidget(row_widget)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _toggle(self) -> None:
+        self._expanded = not self._expanded
+        self._content.setVisible(self._expanded)
+        self._update_header()
+
+    def _update_header(self) -> None:
+        arrow = "▾" if self._expanded else "▸"
+        self._header_btn.setText(f"{arrow} {self._header_html}")
+
+
+# ---------------------------------------------------------------------------
+# Helper: styled competitor row (issues #34, #36)
+# ---------------------------------------------------------------------------
+
+def _make_competitor_row(
+    rank_num: int,
+    val_text: str,
+    comp: SubMod,
+    is_you: bool,
+    is_losing_row: bool,
+    relative_mode: bool,
+    on_click,
+) -> QWidget:
+    """Build a single clickable competitor row with rank badge + name columns.
+
+    Args:
+        rank_num: 1-based rank position.
+        val_text: Formatted priority value (delta or absolute).
+        comp: The competitor SubMod.
+        is_you: Whether this row represents the currently selected submod.
+        is_losing_row: True when this row is the winner that the selected
+            submod is losing to (used for red background tint).
+        relative_mode: Controls priority column width.
+        on_click: Callable invoked when the row is clicked.
+
+    Returns:
+        A QWidget containing the full row layout.
+    """
+    # Outer button so the whole row is clickable (issue #36)
+    btn = QPushButton()
+    btn.setFlat(True)
+
+    # Red background for the row we are losing to (issue #34 spec §7.4)
+    bg = "background: #4a2020;" if is_losing_row else ""
+    btn.setStyleSheet(
+        f"QPushButton {{ text-align: left; padding: 1px 2px; {bg} }}"
+        "QPushButton:hover { background: rgba(255,255,255,0.05); }"
+    )
+
+    row_layout = QHBoxLayout(btn)
+    row_layout.setContentsMargins(2, 1, 2, 1)
+    row_layout.setSpacing(4)
+
+    # -- Rank badge (issue #34) --
+    badge_color = "#4a9" if rank_num == 1 else "#888"
+    badge = QLabel(f"<span style='color:{badge_color}'><b>#{rank_num}</b></span>")
+    badge.setTextFormat(Qt.TextFormat.RichText)
+    badge.setFixedWidth(36)
+    badge.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+    row_layout.addWidget(badge)
+
+    # -- Priority value column (issue #34 — fixed width per spec) --
+    prio_width = 80 if relative_mode else 140
+    prio_lbl = QLabel(val_text)
+    prio_lbl.setFixedWidth(prio_width)
+    prio_lbl.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+    prio_lbl.setStyleSheet("color: #aaa;")
+    row_layout.addWidget(prio_lbl)
+
+    # -- Owner / name --
+    name_text = f"{comp.mo2_mod} / {comp.name}"
+    if is_you:
+        name_text = f"<b>{name_text}  (you)</b>"
+    name_lbl = QLabel(name_text)
+    name_lbl.setTextFormat(Qt.TextFormat.RichText)
+    name_lbl.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+    row_layout.addWidget(name_lbl)
+
+    # Wire click signal (issue #36)
+    btn.clicked.connect(on_click)
+
+    return btn
+
+
+# ---------------------------------------------------------------------------
+# Main panel
+# ---------------------------------------------------------------------------
 
 class StacksPanel(QWidget):
     """Center pane: priority stacks for the selected submod's animations."""
@@ -35,32 +185,90 @@ class StacksPanel(QWidget):
         self._conflict_map = conflict_map
         self._current_submod: SubMod | None = None
         self._relative_mode = True
+        self._collapsed: dict[str, bool] = {}  # anim -> collapsed state (issue #35)
         self._setup_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
 
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
+        # ---- Toolbar: Relative / Absolute toggle (issue #33) ----
+        toolbar_widget = QWidget()
+        toolbar = QHBoxLayout(toolbar_widget)
+        toolbar.setContentsMargins(4, 4, 4, 2)
+
+        self._rel_btn = QPushButton("Relative")
+        self._abs_btn = QPushButton("Absolute")
+        self._rel_btn.setCheckable(True)
+        self._abs_btn.setCheckable(True)
+        self._rel_btn.setChecked(True)   # default: relative mode
+        self._abs_btn.setChecked(False)
+        self._rel_btn.clicked.connect(lambda: self._set_mode(True))
+        self._abs_btn.clicked.connect(lambda: self._set_mode(False))
+        toolbar.addWidget(self._rel_btn)
+        toolbar.addWidget(self._abs_btn)
+        toolbar.addStretch()
+        layout.addWidget(toolbar_widget)
+
+        # ---- Header label ----
         self._header = QLabel("Select a submod to see priority stacks.")
+        self._header.setContentsMargins(4, 0, 4, 4)
         layout.addWidget(self._header)
 
+        # ---- Scroll area for stack sections ----
         self._scroll = QScrollArea()
         self._scroll.setWidgetResizable(True)
         self._content = QWidget()
         self._content_layout = QVBoxLayout(self._content)
+        self._content_layout.setContentsMargins(4, 4, 4, 4)
         self._scroll.setWidget(self._content)
         layout.addWidget(self._scroll)
 
-        # Action buttons (spec §7.4)
+        # ---- Action buttons ----
         layout.addWidget(self._build_action_bar())
+
+    # ------------------------------------------------------------------
+    # Public API (preserved from original)
+    # ------------------------------------------------------------------
 
     def update_selection(self, submod: SubMod | None) -> None:
         """Update stacks display for the selected submod."""
         self._current_submod = submod
         self._refresh_display()
 
+    def set_relative_mode(self, relative: bool) -> None:
+        """Switch between relative (delta) and absolute priority display."""
+        self._relative_mode = relative
+        self._rel_btn.setChecked(relative)
+        self._abs_btn.setChecked(not relative)
+        self._refresh_display()
+
+    def refresh(self, conflict_map: dict[str, list[SubMod]]) -> None:
+        """Refresh display using updated conflict map."""
+        self._conflict_map = conflict_map
+        self._refresh_display()
+
+    # ------------------------------------------------------------------
+    # Internal: mode toggle
+    # ------------------------------------------------------------------
+
+    def _set_mode(self, relative: bool) -> None:
+        """Called by toolbar buttons — update state and refresh."""
+        self._relative_mode = relative
+        self._rel_btn.setChecked(relative)
+        self._abs_btn.setChecked(not relative)
+        self._refresh_display()
+
+    # ------------------------------------------------------------------
+    # Internal: display refresh
+    # ------------------------------------------------------------------
+
     def _refresh_display(self) -> None:
-        # Clear existing content
+        # Clear existing content widgets
         while self._content_layout.count():
             child = self._content_layout.takeAt(0)
             if child.widget():
@@ -82,24 +290,34 @@ class StacksPanel(QWidget):
 
     def _build_stack_section(
         self, anim: str, competitors: list[SubMod], selected: SubMod,
-    ) -> QWidget:
-        """Build one expandable stack section for an animation."""
-        section = QWidget()
-        layout = QVBoxLayout(section)
-        layout.setContentsMargins(4, 4, 4, 4)
+    ) -> _StackSection:
+        """Build one collapsible stack section for a single animation.
 
-        # Header
+        Args:
+            anim: Animation filename (e.g. ``mt_idle.hkx``).
+            competitors: Ordered list of competing SubMods for this animation.
+            selected: The currently selected SubMod.
+
+        Returns:
+            A ``_StackSection`` widget ready for insertion into the scroll area.
+        """
         rank = next((i for i, c in enumerate(competitors) if c is selected), -1)
+
+        # Build status HTML
         if rank == 0:
             status = "<span style='color:#4a9'>you're #1</span>"
         elif rank > 0 and competitors:
             delta = competitors[0].priority - selected.priority
             target = competitors[0].priority + 1
-            status = f"<span style='color:#e66'>losing by {delta} · set to {target:,} to win</span>"
+            status = (
+                f"<span style='color:#e66'>"
+                f"losing by {delta} · set to {target:,} to win"
+                f"</span>"
+            )
         else:
             status = ""
 
-        # Check for ties
+        # Tie detection
         priorities = [c.priority for c in competitors]
         has_ties = len(priorities) != len(set(priorities))
         if has_ties and rank >= 0:
@@ -110,26 +328,61 @@ class StacksPanel(QWidget):
             if tied_with:
                 status += " <span style='color:#aa4'>⚠ TIED</span>"
 
-        header = QLabel(f"▾ <b>{anim}</b> · {len(competitors)} competitors · {status}")
-        header.setTextFormat(Qt.TextFormat.RichText)
-        layout.addWidget(header)
+        header_html = (
+            f"<b>{anim}</b> · {len(competitors)} competitors · {status}"
+        )
+        section = _StackSection(header_html)
+
+        # Restore collapsed state (issue #35)
+        if self._collapsed.get(anim, False):
+            # Simulate collapse without extra toggle machinery
+            section._expanded = False
+            section._content.setVisible(False)
+            section._update_header()
+
+        # Track collapses: wire into header button post-construction
+        _anim = anim  # capture for closure
+        _orig_toggle = section._toggle
+
+        def _patched_toggle(s=section, a=_anim, orig=_orig_toggle):
+            orig()
+            self._collapsed[a] = not s._expanded
+
+        section._header_btn.clicked.disconnect()
+        section._header_btn.clicked.connect(_patched_toggle)
 
         # Competitor rows
         for i, comp in enumerate(competitors):
             is_you = comp is selected
             rank_num = i + 1
+
             if self._relative_mode:
                 delta = comp.priority - competitors[0].priority if competitors else 0
                 val_text = f"+{delta}" if delta >= 0 else str(delta)
             else:
                 val_text = f"{comp.priority:,}"
 
-            you_marker = " <b>(you)</b>" if is_you else ""
-            row_text = f"  #{rank_num} {val_text}  {comp.mo2_mod} / {comp.name}{you_marker}"
-            row = QLabel(row_text)
-            layout.addWidget(row)
+            # "Losing row" = the winning competitor when we are not #1 (issue #34)
+            is_losing_row = (not is_you) and (rank > 0) and (rank_num == 1)
+
+            # Capture comp for the click closure (issue #36)
+            _comp = comp
+            row = _make_competitor_row(
+                rank_num=rank_num,
+                val_text=val_text,
+                comp=comp,
+                is_you=is_you,
+                is_losing_row=is_losing_row,
+                relative_mode=self._relative_mode,
+                on_click=lambda checked=False, c=_comp: self.competitor_focused.emit(c),
+            )
+            section.add_row(row)
 
         return section
+
+    # ------------------------------------------------------------------
+    # Action bar
+    # ------------------------------------------------------------------
 
     def _build_action_bar(self) -> QWidget:
         """Build Move to Top / Set Exact action buttons."""
@@ -162,13 +415,3 @@ class StacksPanel(QWidget):
         )
         if ok:
             self.action_triggered.emit("set_exact", self._current_submod, value)
-
-    def set_relative_mode(self, relative: bool) -> None:
-        """Switch between relative (delta) and absolute priority display."""
-        self._relative_mode = relative
-        self._refresh_display()
-
-    def refresh(self, conflict_map: dict[str, list[SubMod]]) -> None:
-        """Refresh display using updated conflict map."""
-        self._conflict_map = conflict_map
-        self._refresh_display()

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -125,8 +125,13 @@ def _make_competitor_row(
     btn = QPushButton()
     btn.setFlat(True)
 
-    # Red background for the row we are losing to (issue #34 spec §7.4)
-    bg = "background: #4a2020;" if is_losing_row else ""
+    # Red background for losing row; blue tint for the "you" row (issues #34, #72)
+    if is_losing_row:
+        bg = "background: #4a2020;"
+    elif is_you:
+        bg = "background: #1a2a3a;"
+    else:
+        bg = ""
     btn.setStyleSheet(
         f"QPushButton {{ text-align: left; padding: 1px 2px; {bg} }}"
         "QPushButton:hover { background: rgba(255,255,255,0.05); }"

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -397,6 +397,22 @@ class StacksPanel(QWidget):
 
         self._header.setText(f"<b>Priority Stacks</b> · <code>{sm.name}</code>")
 
+        # Config-only submods have no animations and don't compete in any stack.
+        # Show an explanatory message instead of an empty scroll area so the
+        # user doesn't assume something is broken.
+        if sm.is_config_only:
+            info = QLabel(
+                "This submod is a config-only toggle. It has no animations and does"
+                " not compete in priority stacks. Other submods may reference it via"
+                " IsReplacerEnabled conditions."
+            )
+            info.setWordWrap(True)
+            info.setTextFormat(Qt.TextFormat.PlainText)
+            info.setStyleSheet("color: #6af; padding: 8px;")
+            self._content_layout.addWidget(info)
+            self._content_layout.addStretch()
+            return
+
         for anim in sm.animations:
             competitors = self._conflict_map.get(anim, [])
             section = self._build_stack_section(anim, competitors, sm)

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -6,7 +6,8 @@ See spec §7.3. Full implementation in Task 14.
 from __future__ import annotations
 
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from oar_priority_manager.core.models import SubMod
 from oar_priority_manager.ui.tree_model import TreeNode, build_tree
@@ -15,8 +16,8 @@ from oar_priority_manager.ui.tree_model import TreeNode, build_tree
 class TreePanel(QWidget):
     """Tree panel: Mod → Replacer → Submod hierarchy with status icons."""
 
-    # Emitted when a tree node is selected: (node_type, submod_or_None)
-    selection_changed = Signal(object, object)
+    # Emitted when a tree node is selected: the TreeNode itself (or None)
+    selection_changed = Signal(object)
 
     def __init__(self, submods: list[SubMod], parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -68,11 +69,78 @@ class TreePanel(QWidget):
         self, current: QTreeWidgetItem | None, _previous: QTreeWidgetItem | None
     ) -> None:
         if current is None:
-            self.selection_changed.emit(None, None)
+            self.selection_changed.emit(None)
             return
         node = self._item_map.get(id(current))
         if node:
-            self.selection_changed.emit(node.node_type, node.submod)
+            self.selection_changed.emit(node)
+
+    @property
+    def tree_root(self) -> TreeNode:
+        """Return the root TreeNode for use by SearchIndex."""
+        return self._root
+
+    def filter_tree(self, matching_nodes: set[int] | None) -> None:
+        """Filter the tree to highlight matching nodes.
+
+        Args:
+            matching_nodes: Set of ``id()`` values of matching TreeNodes,
+                or None to clear any active filter and show all items normally.
+        """
+        normal_color = QApplication.palette().windowText().color()
+        dim_color = QColor(160, 160, 160)
+
+        if matching_nodes is None:
+            # Clear filter — restore all items to the default palette color.
+            self._set_all_colors(normal_color)
+            return
+
+        # Build the full "visible" set: matching nodes plus all their ancestors
+        # and descendants so the tree context is preserved.
+        visible: set[int] = set()
+
+        def _add_ancestors(node: TreeNode) -> None:
+            if node.parent is not None:
+                visible.add(id(node.parent))
+                _add_ancestors(node.parent)
+
+        def _add_descendants(node: TreeNode) -> None:
+            for child in node.children:
+                visible.add(id(child))
+                _add_descendants(child)
+
+        for node in (n for item_id, n in self._item_map.items() if id(n) in matching_nodes):
+            visible.add(id(node))
+            _add_ancestors(node)
+            _add_descendants(node)
+
+        # Walk every QTreeWidgetItem and apply color + expand parents.
+        def _apply(item: QTreeWidgetItem) -> None:
+            node = self._item_map.get(id(item))
+            if node is not None and id(node) in visible:
+                item.setForeground(0, normal_color)
+                # Ensure parents of matching items are expanded for visibility.
+                parent = item.parent()
+                if parent is not None:
+                    parent.setExpanded(True)
+            else:
+                item.setForeground(0, dim_color)
+            for i in range(item.childCount()):
+                _apply(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            _apply(self._tree.topLevelItem(i))
+
+    def _set_all_colors(self, color: QColor) -> None:
+        """Recursively restore every item's foreground to *color*."""
+
+        def _apply(item: QTreeWidgetItem) -> None:
+            item.setForeground(0, color)
+            for i in range(item.childCount()):
+                _apply(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            _apply(self._tree.topLevelItem(i))
 
     def refresh(self, submods: list[SubMod]) -> None:
         """Refresh tree from new submod data."""

--- a/tests/unit/test_anim_scanner.py
+++ b/tests/unit/test_anim_scanner.py
@@ -15,6 +15,8 @@ from oar_priority_manager.core.anim_scanner import (
 )
 from oar_priority_manager.core.models import OverrideSource, SubMod
 
+_OAR_PATH = "data\\meshes\\actors\\character\\animations\\OAR\\mod"
+
 
 def _make_submod(
     name: str = "sub1",
@@ -109,7 +111,7 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_sneakmtidle",
+                    "path": f"{_OAR_PATH}\\_variants_sneakmtidle",
                     "variants": [
                         {"filename": "replacement1.hkx", "weight": 0.5},
                         {"filename": "replacement2.hkx", "disabled": True},
@@ -142,12 +144,12 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_mt_idle",
+                    "path": f"{_OAR_PATH}\\_variants_mt_idle",
                     "variants": [{"filename": "replacement.hkx"}],
                 },
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_config_only",
+                    "path": f"{_OAR_PATH}\\_variants_config_only",
                     "variants": [{"filename": "replacement.hkx"}],
                 },
             ],
@@ -175,12 +177,12 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_RELAX10",
+                    "path": f"{_OAR_PATH}\\_variants_RELAX10",
                     "variants": [{"filename": "replacement.hkx"}],
                 },
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_MT_Idle",
+                    "path": f"{_OAR_PATH}\\_variants_MT_Idle",
                     "variants": [{"filename": "replacement.hkx"}],
                 },
             ],
@@ -233,22 +235,22 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_relax10",
+                    "path": f"{_OAR_PATH}\\_variants_relax10",
                     "variants": [{"filename": "male_replacement.hkx"}],
                 },
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_unique_male",
+                    "path": f"{_OAR_PATH}\\_variants_unique_male",
                     "variants": [{"filename": "replacement.hkx"}],
                 },
                 {
                     "projectName": "DefaultFemale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_relax10",
+                    "path": f"{_OAR_PATH}\\_variants_relax10",
                     "variants": [{"filename": "female_replacement.hkx"}],
                 },
                 {
                     "projectName": "DefaultFemale",
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_unique_female",
+                    "path": f"{_OAR_PATH}\\_variants_unique_female",
                     "variants": [{"filename": "replacement.hkx"}],
                 },
             ],
@@ -398,7 +400,7 @@ class TestExtractReplacedAnimations:
         raw = {
             "replacementAnimDatas": [
                 {
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_sneakmtidle",
+                    "path": f"{_OAR_PATH}\\_variants_sneakmtidle",
                     "variants": [{"filename": "replacement.hkx"}],
                 }
             ]
@@ -410,7 +412,7 @@ class TestExtractReplacedAnimations:
         raw = {
             "replacementAnimDatas": [
                 {
-                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_1hm_idle",
+                    "path": f"{_OAR_PATH}\\_variants_1hm_idle",
                     "variants": [],
                 }
             ]

--- a/tests/unit/test_anim_scanner.py
+++ b/tests/unit/test_anim_scanner.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.anim_scanner import (
+    _extract_replacement_anim_data_filenames,
+    build_conflict_map,
+    scan_animations,
+)
 from oar_priority_manager.core.models import OverrideSource, SubMod
 
 
@@ -89,6 +93,183 @@ class TestScanAnimations:
         sm = _make_submod(config_path=submod_dir / "config.json")
         scan_animations([sm])
         assert sm.animations == []
+
+    def test_discovers_replacement_anim_data_variants(
+        self, tmp_path: Path
+    ):
+        """Animations in replacementAnimDatas are discovered even with no .hkx
+        files on the filesystem."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+
+        raw = {
+            "name": "sub1",
+            "priority": 100,
+            "replacementAnimDatas": [
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\actors\\character",
+                    "variants": [
+                        {"filename": "relax10.hkx", "weight": 0.5},
+                        {"filename": "hmmm.hkx", "disabled": True},
+                    ],
+                }
+            ],
+        }
+        sm = _make_submod(
+            config_path=submod_dir / "config.json", raw_dict=raw
+        )
+        scan_animations([sm])
+        assert sm.animations == ["hmmm.hkx", "relax10.hkx"]
+
+    def test_replacement_anim_data_merged_with_filesystem(
+        self, tmp_path: Path
+    ):
+        """Filesystem .hkx files and replacementAnimDatas filenames are merged
+        and deduplicated."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        # relax10.hkx exists both on disk and in config — should appear once.
+        (submod_dir / "relax10.hkx").touch()
+        (submod_dir / "mt_idle.hkx").touch()
+
+        raw = {
+            "name": "sub1",
+            "priority": 100,
+            "replacementAnimDatas": [
+                {
+                    "projectName": "DefaultMale",
+                    "variants": [
+                        {"filename": "relax10.hkx"},
+                        {"filename": "config_only.hkx"},
+                    ],
+                }
+            ],
+        }
+        sm = _make_submod(
+            config_path=submod_dir / "config.json", raw_dict=raw
+        )
+        scan_animations([sm])
+        assert sm.animations == [
+            "config_only.hkx",
+            "mt_idle.hkx",
+            "relax10.hkx",
+        ]
+
+    def test_replacement_anim_data_case_insensitive(
+        self, tmp_path: Path
+    ):
+        """Variant filenames from config are normalised to lowercase."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+
+        raw = {
+            "name": "sub1",
+            "priority": 100,
+            "replacementAnimDatas": [
+                {
+                    "projectName": "DefaultMale",
+                    "variants": [
+                        {"filename": "RELAX10.HKX"},
+                        {"filename": "MT_Idle.hkx"},
+                    ],
+                }
+            ],
+        }
+        sm = _make_submod(
+            config_path=submod_dir / "config.json", raw_dict=raw
+        )
+        scan_animations([sm])
+        assert sm.animations == ["mt_idle.hkx", "relax10.hkx"]
+
+    def test_replacement_anim_data_malformed_graceful(
+        self, tmp_path: Path
+    ):
+        """Missing variants key or missing filename key does not raise; result
+        is empty (or partial for valid entries)."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+
+        raw = {
+            "name": "sub1",
+            "priority": 100,
+            "replacementAnimDatas": [
+                # Entry with no 'variants' key
+                {"projectName": "DefaultMale"},
+                # Entry with variants but a variant missing 'filename'
+                {
+                    "projectName": "DefaultFemale",
+                    "variants": [
+                        {"weight": 0.5},  # no filename
+                        None,             # not a dict
+                    ],
+                },
+                # Completely non-dict entry
+                "not_a_dict",
+            ],
+        }
+        sm = _make_submod(
+            config_path=submod_dir / "config.json", raw_dict=raw
+        )
+        # Should not raise and should produce no animations.
+        scan_animations([sm])
+        assert sm.animations == []
+
+    def test_replacement_anim_data_multiple_projects_deduplicated(
+        self, tmp_path: Path
+    ):
+        """Same filename appearing in both DefaultMale and DefaultFemale
+        entries is deduplicated to a single entry."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+
+        raw = {
+            "name": "sub1",
+            "priority": 100,
+            "replacementAnimDatas": [
+                {
+                    "projectName": "DefaultMale",
+                    "variants": [
+                        {"filename": "relax10.hkx"},
+                        {"filename": "unique_male.hkx"},
+                    ],
+                },
+                {
+                    "projectName": "DefaultFemale",
+                    "variants": [
+                        {"filename": "relax10.hkx"},
+                        {"filename": "unique_female.hkx"},
+                    ],
+                },
+            ],
+        }
+        sm = _make_submod(
+            config_path=submod_dir / "config.json", raw_dict=raw
+        )
+        scan_animations([sm])
+        assert sm.animations == [
+            "relax10.hkx",
+            "unique_female.hkx",
+            "unique_male.hkx",
+        ]
+
+
+class TestExtractReplacementAnimDataFilenames:
+    """Unit tests for the _extract_replacement_anim_data_filenames helper."""
+
+    def test_empty_dict_returns_empty_set(self):
+        assert _extract_replacement_anim_data_filenames({}) == set()
+
+    def test_key_absent_returns_empty_set(self):
+        assert _extract_replacement_anim_data_filenames(
+            {"name": "sub1"}
+        ) == set()
+
+    def test_non_list_value_returns_empty_set(self):
+        """replacementAnimDatas that is not a list is ignored gracefully."""
+        assert _extract_replacement_anim_data_filenames(
+            {"replacementAnimDatas": "oops"}
+        ) == set()
 
 
 class TestBuildConflictMap:

--- a/tests/unit/test_anim_scanner.py
+++ b/tests/unit/test_anim_scanner.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from oar_priority_manager.core.anim_scanner import (
+    _discover_variant_folders,
     _extract_replaced_animations,
     build_conflict_map,
     scan_animations,
@@ -261,6 +262,120 @@ class TestScanAnimations:
             "unique_female.hkx",
             "unique_male.hkx",
         ]
+
+    def test_discovers_implicit_variant_folders(self, tmp_path: Path):
+        """Subdirectories starting with _variants_ are discovered without any
+        replacementAnimDatas entry in config — the stripped, lowercased name
+        plus .hkx is added to the animations list."""
+        submod_dir = tmp_path / "relax_sneak_melee_right_dagger"
+        submod_dir.mkdir()
+        (submod_dir / "_variants_sneakmtidle").mkdir()
+        (submod_dir / "_variants_1hm_idle").mkdir()
+
+        sm = _make_submod(config_path=submod_dir / "config.json")
+        scan_animations([sm])
+        assert sorted(sm.animations) == ["1hm_idle.hkx", "sneakmtidle.hkx"]
+
+    def test_variant_folders_merged_with_replacement_anim_data(
+        self, tmp_path: Path
+    ):
+        """When a submod has both implicit _variants_* folders AND
+        replacementAnimDatas entries, the results are merged and deduplicated
+        via set union — an animation found via both paths appears only once."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        # sneakmtidle appears via both routes; config_only appears only in config.
+        (submod_dir / "_variants_sneakmtidle").mkdir()
+        (submod_dir / "_variants_filesystem_only").mkdir()
+
+        raw = {
+            "name": "sub1",
+            "priority": 100,
+            "replacementAnimDatas": [
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\OAR\\mod\\_variants_sneakmtidle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\OAR\\mod\\_variants_config_only",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+            ],
+        }
+        sm = _make_submod(config_path=submod_dir / "config.json", raw_dict=raw)
+        scan_animations([sm])
+        assert sm.animations == [
+            "config_only.hkx",
+            "filesystem_only.hkx",
+            "sneakmtidle.hkx",
+        ]
+
+    def test_variant_folders_case_insensitive(self, tmp_path: Path):
+        """Folder names like _variants_Tor_1HMPose are lowercased to
+        tor_1hmpose.hkx."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        (submod_dir / "_variants_Tor_1HMPose").mkdir()
+
+        sm = _make_submod(config_path=submod_dir / "config.json")
+        scan_animations([sm])
+        assert sm.animations == ["tor_1hmpose.hkx"]
+
+    def test_non_variant_folders_ignored(self, tmp_path: Path):
+        """Subdirectories that do NOT start with _variants_ are not included."""
+        submod_dir = tmp_path / "sub1"
+        submod_dir.mkdir()
+        (submod_dir / "some_other_folder").mkdir()
+        (submod_dir / "meshes").mkdir()
+        (submod_dir / "_not_variants_idle").mkdir()
+        # Only this one should be discovered.
+        (submod_dir / "_variants_sneakmtidle").mkdir()
+
+        sm = _make_submod(config_path=submod_dir / "config.json")
+        scan_animations([sm])
+        assert sm.animations == ["sneakmtidle.hkx"]
+
+
+class TestDiscoverVariantFolders:
+    """Unit tests for the _discover_variant_folders helper."""
+
+    def test_returns_empty_set_for_nonexistent_dir(self, tmp_path: Path):
+        """OSError from a missing directory is caught; empty set returned."""
+        result = _discover_variant_folders(tmp_path / "does_not_exist")
+        assert result == set()
+
+    def test_empty_dir_returns_empty_set(self, tmp_path: Path):
+        assert _discover_variant_folders(tmp_path) == set()
+
+    def test_strips_prefix_and_appends_hkx(self, tmp_path: Path):
+        (tmp_path / "_variants_sneakmtidle").mkdir()
+        assert _discover_variant_folders(tmp_path) == {"sneakmtidle.hkx"}
+
+    def test_lowercases_name(self, tmp_path: Path):
+        (tmp_path / "_variants_MT_Idle").mkdir()
+        assert _discover_variant_folders(tmp_path) == {"mt_idle.hkx"}
+
+    def test_ignores_files_not_dirs(self, tmp_path: Path):
+        """A file named _variants_foo is not a variant folder and is ignored."""
+        (tmp_path / "_variants_sneakmtidle").touch()
+        assert _discover_variant_folders(tmp_path) == set()
+
+    def test_ignores_non_matching_dirs(self, tmp_path: Path):
+        (tmp_path / "meshes").mkdir()
+        (tmp_path / "_not_variants_idle").mkdir()
+        assert _discover_variant_folders(tmp_path) == set()
+
+    def test_multiple_variant_folders(self, tmp_path: Path):
+        (tmp_path / "_variants_sneakmtidle").mkdir()
+        (tmp_path / "_variants_1hm_idle").mkdir()
+        (tmp_path / "_variants_Tor_1HMPose").mkdir()
+        assert _discover_variant_folders(tmp_path) == {
+            "sneakmtidle.hkx",
+            "1hm_idle.hkx",
+            "tor_1hmpose.hkx",
+        }
 
 
 class TestExtractReplacedAnimations:

--- a/tests/unit/test_anim_scanner.py
+++ b/tests/unit/test_anim_scanner.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from oar_priority_manager.core.anim_scanner import (
-    _extract_replacement_anim_data_filenames,
+    _extract_replaced_animations,
     build_conflict_map,
     scan_animations,
 )
@@ -94,11 +94,11 @@ class TestScanAnimations:
         scan_animations([sm])
         assert sm.animations == []
 
-    def test_discovers_replacement_anim_data_variants(
+    def test_discovers_replacement_anim_data_from_path(
         self, tmp_path: Path
     ):
-        """Animations in replacementAnimDatas are discovered even with no .hkx
-        files on the filesystem."""
+        """Animations in replacementAnimDatas are discovered from the path field
+        even with no .hkx files on the filesystem."""
         submod_dir = tmp_path / "sub1"
         submod_dir.mkdir()
 
@@ -108,10 +108,10 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "path": "data\\meshes\\actors\\character",
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_sneakmtidle",
                     "variants": [
-                        {"filename": "relax10.hkx", "weight": 0.5},
-                        {"filename": "hmmm.hkx", "disabled": True},
+                        {"filename": "replacement1.hkx", "weight": 0.5},
+                        {"filename": "replacement2.hkx", "disabled": True},
                     ],
                 }
             ],
@@ -120,18 +120,20 @@ class TestScanAnimations:
             config_path=submod_dir / "config.json", raw_dict=raw
         )
         scan_animations([sm])
-        assert sm.animations == ["hmmm.hkx", "relax10.hkx"]
+        # Derived from path last segment "_variants_sneakmtidle" → sneakmtidle.hkx
+        assert sm.animations == ["sneakmtidle.hkx"]
 
     def test_replacement_anim_data_merged_with_filesystem(
         self, tmp_path: Path
     ):
-        """Filesystem .hkx files and replacementAnimDatas filenames are merged
-        and deduplicated."""
+        """Filesystem .hkx files and replacementAnimDatas path-derived names
+        are merged and deduplicated."""
         submod_dir = tmp_path / "sub1"
         submod_dir.mkdir()
-        # relax10.hkx exists both on disk and in config — should appear once.
-        (submod_dir / "relax10.hkx").touch()
+        # mt_idle.hkx exists both on disk and is also the target of a
+        # replacementAnimDatas entry — should appear once.
         (submod_dir / "mt_idle.hkx").touch()
+        (submod_dir / "mt_walkforward.hkx").touch()
 
         raw = {
             "name": "sub1",
@@ -139,11 +141,14 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "variants": [
-                        {"filename": "relax10.hkx"},
-                        {"filename": "config_only.hkx"},
-                    ],
-                }
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_mt_idle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_config_only",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
             ],
         }
         sm = _make_submod(
@@ -153,13 +158,13 @@ class TestScanAnimations:
         assert sm.animations == [
             "config_only.hkx",
             "mt_idle.hkx",
-            "relax10.hkx",
+            "mt_walkforward.hkx",
         ]
 
     def test_replacement_anim_data_case_insensitive(
         self, tmp_path: Path
     ):
-        """Variant filenames from config are normalised to lowercase."""
+        """Vanilla animation names derived from path are normalised to lowercase."""
         submod_dir = tmp_path / "sub1"
         submod_dir.mkdir()
 
@@ -169,11 +174,14 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "variants": [
-                        {"filename": "RELAX10.HKX"},
-                        {"filename": "MT_Idle.hkx"},
-                    ],
-                }
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_RELAX10",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_MT_Idle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
             ],
         }
         sm = _make_submod(
@@ -185,8 +193,7 @@ class TestScanAnimations:
     def test_replacement_anim_data_malformed_graceful(
         self, tmp_path: Path
     ):
-        """Missing variants key or missing filename key does not raise; result
-        is empty (or partial for valid entries)."""
+        """Missing or invalid path values do not raise; result is empty."""
         submod_dir = tmp_path / "sub1"
         submod_dir.mkdir()
 
@@ -194,16 +201,12 @@ class TestScanAnimations:
             "name": "sub1",
             "priority": 100,
             "replacementAnimDatas": [
-                # Entry with no 'variants' key
-                {"projectName": "DefaultMale"},
-                # Entry with variants but a variant missing 'filename'
-                {
-                    "projectName": "DefaultFemale",
-                    "variants": [
-                        {"weight": 0.5},  # no filename
-                        None,             # not a dict
-                    ],
-                },
+                # Entry with no 'path' key
+                {"projectName": "DefaultMale", "variants": []},
+                # Entry with a non-string path
+                {"projectName": "DefaultFemale", "path": 42},
+                # Entry with an empty string path
+                {"projectName": "DefaultFemale", "path": ""},
                 # Completely non-dict entry
                 "not_a_dict",
             ],
@@ -218,8 +221,8 @@ class TestScanAnimations:
     def test_replacement_anim_data_multiple_projects_deduplicated(
         self, tmp_path: Path
     ):
-        """Same filename appearing in both DefaultMale and DefaultFemale
-        entries is deduplicated to a single entry."""
+        """Same vanilla animation slot targeted by both DefaultMale and
+        DefaultFemale entries is deduplicated to a single entry."""
         submod_dir = tmp_path / "sub1"
         submod_dir.mkdir()
 
@@ -229,17 +232,23 @@ class TestScanAnimations:
             "replacementAnimDatas": [
                 {
                     "projectName": "DefaultMale",
-                    "variants": [
-                        {"filename": "relax10.hkx"},
-                        {"filename": "unique_male.hkx"},
-                    ],
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_relax10",
+                    "variants": [{"filename": "male_replacement.hkx"}],
+                },
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_unique_male",
+                    "variants": [{"filename": "replacement.hkx"}],
                 },
                 {
                     "projectName": "DefaultFemale",
-                    "variants": [
-                        {"filename": "relax10.hkx"},
-                        {"filename": "unique_female.hkx"},
-                    ],
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_relax10",
+                    "variants": [{"filename": "female_replacement.hkx"}],
+                },
+                {
+                    "projectName": "DefaultFemale",
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_unique_female",
+                    "variants": [{"filename": "replacement.hkx"}],
                 },
             ],
         }
@@ -254,22 +263,139 @@ class TestScanAnimations:
         ]
 
 
-class TestExtractReplacementAnimDataFilenames:
-    """Unit tests for the _extract_replacement_anim_data_filenames helper."""
+class TestExtractReplacedAnimations:
+    """Unit tests for the _extract_replaced_animations helper."""
 
     def test_empty_dict_returns_empty_set(self):
-        assert _extract_replacement_anim_data_filenames({}) == set()
+        assert _extract_replaced_animations({}) == set()
 
     def test_key_absent_returns_empty_set(self):
-        assert _extract_replacement_anim_data_filenames(
-            {"name": "sub1"}
-        ) == set()
+        assert _extract_replaced_animations({"name": "sub1"}) == set()
 
     def test_non_list_value_returns_empty_set(self):
         """replacementAnimDatas that is not a list is ignored gracefully."""
-        assert _extract_replacement_anim_data_filenames(
+        assert _extract_replaced_animations(
             {"replacementAnimDatas": "oops"}
         ) == set()
+
+    def test_extracts_name_from_variants_prefix(self):
+        """Last path segment starting with _variants_ yields the stripped name."""
+        raw = {
+            "replacementAnimDatas": [
+                {
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_sneakmtidle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                }
+            ]
+        }
+        assert _extract_replaced_animations(raw) == {"sneakmtidle.hkx"}
+
+    def test_appends_hkx_extension(self):
+        """Derived name without .hkx gets the extension appended."""
+        raw = {
+            "replacementAnimDatas": [
+                {
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\_variants_1hm_idle",
+                    "variants": [],
+                }
+            ]
+        }
+        assert _extract_replaced_animations(raw) == {"1hm_idle.hkx"}
+
+    def test_no_variants_prefix_uses_segment_as_is(self):
+        """Last path segment without _variants_ prefix is used directly."""
+        raw = {
+            "replacementAnimDatas": [
+                {
+                    "path": "data\\meshes\\actors\\character\\animations\\OAR\\mod\\mt_idle",
+                    "variants": [],
+                }
+            ]
+        }
+        assert _extract_replaced_animations(raw) == {"mt_idle.hkx"}
+
+    def test_multiple_entries_one_animation_per_entry(self):
+        """Each entry contributes exactly one animation regardless of how many
+        variant filenames it contains."""
+        raw = {
+            "replacementAnimDatas": [
+                {
+                    "path": "data\\meshes\\OAR\\mod\\_variants_sneakmtidle",
+                    "variants": [
+                        {"filename": "replacement.hkx"},
+                        {"filename": "replacement.hkx"},
+                    ],
+                },
+                {
+                    "path": "data\\meshes\\OAR\\mod\\_variants_1hm_idle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+            ]
+        }
+        assert _extract_replaced_animations(raw) == {
+            "sneakmtidle.hkx",
+            "1hm_idle.hkx",
+        }
+
+    def test_missing_path_key_skipped(self):
+        """Entry without a 'path' key is skipped without error."""
+        raw = {
+            "replacementAnimDatas": [
+                {"projectName": "DefaultMale", "variants": []},
+            ]
+        }
+        assert _extract_replaced_animations(raw) == set()
+
+    def test_non_string_path_skipped(self):
+        """Entry with a non-string path value is skipped without error."""
+        raw = {
+            "replacementAnimDatas": [
+                {"path": 99, "variants": []},
+            ]
+        }
+        assert _extract_replaced_animations(raw) == set()
+
+    def test_empty_string_path_skipped(self):
+        """Entry with an empty string path is skipped without error."""
+        raw = {
+            "replacementAnimDatas": [
+                {"path": "", "variants": []},
+            ]
+        }
+        assert _extract_replaced_animations(raw) == set()
+
+    def test_case_normalised_to_lowercase(self):
+        """Derived animation names are lowercased."""
+        raw = {
+            "replacementAnimDatas": [
+                {
+                    "path": "data\\meshes\\OAR\\mod\\_variants_Shd_BlockIdle",
+                    "variants": [],
+                }
+            ]
+        }
+        assert _extract_replaced_animations(raw) == {"shd_blockidle.hkx"}
+
+    def test_replacement_anim_data_extracts_from_path_not_variants(self):
+        """Each replacementAnimDatas entry = one vanilla animation derived from path."""
+        raw = {
+            "replacementAnimDatas": [
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\...\\submod\\_variants_sneakmtidle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+                {
+                    "projectName": "DefaultMale",
+                    "path": "data\\meshes\\...\\submod\\_variants_1hm_idle",
+                    "variants": [{"filename": "replacement.hkx"}],
+                },
+            ]
+        }
+        # Should extract sneakmtidle.hkx and 1hm_idle.hkx, NOT replacement.hkx
+        result = _extract_replaced_animations(raw)
+        assert result == {"sneakmtidle.hkx", "1hm_idle.hkx"}
+        assert "replacement.hkx" not in result
 
 
 class TestBuildConflictMap:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -107,3 +107,37 @@ def test_illegal_mutation_error():
     err = IllegalMutationError("conditions", "original_value", "new_value")
     assert "conditions" in str(err)
     assert isinstance(err, Exception)
+
+
+def _make_submod(animations: list[str]) -> SubMod:
+    """Helper: construct a minimal SubMod with the given animations list."""
+    return SubMod(
+        mo2_mod="Test Mod",
+        replacer="rep",
+        name="submod",
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path("C:/mods/Test/meshes/actors/character/animations/OpenAnimationReplacer/rep/submod/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": "submod", "priority": 100},
+        animations=animations,
+        conditions={},
+        condition_types_present=set(),
+        condition_types_negated=set(),
+        warnings=[],
+    )
+
+
+def test_is_config_only_false_when_has_animations():
+    """A submod with animations is NOT config-only."""
+    sm = _make_submod(["mt_idle.hkx", "mt_walkforward.hkx"])
+    assert sm.is_config_only is False
+
+
+def test_is_config_only_true_when_no_animations():
+    """A submod with an empty animations list IS config-only."""
+    sm = _make_submod([])
+    assert sm.is_config_only is True


### PR DESCRIPTION
## Summary
Implements all 11 remaining issues in the **Alpha 1 — UI Completion** milestone, completing the primary workflow UI.

### Batch 1 — Core UI wiring
- **#32** Search bar wired: live tree filtering with dimmed non-matching nodes, auto-expand, keyboard focus on launch
- **#40** Details panel enriched: mod/replacer/submod show full metadata (counts, paths, badges, condition summary, override source)
- **#33** Relative/Absolute segmented toggle visible in stacks toolbar
- **#34** Rank badge colors: #1 green, #2+ grey, losing rows red background, fixed-width priority columns
- **#35** Animation sections collapsible with ▾/▸ toggle
- **#36** Competitor rows clickable → updates conditions panel

### Batch 2 — Actions, persistence, cleanup
- **#37** Post-action toast with auto-dismiss after 5 seconds
- **#38** Action buttons disabled for submods with warnings
- **#39** Move to Top at replacer and mod scope (preserves relative ordering)
- **#41** Config persistence: relative/absolute, window geometry, splitter sizes applied on startup and captured on shutdown
- **#42** Clear Overrides button in top bar, scoped to tree selection with confirmation dialog

All 118 tests pass.

## Test plan
- [ ] Launch app, verify search bar has focus
- [ ] Type in search bar → tree filters/dims correctly
- [ ] Select mod → details show counts, path, override summary
- [ ] Select submod → details show all metadata including override source
- [ ] Click Relative/Absolute toggle → priority columns switch
- [ ] Click ▾ on animation section → collapses; click again → expands
- [ ] Click competitor row → conditions panel updates
- [ ] Move to Top → toast appears, auto-dismisses
- [ ] Select warning submod → action buttons disabled
- [ ] Move Replacer/Mod to Top → multiple submods updated
- [ ] Close and reopen → window size/position and toggle state restored
- [ ] Clear Overrides → confirmation dialog, overrides removed after confirm

closes #32 closes #33 closes #34 closes #35 closes #36 closes #37
closes #38 closes #39 closes #40 closes #41 closes #42

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*