### PR TITLE
feat: Alpha 2 UI — conditions panel, stacks UX, context menus

### DIFF
--- a/docs/superpowers/plans/2026-04-12-conditions-panel.md
+++ b/docs/superpowers/plans/2026-04-12-conditions-panel.md
@@ -1,0 +1,1271 @@
+# Conditions Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw-JSON conditions panel with a formatted AND/OR/NOT tree view, a JSON toggle, and on-demand PRESET resolution.
+
+**Architecture:** A pure-logic `conditions_renderer.py` converts OAR condition dicts into `RenderedNode` trees (no Qt dependency). The updated `conditions_panel.py` uses these nodes to build a QWidget-based formatted view alongside the existing JSON view, switched via a segmented toggle. Preset data flows from the scanner through `tree_model.py` TreeNodes to the panel.
+
+**Tech Stack:** Python 3.11, PySide6, pytest, dataclasses
+
+---
+
+### Task 1: Create `conditions_renderer.py` — RenderedNode dataclass and `render_conditions()`
+
+**Files:**
+- Create: `src/oar_priority_manager/ui/conditions_renderer.py`
+- Create: `tests/unit/test_conditions_renderer.py`
+
+- [ ] **Step 1: Write failing tests for `render_conditions()`**
+
+```python
+"""Tests for ui/conditions_renderer.py — pure-logic condition tree renderer."""
+from __future__ import annotations
+
+from oar_priority_manager.ui.conditions_renderer import (
+    RenderedNode,
+    render_conditions,
+)
+
+
+class TestRenderConditions:
+    def test_empty_list_returns_empty(self):
+        result = render_conditions([])
+        assert result == []
+
+    def test_empty_dict_returns_empty(self):
+        result = render_conditions({})
+        assert result == []
+
+    def test_single_leaf_condition(self):
+        conditions = [{"condition": "IsFemale", "negated": False}]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        node = result[0]
+        assert node.text == "IsFemale"
+        assert node.node_type == "leaf"
+        assert node.negated is False
+        assert node.params == {}
+        assert node.children == []
+
+    def test_negated_leaf(self):
+        conditions = [{"condition": "HasShield", "negated": True}]
+        result = render_conditions(conditions)
+        assert result[0].negated is True
+
+    def test_leaf_with_extra_params(self):
+        conditions = [
+            {
+                "condition": "HasPerk",
+                "negated": False,
+                "formID": "0x00012345",
+                "pluginName": "Skyrim.esm",
+            }
+        ]
+        result = render_conditions(conditions)
+        node = result[0]
+        assert node.params == {
+            "formID": "0x00012345",
+            "pluginName": "Skyrim.esm",
+        }
+
+    def test_and_group(self):
+        conditions = [
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": False},
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        group = result[0]
+        assert group.node_type == "AND"
+        assert group.text == "AND"
+        assert len(group.children) == 2
+        assert group.children[0].text == "IsFemale"
+        assert group.children[1].text == "IsInCombat"
+
+    def test_or_group(self):
+        conditions = [
+            {
+                "condition": "OR",
+                "conditions": [
+                    {"condition": "HasKeyword", "negated": False},
+                    {"condition": "HasPerk", "negated": False},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        assert result[0].node_type == "OR"
+        assert len(result[0].children) == 2
+
+    def test_nested_and_inside_or(self):
+        conditions = [
+            {
+                "condition": "OR",
+                "conditions": [
+                    {
+                        "condition": "AND",
+                        "conditions": [
+                            {"condition": "IsFemale", "negated": False},
+                            {"condition": "IsSneaking", "negated": False},
+                        ],
+                    },
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        or_node = result[0]
+        assert or_node.node_type == "OR"
+        assert or_node.children[0].node_type == "AND"
+        assert len(or_node.children[0].children) == 2
+        assert or_node.children[1].text == "IsInCombat"
+
+    def test_preset_reference(self):
+        conditions = [
+            {"condition": "PRESET", "Preset": "Combat Ready Stance"}
+        ]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        node = result[0]
+        assert node.node_type == "preset"
+        assert node.preset_name == "Combat Ready Stance"
+
+    def test_top_level_dict_with_conditions_key(self):
+        conditions = {
+            "condition": "AND",
+            "conditions": [
+                {"condition": "IsFemale", "negated": False},
+            ],
+        }
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].node_type == "AND"
+        assert result[0].children[0].text == "IsFemale"
+
+    def test_top_level_dict_bare_conditions_key(self):
+        """Dict with just a conditions key, no condition type — implicit AND."""
+        conditions = {
+            "conditions": [
+                {"condition": "IsFemale", "negated": False},
+            ],
+        }
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].node_type == "AND"
+
+    def test_missing_negated_defaults_false(self):
+        conditions = [{"condition": "IsFemale"}]
+        result = render_conditions(conditions)
+        assert result[0].negated is False
+
+    def test_non_dict_items_skipped(self):
+        conditions = ["invalid", 42, {"condition": "IsFemale", "negated": False}]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].text == "IsFemale"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_conditions_renderer.py -v`
+Expected: ImportError — `conditions_renderer` module does not exist yet.
+
+- [ ] **Step 3: Implement `conditions_renderer.py`**
+
+```python
+"""Pure-logic renderer for OAR condition trees.
+
+Converts nested OAR condition dicts/lists into RenderedNode dataclass trees.
+No Qt dependency — this module is testable without a GUI.
+
+See spec: docs/superpowers/specs/2026-04-12-conditions-panel-design.md
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Keys that are structural (not user-visible parameters).
+_STRUCTURAL_KEYS: frozenset[str] = frozenset({
+    "condition", "negated", "conditions", "Preset",
+})
+
+# OAR group-node condition types.
+_GROUP_TYPES: frozenset[str] = frozenset({"AND", "OR"})
+
+
+@dataclass
+class RenderedNode:
+    """One node in the rendered condition tree.
+
+    Attributes:
+        text: Display label — condition type name or group label.
+        node_type: One of "AND", "OR", "leaf", "preset".
+        negated: True if this leaf condition is negated.
+        params: Extra JSON keys (excluding structural ones) as key=value.
+        children: Child nodes (populated for AND/OR groups).
+        preset_name: The preset name (only for node_type="preset").
+    """
+
+    text: str
+    node_type: str
+    negated: bool = False
+    params: dict[str, str] = field(default_factory=dict)
+    children: list[RenderedNode] = field(default_factory=list)
+    preset_name: str | None = None
+
+
+def render_conditions(conditions: dict | list) -> list[RenderedNode]:
+    """Convert an OAR condition tree into a list of RenderedNode trees.
+
+    Handles both top-level list format and top-level dict format.
+    Returns an empty list for empty/invalid input.
+
+    Args:
+        conditions: The raw OAR conditions — either a list of condition
+            dicts or a single dict with a "conditions" key.
+
+    Returns:
+        A list of RenderedNode instances representing the tree.
+    """
+    if isinstance(conditions, list):
+        return [node for item in conditions if (node := _render_node(item)) is not None]
+
+    if isinstance(conditions, dict):
+        if not conditions:
+            return []
+        # Dict with a "conditions" key is a group node
+        if "conditions" in conditions:
+            group_type = conditions.get("condition", "AND")
+            if group_type not in _GROUP_TYPES:
+                group_type = "AND"
+            children_raw = conditions.get("conditions", [])
+            children = [
+                node
+                for item in children_raw
+                if (node := _render_node(item)) is not None
+            ]
+            return [RenderedNode(
+                text=group_type,
+                node_type=group_type,
+                children=children,
+            )]
+        # Dict without "conditions" key — single leaf node
+        node = _render_node(conditions)
+        return [node] if node is not None else []
+
+    return []
+
+
+def _render_node(item: object) -> RenderedNode | None:
+    """Render a single condition dict into a RenderedNode.
+
+    Returns None for non-dict items (defensive skip).
+    """
+    if not isinstance(item, dict):
+        return None
+
+    condition_type = item.get("condition")
+    if not isinstance(condition_type, str):
+        # No condition key — skip
+        return None
+
+    # PRESET reference
+    if condition_type == "PRESET":
+        preset_name = item.get("Preset", "")
+        return RenderedNode(
+            text=f"PRESET: {preset_name}",
+            node_type="preset",
+            preset_name=preset_name if isinstance(preset_name, str) else "",
+        )
+
+    # AND/OR group node
+    if condition_type in _GROUP_TYPES and "conditions" in item:
+        children_raw = item.get("conditions", [])
+        children = [
+            node
+            for child in children_raw
+            if (node := _render_node(child)) is not None
+        ]
+        return RenderedNode(
+            text=condition_type,
+            node_type=condition_type,
+            children=children,
+        )
+
+    # Leaf condition
+    negated = bool(item.get("negated", False))
+    params = {
+        k: str(v) for k, v in item.items() if k not in _STRUCTURAL_KEYS
+    }
+    return RenderedNode(
+        text=condition_type,
+        node_type="leaf",
+        negated=negated,
+        params=params,
+    )
+
+
+def resolve_preset(
+    preset_name: str, presets: dict
+) -> list[RenderedNode] | None:
+    """Resolve a PRESET reference using the replacer's conditionPresets.
+
+    Args:
+        preset_name: The name of the preset to look up.
+        presets: The conditionPresets dict from the replacer config.
+            Keys are preset names, values are condition dicts/lists.
+
+    Returns:
+        A list of RenderedNode trees for the preset's conditions,
+        or None if the preset name is not found.
+    """
+    if not isinstance(presets, dict):
+        return None
+    preset_data = presets.get(preset_name)
+    if preset_data is None:
+        return None
+    return render_conditions(preset_data)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_conditions_renderer.py -v`
+Expected: All 13 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "<worktree>" add src/oar_priority_manager/ui/conditions_renderer.py tests/unit/test_conditions_renderer.py
+git -C "<worktree>" commit -m "feat: add conditions_renderer with RenderedNode and render_conditions (#43)"
+```
+
+---
+
+### Task 2: Add `resolve_preset()` tests
+
+**Files:**
+- Modify: `tests/unit/test_conditions_renderer.py`
+
+- [ ] **Step 1: Add failing tests for `resolve_preset()`**
+
+Append to `tests/unit/test_conditions_renderer.py`:
+
+```python
+from oar_priority_manager.ui.conditions_renderer import resolve_preset
+
+
+class TestResolvePreset:
+    def test_resolve_existing_preset(self):
+        presets = {
+            "Combat Ready": [
+                {"condition": "IsWeaponDrawn", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+            ]
+        }
+        result = resolve_preset("Combat Ready", presets)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].text == "IsWeaponDrawn"
+        assert result[1].text == "IsInCombat"
+
+    def test_resolve_missing_preset_returns_none(self):
+        presets = {"Combat Ready": [{"condition": "IsWeaponDrawn", "negated": False}]}
+        result = resolve_preset("Nonexistent", presets)
+        assert result is None
+
+    def test_resolve_empty_presets_dict(self):
+        result = resolve_preset("Anything", {})
+        assert result is None
+
+    def test_resolve_invalid_presets_type(self):
+        result = resolve_preset("Anything", "not a dict")
+        assert result is None
+
+    def test_resolve_preset_with_nested_group(self):
+        presets = {
+            "Weapon Check": {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsWeaponDrawn", "negated": False},
+                    {"condition": "IsMounted", "negated": True},
+                ],
+            }
+        }
+        result = resolve_preset("Weapon Check", presets)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].node_type == "AND"
+        assert len(result[0].children) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_conditions_renderer.py -v`
+Expected: All 18 tests PASS (the implementation from Task 1 already includes `resolve_preset`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C "<worktree>" add tests/unit/test_conditions_renderer.py
+git -C "<worktree>" commit -m "test: add resolve_preset tests (#44)"
+```
+
+---
+
+### Task 3: Add `conditions_stats()` helper and tests
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/conditions_renderer.py`
+- Modify: `tests/unit/test_conditions_renderer.py`
+
+- [ ] **Step 1: Write failing tests for `conditions_stats()`**
+
+Append to `tests/unit/test_conditions_renderer.py`:
+
+```python
+from oar_priority_manager.ui.conditions_renderer import conditions_stats
+
+
+class TestConditionsStats:
+    def test_empty_tree(self):
+        stats = conditions_stats([])
+        assert stats == {"conditions": 0, "types": 0, "negated": 0, "presets": 0}
+
+    def test_flat_leaves(self):
+        nodes = render_conditions([
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "IsInCombat", "negated": False},
+            {"condition": "HasShield", "negated": True},
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["conditions"] == 3
+        assert stats["types"] == 3
+        assert stats["negated"] == 1
+        assert stats["presets"] == 0
+
+    def test_duplicate_types_counted_once(self):
+        nodes = render_conditions([
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "IsFemale", "negated": True},
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["conditions"] == 2
+        assert stats["types"] == 1
+        assert stats["negated"] == 1
+
+    def test_with_presets(self):
+        nodes = render_conditions([
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "PRESET", "Preset": "Combat Ready"},
+            {"condition": "PRESET", "Preset": "Weapon Check"},
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["presets"] == 2
+        assert stats["conditions"] == 1
+        assert stats["types"] == 1
+
+    def test_nested_groups(self):
+        nodes = render_conditions([
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": False},
+                    {
+                        "condition": "OR",
+                        "conditions": [
+                            {"condition": "HasPerk", "negated": False},
+                            {"condition": "HasKeyword", "negated": True},
+                        ],
+                    },
+                ],
+            },
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["conditions"] == 3
+        assert stats["types"] == 3
+        assert stats["negated"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_conditions_renderer.py::TestConditionsStats -v`
+Expected: ImportError — `conditions_stats` not yet exported.
+
+- [ ] **Step 3: Implement `conditions_stats()`**
+
+Add to `src/oar_priority_manager/ui/conditions_renderer.py`:
+
+```python
+def conditions_stats(nodes: list[RenderedNode]) -> dict[str, int]:
+    """Compute summary statistics for a rendered condition tree.
+
+    Walks the tree and counts leaf conditions, unique types, negated
+    leaves, and preset references.
+
+    Args:
+        nodes: The top-level list of RenderedNode from render_conditions().
+
+    Returns:
+        Dict with keys: "conditions", "types", "negated", "presets".
+    """
+    types: set[str] = set()
+    total = 0
+    negated = 0
+    presets = 0
+
+    def _walk(node_list: list[RenderedNode]) -> None:
+        nonlocal total, negated, presets
+        for node in node_list:
+            if node.node_type == "preset":
+                presets += 1
+            elif node.node_type in ("AND", "OR"):
+                _walk(node.children)
+            else:
+                # leaf
+                total += 1
+                types.add(node.text)
+                if node.negated:
+                    negated += 1
+
+    _walk(nodes)
+    return {
+        "conditions": total,
+        "types": len(types),
+        "negated": negated,
+        "presets": presets,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_conditions_renderer.py -v`
+Expected: All 23 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "<worktree>" add src/oar_priority_manager/ui/conditions_renderer.py tests/unit/test_conditions_renderer.py
+git -C "<worktree>" commit -m "feat: add conditions_stats helper for footer display (#43)"
+```
+
+---
+
+### Task 4: Extract `conditionPresets` in the scanner and attach to TreeNode
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/tree_model.py`
+- Modify: `src/oar_priority_manager/core/scanner.py`
+- Modify: `tests/unit/test_conditions_renderer.py`
+
+- [ ] **Step 1: Add `condition_presets` field to TreeNode**
+
+In `src/oar_priority_manager/ui/tree_model.py`, add a new field to the `TreeNode` dataclass:
+
+```python
+# Add after the auto_expand field (line 55):
+    condition_presets: dict = field(default_factory=dict)
+```
+
+Update the docstring to include:
+
+```python
+        condition_presets: conditionPresets dict from the replacer-level
+            config.json. Populated only on REPLACER nodes; empty for others.
+```
+
+- [ ] **Step 2: Add `replacer_presets` to `SubMod` model**
+
+In `src/oar_priority_manager/core/models.py`, add a field to `SubMod` after the `conditions` field (line 47):
+
+```python
+    # conditionPresets from the replacer-level config.json.
+    # Stored per-submod so it's available without needing the replacer path.
+    replacer_presets: dict = field(default_factory=dict)
+```
+
+- [ ] **Step 3: Extract `conditionPresets` in scanner**
+
+In `src/oar_priority_manager/core/scanner.py`, inside `_find_submod_dirs()`, the scanner already iterates through replacer directories. We need to read the replacer-level config.json for each replacer and pass the presets down.
+
+Modify `_build_submod()` to accept and store `replacer_presets`:
+
+Add parameter `replacer_presets: dict` to the `_build_submod` function signature (after `overwrite_dir`).
+
+In the `return SubMod(...)` call, add `replacer_presets=replacer_presets,`.
+
+In `scan_mods()`, read the replacer config before building submods. Replace the inner loop body (lines 177-181) with:
+
+```python
+    for mo2_mod, replacer, submod_folder, submod_path in submod_dirs:
+        # Read replacer-level config.json for conditionPresets
+        replacer_dir = submod_path.parent
+        replacer_config_path = replacer_dir / "config.json"
+        replacer_presets: dict = {}
+        if replacer_config_path.is_file():
+            from oar_priority_manager.core.parser import parse_config
+            rep_dict, _ = parse_config(replacer_config_path)
+            raw_presets = rep_dict.get("conditionPresets", {})
+            if isinstance(raw_presets, dict):
+                replacer_presets = raw_presets
+
+        sm = _build_submod(
+            mo2_mod, replacer, submod_folder, submod_path,
+            overwrite_dir, replacer_presets,
+        )
+        submods.append(sm)
+        if on_progress is not None:
+            on_progress(len(submods), total)
+```
+
+Note: `parse_config` is already imported at the top of scanner.py, so move the import up to the function level rather than inside the loop, or just use the existing top-level import.
+
+- [ ] **Step 4: Attach presets to REPLACER TreeNodes in `build_tree()`**
+
+In `src/oar_priority_manager/ui/tree_model.py`, inside `build_tree()`, when creating `rep_node`, populate `condition_presets` from the first submod's `replacer_presets`:
+
+```python
+        for rep_name in sorted(replacer_dict.keys()):
+            # Get presets from first submod in this replacer (all share the same)
+            first_submod = replacer_dict[rep_name][0]
+            rep_presets = (
+                first_submod.replacer_presets
+                if hasattr(first_submod, "replacer_presets")
+                else {}
+            )
+            rep_node = TreeNode(
+                display_name=rep_name,
+                node_type=NodeType.REPLACER,
+                parent=mod_node,
+                auto_expand=single_replacer,
+                condition_presets=rep_presets,
+            )
+```
+
+- [ ] **Step 5: Write tests for preset data flow**
+
+Add to `tests/unit/test_conditions_renderer.py`:
+
+```python
+class TestPresetDataFlow:
+    """Integration-style tests verifying presets flow from scanner to TreeNode."""
+
+    def test_tree_node_has_condition_presets_field(self):
+        from oar_priority_manager.ui.tree_model import TreeNode, NodeType
+        node = TreeNode(
+            display_name="test",
+            node_type=NodeType.REPLACER,
+            condition_presets={"Combat": [{"condition": "IsInCombat"}]},
+        )
+        assert node.condition_presets == {"Combat": [{"condition": "IsInCombat"}]}
+
+    def test_tree_node_default_empty_presets(self):
+        from oar_priority_manager.ui.tree_model import TreeNode, NodeType
+        node = TreeNode(display_name="test", node_type=NodeType.MOD)
+        assert node.condition_presets == {}
+```
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pytest tests/ -v`
+Expected: All tests PASS. No existing tests should break since the new fields have defaults.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C "<worktree>" add src/oar_priority_manager/core/models.py src/oar_priority_manager/core/scanner.py src/oar_priority_manager/ui/tree_model.py tests/unit/test_conditions_renderer.py
+git -C "<worktree>" commit -m "feat: extract conditionPresets from replacer configs and attach to TreeNode (#44)"
+```
+
+---
+
+### Task 5: Rewrite `conditions_panel.py` — formatted view + JSON toggle
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/conditions_panel.py`
+- Create: `tests/unit/test_conditions_panel.py`
+
+- [ ] **Step 1: Write failing tests for the new panel**
+
+```python
+"""Tests for ui/conditions_panel.py — formatted conditions view + JSON toggle."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.ui.conditions_panel import ConditionsPanel
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Ensure a QApplication exists for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_submod(
+    conditions=None, name="TestSub", mo2_mod="TestMod", replacer_presets=None
+):
+    """Build a minimal SubMod for testing."""
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer="TestReplacer",
+        name=name,
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path("/fake/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        conditions=conditions if conditions is not None else [],
+        replacer_presets=replacer_presets if replacer_presets is not None else {},
+    )
+
+
+class TestConditionsPanelInit:
+    def test_default_shows_placeholder(self, qapp):
+        panel = ConditionsPanel()
+        # Should show placeholder text, not conditions
+        assert panel._formatted_view is not None
+        assert panel._json_view is not None
+
+    def test_formatted_is_default_mode(self, qapp):
+        panel = ConditionsPanel()
+        assert panel._formatted_btn.isChecked() is True
+        assert panel._json_btn.isChecked() is False
+
+
+class TestConditionsPanelUpdate:
+    def test_update_none_shows_placeholder(self, qapp):
+        panel = ConditionsPanel()
+        panel.update_focus(None)
+        # Header should be generic
+        assert "Select" in panel._header.text()
+
+    def test_update_with_submod_shows_header(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[{"condition": "IsFemale", "negated": False}]
+        )
+        panel.update_focus(sm)
+        assert "TestMod" in panel._header.text()
+        assert "TestSub" in panel._header.text()
+
+    def test_update_with_empty_conditions(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(conditions=[])
+        panel.update_focus(sm)
+        # Should show "No conditions defined" or similar
+
+    def test_json_toggle_shows_raw_json(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[{"condition": "IsFemale", "negated": False}]
+        )
+        panel.update_focus(sm)
+        # Switch to JSON mode
+        panel._json_btn.click()
+        # The JSON view should be visible and contain the condition text
+        assert "IsFemale" in panel._json_view.toPlainText()
+
+    def test_formatted_toggle_returns_to_tree(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[{"condition": "IsFemale", "negated": False}]
+        )
+        panel.update_focus(sm)
+        panel._json_btn.click()
+        panel._formatted_btn.click()
+        assert panel._formatted_btn.isChecked() is True
+
+
+class TestConditionsPanelStats:
+    def test_stats_footer_shows_counts(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[
+                {"condition": "IsFemale", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+                {"condition": "HasShield", "negated": True},
+            ]
+        )
+        panel.update_focus(sm)
+        footer_text = panel._stats_label.text()
+        assert "3" in footer_text  # 3 conditions
+        assert "3" in footer_text  # 3 types
+        assert "1" in footer_text  # 1 negated
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_conditions_panel.py -v`
+Expected: AttributeError — `_formatted_view`, `_json_view`, `_formatted_btn` etc. don't exist on the old panel.
+
+- [ ] **Step 3: Rewrite `conditions_panel.py`**
+
+Replace the entire contents of `src/oar_priority_manager/ui/conditions_panel.py`:
+
+```python
+"""Conditions panel — formatted AND/OR/NOT tree + raw JSON toggle.
+
+See spec: docs/superpowers/specs/2026-04-12-conditions-panel-design.md
+Issues: #43 (formatted display), #44 (JSON toggle)
+"""
+from __future__ import annotations
+
+import json
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QFont
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from oar_priority_manager.core.models import SubMod
+from oar_priority_manager.ui.conditions_renderer import (
+    RenderedNode,
+    conditions_stats,
+    render_conditions,
+    resolve_preset,
+)
+
+
+class ConditionsPanel(QWidget):
+    """Right pane: formatted condition tree with JSON toggle."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._current_submod: SubMod | None = None
+        self._show_formatted: bool = True
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # -- Header row: label + Formatted/JSON toggle --
+        header_row = QWidget()
+        header_layout = QHBoxLayout(header_row)
+        header_layout.setContentsMargins(4, 4, 4, 2)
+
+        self._header = QLabel("Conditions")
+        self._header.setTextFormat(Qt.TextFormat.RichText)
+        header_layout.addWidget(self._header, stretch=1)
+
+        # Segmented toggle matching tree_panel.py / stacks_panel.py pattern
+        _seg_checked = (
+            "QPushButton:checked {"
+            "  background: #3a3a5a;"
+            "  font-weight: bold;"
+            "  border: 1px solid #5a5a8a;"
+            "}"
+        )
+        _seg_unchecked = (
+            "QPushButton {"
+            "  background: #2a2a2a;"
+            "  border: 1px solid #444;"
+            "  padding: 3px 10px;"
+            "}"
+            "QPushButton:hover { background: #333; }"
+        )
+
+        self._formatted_btn = QPushButton("Formatted")
+        self._formatted_btn.setCheckable(True)
+        self._formatted_btn.setChecked(True)
+        self._formatted_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-left-radius: 4px;"
+            "  border-bottom-left-radius: 4px;"
+            "  border-right: none; }"
+        )
+
+        self._json_btn = QPushButton("JSON")
+        self._json_btn.setCheckable(True)
+        self._json_btn.setChecked(False)
+        self._json_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-right-radius: 4px;"
+            "  border-bottom-right-radius: 4px; }"
+        )
+
+        self._toggle_group = QButtonGroup(self)
+        self._toggle_group.setExclusive(True)
+        self._toggle_group.addButton(self._formatted_btn)
+        self._toggle_group.addButton(self._json_btn)
+
+        self._formatted_btn.clicked.connect(lambda: self._set_mode(True))
+        self._json_btn.clicked.connect(lambda: self._set_mode(False))
+
+        header_layout.addWidget(self._formatted_btn)
+        header_layout.addWidget(self._json_btn)
+
+        layout.addWidget(header_row)
+
+        # -- Formatted view (scroll area with rendered tree) --
+        self._formatted_view = QScrollArea()
+        self._formatted_view.setWidgetResizable(True)
+        self._formatted_content = QWidget()
+        self._formatted_layout = QVBoxLayout(self._formatted_content)
+        self._formatted_layout.setContentsMargins(8, 8, 8, 8)
+        self._formatted_layout.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop
+        )
+        self._formatted_view.setWidget(self._formatted_content)
+        layout.addWidget(self._formatted_view)
+
+        # -- JSON view (existing QTextEdit, hidden by default) --
+        self._json_view = QTextEdit()
+        self._json_view.setReadOnly(True)
+        self._json_view.hide()
+        layout.addWidget(self._json_view)
+
+        # -- Stats footer --
+        self._stats_label = QLabel("")
+        self._stats_label.setStyleSheet("color: #565f89; padding: 4px 8px;")
+        layout.addWidget(self._stats_label)
+
+    def _set_mode(self, formatted: bool) -> None:
+        """Switch between formatted and JSON view modes."""
+        if self._show_formatted == formatted:
+            return
+        self._show_formatted = formatted
+        self._formatted_view.setVisible(formatted)
+        self._json_view.setVisible(not formatted)
+
+    def update_focus(self, submod: SubMod | None) -> None:
+        """Update display for the focused competitor submod."""
+        self._current_submod = submod
+
+        if submod is None:
+            self._header.setText("Conditions")
+            self._clear_formatted()
+            self._json_view.clear()
+            self._stats_label.setText("")
+            self._add_placeholder("Select a submod to view conditions.")
+            return
+
+        self._header.setText(
+            f"<b>Conditions</b> · {submod.mo2_mod} / {submod.name}"
+        )
+
+        # JSON view (always updated, even if hidden)
+        self._json_view.setPlainText(json.dumps(submod.conditions, indent=2))
+
+        # Formatted view
+        nodes = render_conditions(submod.conditions)
+        self._clear_formatted()
+
+        if not nodes:
+            self._add_placeholder("No conditions defined.")
+            self._stats_label.setText("")
+            return
+
+        self._render_nodes(nodes, self._formatted_layout, indent=0)
+
+        # Stats footer
+        stats = conditions_stats(nodes)
+        parts = [
+            f"{stats['conditions']} conditions",
+            f"{stats['types']} types",
+            f"{stats['negated']} negated",
+        ]
+        if stats["presets"] > 0:
+            parts.append(f"{stats['presets']} presets")
+        self._stats_label.setText(" · ".join(parts))
+
+    def _clear_formatted(self) -> None:
+        """Remove all widgets from the formatted view layout."""
+        while self._formatted_layout.count():
+            child = self._formatted_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+    def _add_placeholder(self, text: str) -> None:
+        """Add a placeholder label to the formatted view."""
+        label = QLabel(text)
+        label.setStyleSheet("color: #565f89; padding: 8px;")
+        self._formatted_layout.addWidget(label)
+
+    def _render_nodes(
+        self,
+        nodes: list[RenderedNode],
+        parent_layout: QVBoxLayout,
+        indent: int,
+    ) -> None:
+        """Recursively render RenderedNode trees into QLabels."""
+        for node in nodes:
+            if node.node_type in ("AND", "OR"):
+                self._render_group(node, parent_layout, indent)
+            elif node.node_type == "preset":
+                self._render_preset(node, parent_layout, indent)
+            else:
+                self._render_leaf(node, parent_layout, indent)
+
+    def _render_group(
+        self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
+    ) -> None:
+        """Render an AND/OR group with its children."""
+        label_text = "ALL of:" if node.node_type == "AND" else "ANY of:"
+        color = "#7aa2f7" if node.node_type == "AND" else "#bb9af7"
+
+        group_label = QLabel(f"<b style='color:{color};'>{label_text}</b>")
+        group_label.setTextFormat(Qt.TextFormat.RichText)
+        group_label.setContentsMargins(indent * 20, 2, 0, 0)
+        parent_layout.addWidget(group_label)
+
+        # Render children at increased indent
+        self._render_nodes(node.children, parent_layout, indent + 1)
+
+    def _render_leaf(
+        self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
+    ) -> None:
+        """Render a single leaf condition with icon, name, and params."""
+        if node.negated:
+            icon = "<span style='color:#f7768e;'>✗</span>"
+            name_html = (
+                f"<span style='color:#c0caf5; text-decoration:line-through;"
+                f" opacity:0.7;'>{node.text}</span>"
+                f" <span style='background:#3a1a1a; color:#f7768e;"
+                f" padding:1px 6px; border-radius:3px; font-size:11px;'>"
+                f"NOT</span>"
+            )
+        else:
+            icon = "<span style='color:#9ece6a;'>✓</span>"
+            name_html = f"<span style='color:#c0caf5;'>{node.text}</span>"
+
+        html = f"{icon} {name_html}"
+
+        # Add parameters line if any
+        if node.params:
+            param_parts = [f'{k} = "{v}"' for k, v in node.params.items()]
+            params_str = " · ".join(param_parts)
+            html += (
+                f"<br><span style='color:#565f89; font-size:11px;"
+                f" margin-left:22px;'>{params_str}</span>"
+            )
+
+        label = QLabel(html)
+        label.setTextFormat(Qt.TextFormat.RichText)
+        label.setContentsMargins(indent * 20, 2, 0, 2)
+        parent_layout.addWidget(label)
+
+    def _render_preset(
+        self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
+    ) -> None:
+        """Render a PRESET reference as a clickable expandable card."""
+        preset_name = node.preset_name or "Unknown"
+
+        # Create a container widget for the preset card
+        card = QWidget()
+        card.setStyleSheet(
+            "background: #2a2a3a; border: 1px solid #444; border-radius: 6px;"
+        )
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(10, 8, 10, 8)
+
+        # Header row
+        header = QLabel(
+            f"<span style='color:#e0af68;'>⚙</span>"
+            f" <b style='color:#e0af68;'>PRESET:</b>"
+            f" <span style='color:#c0caf5;'>{preset_name}</span>"
+            f" <span style='color:#565f89; font-size:11px;'>"
+            f"▸ expand</span>"
+        )
+        header.setTextFormat(Qt.TextFormat.RichText)
+        header.setCursor(Qt.CursorShape.PointingHandCursor)
+        card_layout.addWidget(header)
+
+        # Expanded content container (hidden initially)
+        expanded = QWidget()
+        expanded.hide()
+        expanded_layout = QVBoxLayout(expanded)
+        expanded_layout.setContentsMargins(8, 4, 0, 0)
+        card_layout.addWidget(expanded)
+
+        # Wire up click to toggle expand/collapse
+        def _toggle_preset(
+            checked: bool = False,
+            *,
+            exp: QWidget = expanded,
+            hdr: QLabel = header,
+            pname: str = preset_name,
+        ) -> None:
+            if exp.isVisible():
+                exp.hide()
+                hdr.setText(
+                    f"<span style='color:#e0af68;'>⚙</span>"
+                    f" <b style='color:#e0af68;'>PRESET:</b>"
+                    f" <span style='color:#c0caf5;'>{pname}</span>"
+                    f" <span style='color:#565f89; font-size:11px;'>"
+                    f"▸ expand</span>"
+                )
+            else:
+                # Resolve preset on demand
+                if expanded_layout.count() == 0:
+                    self._populate_preset(pname, expanded_layout)
+                exp.show()
+                hdr.setText(
+                    f"<span style='color:#e0af68;'>⚙</span>"
+                    f" <b style='color:#e0af68;'>PRESET:</b>"
+                    f" <span style='color:#c0caf5;'>{pname}</span>"
+                    f" <span style='color:#565f89; font-size:11px;'>"
+                    f"▾ collapse</span>"
+                )
+
+        header.mousePressEvent = _toggle_preset
+
+        card.setContentsMargins(indent * 20, 4, 0, 4)
+        parent_layout.addWidget(card)
+
+    def _populate_preset(
+        self, preset_name: str, layout: QVBoxLayout
+    ) -> None:
+        """Resolve and render a preset's conditions into the given layout."""
+        presets = {}
+        if self._current_submod is not None:
+            presets = getattr(self._current_submod, "replacer_presets", {})
+
+        nodes = resolve_preset(preset_name, presets)
+        if nodes is None:
+            warning = QLabel(
+                f"<span style='color:#f7768e;'>Preset '{preset_name}'"
+                f" not found in replacer config.</span>"
+            )
+            warning.setTextFormat(Qt.TextFormat.RichText)
+            layout.addWidget(warning)
+            return
+
+        self._render_nodes(nodes, layout, indent=0)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_conditions_panel.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `pytest tests/ -v`
+Expected: All tests PASS. The old `conditions_panel.py` tests (if any) may need updating since the API changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "<worktree>" add src/oar_priority_manager/ui/conditions_panel.py tests/unit/test_conditions_panel.py
+git -C "<worktree>" commit -m "feat: rewrite conditions panel with formatted tree view and JSON toggle (#43, #44)"
+```
+
+---
+
+### Task 6: Wire preset data through `main_window.py` and integration test
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/main_window.py`
+- Modify: `tests/unit/test_conditions_panel.py`
+
+- [ ] **Step 1: Verify main_window.py passes SubMod to conditions panel**
+
+Check that `_on_tree_selection` and `_on_competitor_focused` already pass `submod` objects to `conditions_panel.update_focus()`. They do (lines 138 and 142 of main_window.py), so no change is needed — the SubMod already carries `replacer_presets` from Task 4.
+
+- [ ] **Step 2: Add integration test for preset expansion**
+
+Add to `tests/unit/test_conditions_panel.py`:
+
+```python
+class TestPresetExpansion:
+    def test_preset_resolves_from_submod_replacer_presets(self, qapp):
+        panel = ConditionsPanel()
+        presets = {
+            "Combat Ready": [
+                {"condition": "IsWeaponDrawn", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+            ]
+        }
+        sm = _make_submod(
+            conditions=[
+                {"condition": "PRESET", "Preset": "Combat Ready"},
+            ],
+            replacer_presets=presets,
+        )
+        panel.update_focus(sm)
+        # The formatted view should contain a preset card widget
+        # (detailed rendering tested via conditions_renderer unit tests)
+        assert panel._formatted_layout.count() >= 1
+
+    def test_missing_preset_shows_warning(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[
+                {"condition": "PRESET", "Preset": "Nonexistent"},
+            ],
+            replacer_presets={},
+        )
+        panel.update_focus(sm)
+        assert panel._formatted_layout.count() >= 1
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pytest tests/ -v`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "<worktree>" add tests/unit/test_conditions_panel.py
+git -C "<worktree>" commit -m "test: add preset expansion integration tests (#44)"
+```
+
+---
+
+### Task 7: Lint, final verification, and cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run ruff linter**
+
+Run: `ruff check src/ tests/ --fix`
+Expected: No errors, or auto-fixable ones resolved.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pytest tests/ -v`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Verify no import cycles**
+
+Run: `python -c "from oar_priority_manager.ui.conditions_panel import ConditionsPanel; print('OK')"`
+Expected: "OK" — no circular imports.
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git -C "<worktree>" add -A
+git -C "<worktree>" commit -m "chore: lint fixes for conditions panel implementation"
+```
+
+Only commit if there were actual changes from the lint step.

--- a/docs/superpowers/plans/2026-04-14-category-tags.md
+++ b/docs/superpowers/plans/2026-04-14-category-tags.md
@@ -1,0 +1,1965 @@
+# Category Tags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add auto-detected category tags (colored pills) to mods and submods in the tree panel, with manual override support and search integration.
+
+**Architecture:** A new `core/tag_engine.py` module computes tags via a 3-layer rule pipeline (folder keywords → animation patterns → condition types). Tags are stored on `SubMod`, rendered via a custom `QStyledItemDelegate` in the tree panel, and editable via a right-click dialog. Manual overrides persist in `AppConfig`.
+
+**Tech Stack:** Python 3.11+, PySide6, pytest
+
+**Issue:** #73
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/oar_priority_manager/core/tag_engine.py` | **New.** `TagCategory` enum (10 values with color metadata), `compute_tags()` pure function, 3-layer rule pipeline |
+| `src/oar_priority_manager/core/models.py` | Add `tags: set` field to `SubMod` dataclass |
+| `src/oar_priority_manager/app/config.py` | Add `tag_overrides: dict[str, list[str]]` to `AppConfig`, update `load_config`/`save_config` |
+| `src/oar_priority_manager/app/main.py` | Call `compute_tags()` in `run_scan()` after condition extraction |
+| `src/oar_priority_manager/ui/tree_panel.py` | Wire `TagDelegate`, add "Edit Tags..." context menu |
+| `src/oar_priority_manager/ui/tag_delegate.py` | **New.** `QStyledItemDelegate` subclass that paints tag pills after display name |
+| `src/oar_priority_manager/ui/tag_edit_dialog.py` | **New.** Checkbox dialog for manual tag editing with "Reset to Auto" |
+| `src/oar_priority_manager/ui/details_panel.py` | Add Tags section with pill HTML and `+` button |
+| `src/oar_priority_manager/ui/tree_model.py` | Extend `SearchIndex` to index tag names |
+| `tests/unit/test_tag_engine.py` | **New.** Unit tests for tag engine |
+| `tests/unit/test_config.py` | Add tests for `tag_overrides` persistence |
+| `tests/unit/test_tree_model.py` | Add tests for tag-name search |
+
+---
+
+### Task 1: TagCategory Enum and Stub compute_tags
+
+**Files:**
+- Create: `src/oar_priority_manager/core/tag_engine.py`
+- Test: `tests/unit/test_tag_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_tag_engine.py`:
+
+```python
+"""Tests for core/tag_engine.py — category tag auto-detection.
+
+See design spec docs/superpowers/specs/2026-04-14-category-tags-design.md.
+"""
+from __future__ import annotations
+
+from oar_priority_manager.core.tag_engine import TagCategory, compute_tags
+from oar_priority_manager.core.models import SubMod, OverrideSource
+from pathlib import Path
+
+
+def _make_submod(
+    mo2_mod: str = "Test Mod",
+    replacer: str = "TestReplacer",
+    name: str = "test_sub",
+    animations: list[str] | None = None,
+    condition_types_present: set[str] | None = None,
+    condition_types_negated: set[str] | None = None,
+) -> SubMod:
+    """Factory for SubMod instances with sensible defaults."""
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path(f"/fake/{mo2_mod}/{replacer}/{name}/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        animations=animations or [],
+        condition_types_present=condition_types_present or set(),
+        condition_types_negated=condition_types_negated or set(),
+    )
+
+
+class TestTagCategory:
+    def test_enum_has_10_members(self):
+        assert len(TagCategory) == 10
+
+    def test_each_member_has_color_metadata(self):
+        for tag in TagCategory:
+            assert tag.color_bg.startswith("#"), f"{tag.name} missing color_bg"
+            assert tag.color_fg.startswith("#"), f"{tag.name} missing color_fg"
+            assert tag.color_border.startswith("#"), f"{tag.name} missing color_border"
+
+    def test_each_member_has_label(self):
+        for tag in TagCategory:
+            assert isinstance(tag.label, str) and len(tag.label) > 0
+
+    def test_sort_order_is_unique(self):
+        orders = [tag.sort_order for tag in TagCategory]
+        assert len(orders) == len(set(orders))
+
+    def test_nsfw_sorts_first(self):
+        assert TagCategory.NSFW.sort_order == 0
+
+
+class TestComputeTagsEmpty:
+    def test_empty_submod_returns_empty_set(self):
+        sm = _make_submod()
+        assert compute_tags(sm) == set()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_tag_engine.py -v`
+Expected: `ModuleNotFoundError: No module named 'oar_priority_manager.core.tag_engine'`
+
+- [ ] **Step 3: Write TagCategory enum and stub compute_tags**
+
+Create `src/oar_priority_manager/core/tag_engine.py`:
+
+```python
+"""Category tag auto-detection engine for OAR Priority Manager.
+
+Computes category tags for submods based on a 3-layer rule pipeline:
+  1. Folder/mod name keywords (highest confidence)
+  2. Animation filename patterns (primary behavioral signal)
+  3. Condition types (secondary refinement with precondition filter)
+
+See design spec: docs/superpowers/specs/2026-04-14-category-tags-design.md
+"""
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from oar_priority_manager.core.models import SubMod
+
+
+class TagCategory(Enum):
+    """Category tag with display metadata.
+
+    Each member is a tuple of (label, sort_order, color_bg, color_fg, color_border).
+    """
+
+    NSFW = ("NSFW", 0, "#5c2d4a", "#f0a0d0", "#8b446e")
+    COMBAT = ("Combat", 1, "#5c2d2d", "#f0a0a0", "#8b4444")
+    EQUIPMENT = ("Equipment", 2, "#3d3d3d", "#b0b0b0", "#5a5a5a")
+    FURNITURE = ("Furniture", 3, "#5c4a2d", "#f0d0a0", "#8b6e44")
+    GENDER = ("Gender", 4, "#5c5c2d", "#f0f0a0", "#8b8b44")
+    IDLE = ("Idle", 5, "#2d5c4a", "#a0f0d0", "#448b6e")
+    MAGIC = ("Magic", 6, "#4a2d5c", "#d0a0f0", "#6e448b")
+    MOVEMENT = ("Movement", 7, "#2d3a5c", "#a0b8f0", "#44578b")
+    NPC = ("NPC", 8, "#2d4a5c", "#a0d0f0", "#446e8b")
+    SNEAK = ("Sneak", 9, "#3d2d5c", "#b8a0f0", "#5b448b")
+
+    def __init__(
+        self,
+        label: str,
+        sort_order: int,
+        color_bg: str,
+        color_fg: str,
+        color_border: str,
+    ) -> None:
+        self.label = label
+        self.sort_order = sort_order
+        self.color_bg = color_bg
+        self.color_fg = color_fg
+        self.color_border = color_border
+
+
+def compute_tags(submod: SubMod) -> set[TagCategory]:
+    """Compute category tags for a submod using the 3-layer rule pipeline.
+
+    Args:
+        submod: The SubMod to tag.
+
+    Returns:
+        Set of matching TagCategory values (may be empty).
+    """
+    tags: set[TagCategory] = set()
+    tags |= _layer1_keywords(submod)
+    tags |= _layer2_animations(submod, tags)
+    tags |= _layer3_conditions(submod, tags)
+    return tags
+
+
+def _layer1_keywords(submod: SubMod) -> set[TagCategory]:
+    """Layer 1: folder/mod name keyword matching."""
+    return set()
+
+
+def _layer2_animations(
+    submod: SubMod, existing: set[TagCategory]
+) -> set[TagCategory]:
+    """Layer 2: animation filename pattern voting."""
+    return set()
+
+
+def _layer3_conditions(
+    submod: SubMod, existing: set[TagCategory]
+) -> set[TagCategory]:
+    """Layer 3: condition type refinement with precondition filter."""
+    return set()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_tag_engine.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oar_priority_manager/core/tag_engine.py tests/unit/test_tag_engine.py
+git commit -m "feat: add TagCategory enum and stub compute_tags (#73)"
+```
+
+---
+
+### Task 2: Layer 1 — Folder/Mod Name Keyword Detection
+
+**Files:**
+- Modify: `src/oar_priority_manager/core/tag_engine.py`
+- Modify: `tests/unit/test_tag_engine.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_tag_engine.py`:
+
+```python
+class TestLayer1Keywords:
+    """Layer 1: folder/mod name keyword matching."""
+
+    def test_nsfw_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Dynamic Feminine Female Modesty Animations OAR")
+        tags = compute_tags(sm)
+        assert TagCategory.NSFW in tags
+
+    def test_nsfw_from_submod_name(self):
+        sm = _make_submod(name="nude_both_free")
+        tags = compute_tags(sm)
+        assert TagCategory.NSFW in tags
+
+    def test_nsfw_sexlab_keyword(self):
+        sm = _make_submod(mo2_mod="SexLab Animation Pack")
+        tags = compute_tags(sm)
+        assert TagCategory.NSFW in tags
+
+    def test_gender_female_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Dynamic Female Weather Idles")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+
+    def test_gender_male_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Random Male Wall Leaning Animations")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+
+    def test_gender_no_substring_match(self):
+        """'female' inside 'maleficent' should NOT match."""
+        sm = _make_submod(mo2_mod="Maleficent Anim Pack")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER not in tags
+
+    def test_npc_from_mod_name(self):
+        sm = _make_submod(mo2_mod="NPC Animation Remix")
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_npc_children_keyword(self):
+        sm = _make_submod(mo2_mod="Lively Children Animations")
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_sneak_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Dynamic Relaxed sneak OAR")
+        tags = compute_tags(sm)
+        assert TagCategory.SNEAK in tags
+
+    def test_combat_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Combat Animation Overhaul")
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_combat_dodge_keyword(self):
+        sm = _make_submod(mo2_mod="Nolvus Awakening Dodge Framework")
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_movement_from_mod_name(self):
+        sm = _make_submod(mo2_mod="EVG Animated Traversal")
+        tags = compute_tags(sm)
+        assert TagCategory.MOVEMENT in tags
+
+    def test_multiple_keywords_yield_multiple_tags(self):
+        sm = _make_submod(mo2_mod="Female NPC Sneak Pack")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+        assert TagCategory.NPC in tags
+        assert TagCategory.SNEAK in tags
+
+    def test_no_match_returns_empty(self):
+        sm = _make_submod(mo2_mod="Some Random Mod")
+        tags = compute_tags(sm)
+        assert len(tags) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_tag_engine.py::TestLayer1Keywords -v`
+Expected: All fail (keyword tests return empty sets)
+
+- [ ] **Step 3: Implement _layer1_keywords**
+
+Replace the `_layer1_keywords` stub in `src/oar_priority_manager/core/tag_engine.py`:
+
+```python
+# Module-level constant: keyword -> TagCategory mapping.
+# Multi-word keywords must come before single-word to avoid partial matches.
+_KEYWORD_RULES: list[tuple[list[str], TagCategory]] = [
+    # NSFW
+    (
+        [
+            "modesty", "nude", "naked", "nsfw", "adult", "sexlab",
+            "ostim", "pregnancy", "inflation", "flower girl", "billyy", "leito",
+        ],
+        TagCategory.NSFW,
+    ),
+    # Gender — whole-word only (handled by regex in _layer1_keywords)
+    (["female", "male"], TagCategory.GENDER),
+    # NPC — multi-word first
+    (["cart driver", "npc", "children", "child"], TagCategory.NPC),
+    # Sneak
+    (["sneak"], TagCategory.SNEAK),
+    # Combat — multi-word first
+    (
+        ["ashes of war", "boss fight", "combat", "stagger", "block", "dodge"],
+        TagCategory.COMBAT,
+    ),
+    # Movement
+    (["traversal", "clamber", "swimming", "jump"], TagCategory.MOVEMENT),
+]
+
+# Pre-compiled patterns for whole-word matching.
+# Gender keywords need word-boundary matching to avoid "female" in "maleficent".
+_WHOLE_WORD_TAGS: frozenset[TagCategory] = frozenset({TagCategory.GENDER})
+
+
+def _layer1_keywords(submod: SubMod) -> set[TagCategory]:
+    """Layer 1: folder/mod name keyword matching.
+
+    Scans mo2_mod, replacer, and name for keyword hits. Gender keywords
+    use whole-word matching; others use substring matching.
+    """
+    tags: set[TagCategory] = set()
+    # Combine all name sources into one lowered string for scanning.
+    text = f"{submod.mo2_mod} {submod.replacer} {submod.name}".lower()
+
+    for keywords, tag in _KEYWORD_RULES:
+        if tag in tags:
+            continue  # Already found this tag
+        for kw in keywords:
+            if tag in _WHOLE_WORD_TAGS:
+                # Whole-word boundary match
+                if re.search(rf"\b{re.escape(kw)}\b", text):
+                    tags.add(tag)
+                    break
+            else:
+                if kw in text:
+                    tags.add(tag)
+                    break
+
+    return tags
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_tag_engine.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oar_priority_manager/core/tag_engine.py tests/unit/test_tag_engine.py
+git commit -m "feat: implement Layer 1 keyword detection for tag engine (#73)"
+```
+
+---
+
+### Task 3: Layer 2 — Animation Filename Pattern Voting
+
+**Files:**
+- Modify: `src/oar_priority_manager/core/tag_engine.py`
+- Modify: `tests/unit/test_tag_engine.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_tag_engine.py`:
+
+```python
+class TestLayer2Animations:
+    """Layer 2: animation filename pattern voting with 30% threshold."""
+
+    def test_combat_animations(self):
+        anims = [f"1hm_attack{i}.hkx" for i in range(10)]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_movement_animations(self):
+        anims = ["mt_runforward.hkx", "mt_runbackward.hkx", "mt_walk.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.MOVEMENT in tags
+
+    def test_sneak_animations(self):
+        anims = ["mt_sneak_idle.hkx", "sneak_forward.hkx", "sneak_back.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.SNEAK in tags
+
+    def test_idle_animations(self):
+        anims = ["mt_idle.hkx", "1hm_idle.hkx", "idle_front.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.IDLE in tags
+
+    def test_furniture_animations(self):
+        anims = ["chair_sit.hkx", "sit_idle.hkx", "bed_enter.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.FURNITURE in tags
+
+    def test_equipment_animations(self):
+        anims = ["1hm_equip.hkx", "1hm_unequip.hkx", "bow_draw.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.EQUIPMENT in tags
+
+    def test_magic_animations(self):
+        anims = ["mlh_cast.hkx", "mrh_cast.hkx", "mt_cast_idle.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.MAGIC in tags
+
+    def test_voting_threshold_below_30_percent(self):
+        """1 idle out of 10 combat = 10% idle, should NOT tag Idle."""
+        anims = [f"1hm_attack{i}.hkx" for i in range(9)] + ["mt_idle.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+        assert TagCategory.IDLE not in tags
+
+    def test_voting_threshold_at_30_percent(self):
+        """3 idle out of 10 = 30%, should tag Idle."""
+        anims = [f"1hm_attack{i}.hkx" for i in range(7)] + [
+            "mt_idle.hkx",
+            "idle_front.hkx",
+            "1hm_idle.hkx",
+        ]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+        assert TagCategory.IDLE in tags
+
+    def test_empty_animations_no_tags(self):
+        sm = _make_submod(animations=[])
+        tags = compute_tags(sm)
+        assert len(tags) == 0
+
+    def test_unrecognized_animations_no_tags(self):
+        anims = ["custom_anim1.hkx", "custom_anim2.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert len(tags) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_tag_engine.py::TestLayer2Animations -v`
+Expected: All fail (animation voting returns empty sets)
+
+- [ ] **Step 3: Implement _layer2_animations**
+
+Replace the `_layer2_animations` stub in `src/oar_priority_manager/core/tag_engine.py`:
+
+```python
+# Animation filename patterns for each tag category.
+# Patterns are matched against lowercased animation filenames (without extension).
+_ANIM_PATTERNS: list[tuple[list[str], TagCategory]] = [
+    (["_attack", "_block", "_stagger", "_recoil", "_power"], TagCategory.COMBAT),
+    (["_run", "_walk", "_sprint", "_swim", "_jump"], TagCategory.MOVEMENT),
+    (["sneak"], TagCategory.SNEAK),
+    (["_idle", "mt_idle"], TagCategory.IDLE),
+    (["_sit", "_chair", "_bed", "_lean"], TagCategory.FURNITURE),
+    (["_equip", "_sheathe", "_draw", "_unequip"], TagCategory.EQUIPMENT),
+    (["_cast", "mlh_", "mrh_"], TagCategory.MAGIC),
+]
+
+# Minimum fraction of animations that must match a category for it to apply.
+_ANIM_VOTE_THRESHOLD: float = 0.30
+
+
+def _classify_animation(filename: str) -> set[TagCategory]:
+    """Classify a single animation filename into zero or more tag categories."""
+    # Strip extension and lowercase
+    name = filename.rsplit(".", 1)[0].lower() if "." in filename else filename.lower()
+    matched: set[TagCategory] = set()
+    for patterns, tag in _ANIM_PATTERNS:
+        for pattern in patterns:
+            if pattern in name:
+                matched.add(tag)
+                break
+    return matched
+
+
+def _layer2_animations(
+    submod: SubMod, existing: set[TagCategory]
+) -> set[TagCategory]:
+    """Layer 2: animation filename pattern voting.
+
+    Each animation filename is classified into zero or more categories.
+    A tag is applied only if >= 30% of the submod's animations match it.
+    """
+    if not submod.animations:
+        return set()
+
+    total = len(submod.animations)
+    votes: dict[TagCategory, int] = {}
+
+    for anim in submod.animations:
+        for tag in _classify_animation(anim):
+            votes[tag] = votes.get(tag, 0) + 1
+
+    tags: set[TagCategory] = set()
+    for tag, count in votes.items():
+        if count / total >= _ANIM_VOTE_THRESHOLD:
+            tags.add(tag)
+
+    return tags
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_tag_engine.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oar_priority_manager/core/tag_engine.py tests/unit/test_tag_engine.py
+git commit -m "feat: implement Layer 2 animation pattern voting for tag engine (#73)"
+```
+
+---
+
+### Task 4: Layer 3 — Condition Type Refinement
+
+**Files:**
+- Modify: `src/oar_priority_manager/core/tag_engine.py`
+- Modify: `tests/unit/test_tag_engine.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_tag_engine.py`:
+
+```python
+class TestLayer3Conditions:
+    """Layer 3: condition type refinement with precondition filter."""
+
+    def test_distinctive_issneaking_always_tags(self):
+        """IsSneaking is distinctive — tags Sneak even with 8+ condition types."""
+        sm = _make_submod(
+            condition_types_present={
+                "IsSneaking", "IsEquippedType", "IsWornInSlotHasKeyword",
+                "HasMagicEffect", "IsActorBase", "IsClass", "HasPerk",
+                "CompareValues", "HasKeyword",
+            },
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.SNEAK in tags
+
+    def test_distinctive_isfemale_always_tags(self):
+        sm = _make_submod(
+            condition_types_present={"IsFemale", "IsEquippedType", "IsWornInSlotHasKeyword",
+                                      "HasMagicEffect", "IsClass", "HasPerk",
+                                      "CompareValues", "HasKeyword", "IsActorBase"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+
+    def test_distinctive_ischild_always_tags_npc(self):
+        sm = _make_submod(
+            condition_types_present={"IsChild", "IsEquippedType", "IsWornInSlotHasKeyword",
+                                      "HasMagicEffect", "IsClass", "HasPerk",
+                                      "CompareValues", "HasKeyword", "IsActorBase"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_nondistinctive_with_few_conditions_tags(self):
+        """IsEquippedType with <=3 total conditions should tag Equipment."""
+        sm = _make_submod(
+            condition_types_present={"IsEquippedType", "IsWeaponDrawn"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.EQUIPMENT in tags
+
+    def test_nondistinctive_with_many_conditions_skipped(self):
+        """IsEquippedType with 8+ total conditions is a precondition — skip."""
+        sm = _make_submod(
+            condition_types_present={
+                "IsEquippedType", "IsWornInSlotHasKeyword", "HasMagicEffect",
+                "IsActorBase", "IsClass", "HasPerk", "CompareValues",
+                "HasKeyword",
+            },
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.EQUIPMENT not in tags
+
+    def test_combat_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"IsInCombat", "IsCombatState"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_magic_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"HasMagicEffect", "HasSpell"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.MAGIC in tags
+
+    def test_npc_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"IsActorBase", "IsRace"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_furniture_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"SitSleepState", "CurrentFurniture"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.FURNITURE in tags
+
+    def test_movement_distinctive_isonmount(self):
+        sm = _make_submod(
+            condition_types_present={
+                "IsOnMount", "IsEquippedType", "IsWornInSlotHasKeyword",
+                "HasMagicEffect", "IsActorBase", "IsClass", "HasPerk",
+                "CompareValues", "HasKeyword",
+            },
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.MOVEMENT in tags
+
+    def test_layer3_skips_already_tagged(self):
+        """If Layer 1 already tagged Combat, Layer 3 should not re-add it."""
+        sm = _make_submod(
+            mo2_mod="Combat Animation Overhaul",
+            condition_types_present={"IsInCombat"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+        # Should be exactly 1 Combat tag, not duplicated
+        assert tags.count(TagCategory.COMBAT) if isinstance(tags, list) else True
+
+    def test_ignored_conditions(self):
+        """IED_*, SDS_*, PRESET, AND, OR should not produce tags."""
+        sm = _make_submod(
+            condition_types_present={
+                "IED_GearNodeEquippedPlacementHint", "SDS_IsShieldOnBackEnabled",
+                "PRESET",
+            },
+        )
+        tags = compute_tags(sm)
+        assert len(tags) == 0
+
+    def test_negated_isfemale_skipped(self):
+        """IsFemale that is negated should NOT tag Gender (it's a filter, not purpose)."""
+        sm = _make_submod(
+            condition_types_present={"IsFemale"},
+            condition_types_negated={"IsFemale"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER not in tags
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_tag_engine.py::TestLayer3Conditions -v`
+Expected: Most fail (condition layer returns empty sets)
+
+- [ ] **Step 3: Implement _layer3_conditions**
+
+Replace the `_layer3_conditions` stub in `src/oar_priority_manager/core/tag_engine.py`:
+
+```python
+# Conditions ignored during tag computation (non-standard plugins, structural).
+_IGNORED_CONDITION_PREFIXES: tuple[str, ...] = ("IED_", "SDS_")
+_IGNORED_CONDITIONS: frozenset[str] = frozenset({"AND", "OR", "PRESET"})
+
+# Distinctive conditions — always count regardless of total condition count.
+_DISTINCTIVE_CONDITIONS: dict[str, TagCategory] = {
+    "IsSneaking": TagCategory.SNEAK,
+    "IsFemale": TagCategory.GENDER,
+    "IsChild": TagCategory.NPC,
+    "IsOnMount": TagCategory.MOVEMENT,
+}
+
+# Non-distinctive conditions — only count if submod has <= 3 unique condition types.
+_NON_DISTINCTIVE_CONDITIONS: dict[str, TagCategory] = {
+    "IsEquippedType": TagCategory.EQUIPMENT,
+    "IsWornInSlotHasKeyword": TagCategory.EQUIPMENT,
+    "IsInCombat": TagCategory.COMBAT,
+    "IsCombatState": TagCategory.COMBAT,
+    "IsAttacking": TagCategory.COMBAT,
+    "IsBlocking": TagCategory.COMBAT,
+    "IsRunning": TagCategory.MOVEMENT,
+    "IsSprinting": TagCategory.MOVEMENT,
+    "HasMagicEffect": TagCategory.MAGIC,
+    "HasSpell": TagCategory.MAGIC,
+    "IsActorBase": TagCategory.NPC,
+    "IsRace": TagCategory.NPC,
+    "IsClass": TagCategory.NPC,
+    "IsVoiceType": TagCategory.NPC,
+    "SitSleepState": TagCategory.FURNITURE,
+    "CurrentFurniture": TagCategory.FURNITURE,
+    "CurrentFurnitureHasKeyword": TagCategory.FURNITURE,
+}
+
+# Maximum number of unique condition types for non-distinctive rules to fire.
+_FEW_CONDITIONS_THRESHOLD: int = 3
+
+
+def _layer3_conditions(
+    submod: SubMod, existing: set[TagCategory]
+) -> set[TagCategory]:
+    """Layer 3: condition type refinement with precondition filter.
+
+    Only adds tags NOT already present from layers 1-2. Distinctive
+    conditions always count; non-distinctive only count when the submod
+    has few unique condition types (likely definitional, not preconditions).
+    """
+    # Filter out ignored conditions for counting purposes.
+    relevant = {
+        ct for ct in submod.condition_types_present
+        if ct not in _IGNORED_CONDITIONS
+        and not any(ct.startswith(p) for p in _IGNORED_CONDITION_PREFIXES)
+    }
+
+    if not relevant:
+        return set()
+
+    tags: set[TagCategory] = set()
+    few_conditions = len(relevant) <= _FEW_CONDITIONS_THRESHOLD
+
+    for ct in relevant:
+        # Distinctive conditions — always count
+        if ct in _DISTINCTIVE_CONDITIONS:
+            tag = _DISTINCTIVE_CONDITIONS[ct]
+            # Special case: IsFemale only counts if NOT negated
+            if ct == "IsFemale" and ct in submod.condition_types_negated:
+                continue
+            if tag not in existing:
+                tags.add(tag)
+
+        # Non-distinctive conditions — only count with few conditions
+        elif few_conditions and ct in _NON_DISTINCTIVE_CONDITIONS:
+            tag = _NON_DISTINCTIVE_CONDITIONS[ct]
+            if tag not in existing:
+                tags.add(tag)
+
+    return tags
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_tag_engine.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oar_priority_manager/core/tag_engine.py tests/unit/test_tag_engine.py
+git commit -m "feat: implement Layer 3 condition type refinement for tag engine (#73)"
+```
+
+---
+
+### Task 5: SubMod.tags Field and AppConfig.tag_overrides
+
+**Files:**
+- Modify: `src/oar_priority_manager/core/models.py`
+- Modify: `src/oar_priority_manager/app/config.py`
+- Modify: `tests/unit/test_config.py`
+
+- [ ] **Step 1: Write the failing test for AppConfig**
+
+Add to `tests/unit/test_config.py`:
+
+```python
+class TestTagOverrides:
+    def test_tag_overrides_default_empty(self):
+        config = AppConfig()
+        assert config.tag_overrides == {}
+
+    def test_tag_overrides_round_trip(self, tmp_path):
+        config = AppConfig(tag_overrides={
+            "TestMod/Replacer/Sub1": ["combat", "npc"],
+            "OtherMod/Rep/Sub2": ["nsfw"],
+        })
+        path = tmp_path / "config.json"
+        save_config(config, path)
+        loaded = load_config(path)
+        assert loaded.tag_overrides == {
+            "TestMod/Replacer/Sub1": ["combat", "npc"],
+            "OtherMod/Rep/Sub2": ["nsfw"],
+        }
+
+    def test_tag_overrides_missing_from_file(self, tmp_path):
+        """Old config files without tag_overrides should load with empty dict."""
+        path = tmp_path / "config.json"
+        path.write_text('{"submod_sort": "priority"}', encoding="utf-8")
+        loaded = load_config(path)
+        assert loaded.tag_overrides == {}
+```
+
+Add the necessary imports at the top of `test_config.py`:
+
+```python
+from oar_priority_manager.app.config import AppConfig, load_config, save_config
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_config.py::TestTagOverrides -v`
+Expected: `AttributeError: 'AppConfig' has no attribute 'tag_overrides'`
+
+- [ ] **Step 3: Add tags field to SubMod**
+
+In `src/oar_priority_manager/core/models.py`, add after line 51 (`warnings: list[str] = ...`):
+
+```python
+    tags: set = field(default_factory=set)
+```
+
+Note: Type is `set` (not `set[TagCategory]`) to avoid a circular import between `models.py` and `tag_engine.py`. The tag engine populates it with `TagCategory` values at runtime.
+
+- [ ] **Step 4: Add tag_overrides to AppConfig**
+
+In `src/oar_priority_manager/app/config.py`, add to `AppConfig` after `last_selected_path`:
+
+```python
+    tag_overrides: dict[str, list[str]] = field(default_factory=dict)
+```
+
+Update `load_config` to read the new field — add after the `last_selected_path` line in the `AppConfig(...)` constructor call:
+
+```python
+            tag_overrides=data.get("tag_overrides", {}),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_config.py -v`
+Expected: All tests PASS (including new TestTagOverrides)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pytest -v`
+Expected: All existing tests still PASS (adding a defaulted field doesn't break anything)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/oar_priority_manager/core/models.py src/oar_priority_manager/app/config.py tests/unit/test_config.py
+git commit -m "feat: add SubMod.tags field and AppConfig.tag_overrides (#73)"
+```
+
+---
+
+### Task 6: Wire Tag Computation into Scan Pipeline
+
+**Files:**
+- Modify: `src/oar_priority_manager/app/main.py`
+- Modify: `tests/unit/test_tag_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_tag_engine.py`:
+
+```python
+class TestComputeTagsMultiLayer:
+    """Integration: tags accumulate across layers."""
+
+    def test_keyword_plus_animation_tags(self):
+        """Layer 1 keyword + Layer 2 animation should combine."""
+        sm = _make_submod(
+            mo2_mod="Dynamic Female Weather Idles",
+            animations=["mt_idle.hkx", "idle_front.hkx", "idle_rain.hkx"],
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags  # Layer 1
+        assert TagCategory.IDLE in tags    # Layer 2
+
+    def test_keyword_plus_condition_tags(self):
+        """Layer 1 + Layer 3 should combine."""
+        sm = _make_submod(
+            mo2_mod="NPC Animation Remix",
+            condition_types_present={"IsSneaking"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags    # Layer 1
+        assert TagCategory.SNEAK in tags  # Layer 3
+
+    def test_all_three_layers_combine(self):
+        sm = _make_submod(
+            mo2_mod="Female Combat Pack",
+            animations=["1hm_attack1.hkx", "1hm_attack2.hkx", "1hm_attack3.hkx"],
+            condition_types_present={"IsSneaking"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags   # Layer 1 (female)
+        assert TagCategory.COMBAT in tags   # Layer 1 (combat) + Layer 2 (attack anims)
+        assert TagCategory.SNEAK in tags    # Layer 3 (IsSneaking)
+```
+
+- [ ] **Step 2: Run test to verify it passes** (these should pass already since layers are implemented)
+
+Run: `pytest tests/unit/test_tag_engine.py::TestComputeTagsMultiLayer -v`
+Expected: All PASS
+
+- [ ] **Step 3: Wire compute_tags into run_scan**
+
+In `src/oar_priority_manager/app/main.py`, add import at line 23 (after the `extract_condition_types` import):
+
+```python
+from oar_priority_manager.core.tag_engine import compute_tags
+```
+
+Then in `run_scan()`, add after line 61 (`sm.condition_types_negated = negated`):
+
+```python
+        sm.tags = compute_tags(sm)
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oar_priority_manager/app/main.py tests/unit/test_tag_engine.py
+git commit -m "feat: wire tag computation into scan pipeline (#73)"
+```
+
+---
+
+### Task 7: Tag Pill Delegate for Tree Panel
+
+**Files:**
+- Create: `src/oar_priority_manager/ui/tag_delegate.py`
+- Modify: `src/oar_priority_manager/ui/tree_panel.py`
+
+- [ ] **Step 1: Create TagDelegate**
+
+Create `src/oar_priority_manager/ui/tag_delegate.py`:
+
+```python
+"""Custom tree item delegate that paints category tag pills.
+
+Renders colored pills after the display name in each tree row.
+Uses TagCategory color metadata for the muted palette.
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QRect, QSize, Qt
+from PySide6.QtGui import QBrush, QColor, QFont, QFontMetrics, QPainter, QPen
+from PySide6.QtWidgets import QStyle, QStyledItemDelegate, QStyleOptionViewItem, QTreeWidgetItem
+
+from oar_priority_manager.core.tag_engine import TagCategory
+from oar_priority_manager.ui.tree_model import NodeType, TreeNode
+
+# Custom data role to store tags on QTreeWidgetItem
+TAG_DATA_ROLE: int = Qt.ItemDataRole.UserRole + 100
+# Custom data role to store override indicator
+TAG_OVERRIDE_ROLE: int = Qt.ItemDataRole.UserRole + 101
+
+# Pill layout constants
+_PILL_H_PAD: int = 6
+_PILL_V_PAD: int = 2
+_PILL_GAP: int = 3
+_PILL_RADIUS: int = 6
+_PILL_FONT_SIZE: int = 9
+_PILL_LEFT_MARGIN: int = 8
+_MAX_MOD_PILLS: int = 4
+
+
+def sorted_tags(tags: set[TagCategory]) -> list[TagCategory]:
+    """Sort tags by sort_order for consistent display."""
+    return sorted(tags, key=lambda t: t.sort_order)
+
+
+class TagDelegate(QStyledItemDelegate):
+    """Delegate that paints tag pills to the right of the item text."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._pill_font = QFont()
+        self._pill_font.setPixelSize(_PILL_FONT_SIZE)
+        self._pill_font.setBold(True)
+        self._pill_fm = QFontMetrics(self._pill_font)
+
+    def _get_tags(self, index) -> list[TagCategory]:
+        """Retrieve sorted tags from item data."""
+        tags = index.data(TAG_DATA_ROLE)
+        if not tags:
+            return []
+        return sorted_tags(tags) if isinstance(tags, set) else []
+
+    def _pill_width(self, label: str) -> int:
+        """Width of a single pill including padding."""
+        return self._pill_fm.horizontalAdvance(label) + 2 * _PILL_H_PAD
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index,
+    ) -> None:
+        """Paint the default item, then overlay tag pills."""
+        # Draw default content (icon, text, selection highlight)
+        super().paint(painter, option, index)
+
+        tags = self._get_tags(index)
+        if not tags:
+            return
+
+        is_override = index.data(TAG_OVERRIDE_ROLE)
+
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setFont(self._pill_font)
+
+        # Calculate pill start position: right-align within the item rect
+        rect = option.rect
+        pill_h = self._pill_fm.height() + 2 * _PILL_V_PAD
+        y = rect.top() + (rect.height() - pill_h) // 2
+
+        # Calculate total pills width to right-align
+        total_width = 0
+        for tag in tags:
+            total_width += self._pill_width(tag.label) + _PILL_GAP
+        if is_override:
+            total_width += self._pill_fm.horizontalAdvance("\u270E ") + _PILL_GAP
+        total_width -= _PILL_GAP  # Remove trailing gap
+
+        x = rect.right() - total_width - _PILL_LEFT_MARGIN
+
+        # Draw override indicator (pencil)
+        if is_override:
+            painter.setPen(QColor("#888888"))
+            painter.drawText(
+                x,
+                y + _PILL_V_PAD + self._pill_fm.ascent(),
+                "\u270E",
+            )
+            x += self._pill_fm.horizontalAdvance("\u270E ") + _PILL_GAP
+
+        # Draw each pill
+        for tag in tags:
+            w = self._pill_width(tag.label)
+            pill_rect = QRect(x, y, w, pill_h)
+
+            # Background
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QBrush(QColor(tag.color_bg)))
+            painter.drawRoundedRect(pill_rect, _PILL_RADIUS, _PILL_RADIUS)
+
+            # Border
+            painter.setPen(QPen(QColor(tag.color_border), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(pill_rect, _PILL_RADIUS, _PILL_RADIUS)
+
+            # Text
+            painter.setPen(QColor(tag.color_fg))
+            painter.drawText(
+                pill_rect,
+                Qt.AlignmentFlag.AlignCenter,
+                tag.label,
+            )
+
+            x += w + _PILL_GAP
+
+        painter.restore()
+
+    def sizeHint(
+        self,
+        option: QStyleOptionViewItem,
+        index,
+    ) -> QSize:
+        """Expand width to accommodate pills."""
+        size = super().sizeHint(option, index)
+        tags = self._get_tags(index)
+        if tags:
+            extra = _PILL_LEFT_MARGIN
+            for tag in tags:
+                extra += self._pill_width(tag.label) + _PILL_GAP
+            size.setWidth(size.width() + extra)
+        return size
+```
+
+- [ ] **Step 2: Wire delegate into TreePanel**
+
+In `src/oar_priority_manager/ui/tree_panel.py`, add imports:
+
+```python
+from oar_priority_manager.ui.tag_delegate import TagDelegate, TAG_DATA_ROLE, TAG_OVERRIDE_ROLE, sorted_tags, _MAX_MOD_PILLS
+from oar_priority_manager.core.tag_engine import TagCategory
+```
+
+In `_setup_ui()`, after `self._tree.setHeaderHidden(True)`, add:
+
+```python
+        self._tag_delegate = TagDelegate(self._tree)
+        self._tree.setItemDelegate(self._tag_delegate)
+```
+
+In `_populate()`, update the submod item creation to store tags. After creating `sub_item`:
+
+```python
+                    if sm and sm.tags:
+                        sub_item.setData(0, TAG_DATA_ROLE, sm.tags)
+```
+
+After creating `mod_item` and adding all its children, compute rollup tags. Replace the `self._tree.addTopLevelItem(mod_item)` section:
+
+```python
+            # Compute mod-level rollup tags (union of all submod tags)
+            mod_tags: set[TagCategory] = set()
+            for rep_node in mod_node.children:
+                for sub_node in rep_node.children:
+                    if sub_node.submod and sub_node.submod.tags:
+                        mod_tags.update(sub_node.submod.tags)
+            if mod_tags:
+                # Limit to max pills for mod rows
+                display_tags = sorted_tags(mod_tags)[:_MAX_MOD_PILLS]
+                mod_item.setData(0, TAG_DATA_ROLE, set(display_tags))
+
+            self._tree.addTopLevelItem(mod_item)
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/oar_priority_manager/ui/tag_delegate.py src/oar_priority_manager/ui/tree_panel.py
+git commit -m "feat: add TagDelegate for pill rendering in tree panel (#73)"
+```
+
+---
+
+### Task 8: Tag Edit Dialog
+
+**Files:**
+- Create: `src/oar_priority_manager/ui/tag_edit_dialog.py`
+
+- [ ] **Step 1: Create the dialog**
+
+Create `src/oar_priority_manager/ui/tag_edit_dialog.py`:
+
+```python
+"""Dialog for manually editing category tags on a mod or submod.
+
+Displays checkboxes for each TagCategory with colored pill previews.
+Provides a "Reset to Auto" button to clear manual overrides.
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from oar_priority_manager.core.tag_engine import TagCategory
+from oar_priority_manager.ui.tag_delegate import sorted_tags
+
+
+def _pill_html(tag: TagCategory) -> str:
+    """Render a single tag as an HTML pill span."""
+    return (
+        f'<span style="'
+        f"background:{tag.color_bg};"
+        f"color:{tag.color_fg};"
+        f"border:1px solid {tag.color_border};"
+        f"border-radius:6px;"
+        f"padding:1px 6px;"
+        f"font-size:10px;"
+        f"font-weight:bold;"
+        f'">{tag.label}</span>'
+    )
+
+
+class TagEditDialog(QDialog):
+    """Modal dialog for editing tags on a tree node.
+
+    Args:
+        current_tags: The currently active tags (auto or override).
+        is_override: Whether the current tags are a manual override.
+        parent: Parent widget.
+    """
+
+    def __init__(
+        self,
+        current_tags: set[TagCategory],
+        is_override: bool,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Edit Tags")
+        self.setMinimumWidth(300)
+        self._reset_requested = False
+
+        layout = QVBoxLayout(self)
+
+        # Info label
+        if is_override:
+            info = QLabel(
+                '<span style="color:#888">These tags are manually set. '
+                'Click "Reset to Auto" to revert to auto-detected tags.</span>'
+            )
+        else:
+            info = QLabel(
+                '<span style="color:#888">Check/uncheck tags to override '
+                "auto-detection for this item.</span>"
+            )
+        info.setTextFormat(Qt.TextFormat.RichText)
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        # Checkboxes — one per tag category
+        self._checkboxes: dict[TagCategory, QCheckBox] = {}
+        for tag in sorted_tags(set(TagCategory)):
+            row = QHBoxLayout()
+            cb = QCheckBox()
+            cb.setChecked(tag in current_tags)
+            self._checkboxes[tag] = cb
+            row.addWidget(cb)
+
+            pill_label = QLabel(_pill_html(tag))
+            pill_label.setTextFormat(Qt.TextFormat.RichText)
+            row.addWidget(pill_label)
+
+            row.addStretch()
+            layout.addLayout(row)
+
+        # Reset button
+        reset_btn = QPushButton("Reset to Auto")
+        reset_btn.setToolTip("Clear manual override and revert to auto-detected tags")
+        reset_btn.clicked.connect(self._on_reset)
+        layout.addWidget(reset_btn)
+
+        # OK / Cancel
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def _on_reset(self) -> None:
+        """Handle Reset to Auto button click."""
+        self._reset_requested = True
+        self.accept()
+
+    @property
+    def reset_requested(self) -> bool:
+        """True if user clicked Reset to Auto instead of OK."""
+        return self._reset_requested
+
+    def selected_tags(self) -> set[TagCategory]:
+        """Return the set of checked tag categories."""
+        return {tag for tag, cb in self._checkboxes.items() if cb.isChecked()}
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS (dialog is new, no existing tests break)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/oar_priority_manager/ui/tag_edit_dialog.py
+git commit -m "feat: add TagEditDialog for manual tag editing (#73)"
+```
+
+---
+
+### Task 9: Context Menu and Tag Override Persistence
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/tree_panel.py`
+- Modify: `src/oar_priority_manager/ui/main_window.py`
+
+- [ ] **Step 1: Read main_window.py to understand the app_config wiring**
+
+Read `src/oar_priority_manager/ui/main_window.py` to see how `app_config` is passed around and how context menus are set up.
+
+- [ ] **Step 2: Add context menu to TreePanel**
+
+In `src/oar_priority_manager/ui/tree_panel.py`, add imports:
+
+```python
+from PySide6.QtWidgets import QMenu
+from PySide6.QtCore import QPoint
+from oar_priority_manager.app.config import AppConfig
+from oar_priority_manager.ui.tag_edit_dialog import TagEditDialog
+```
+
+Update `__init__` to accept `app_config`:
+
+```python
+    def __init__(
+        self,
+        submods: list[SubMod],
+        app_config: AppConfig | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._submods = submods
+        self._app_config = app_config
+        self._root = build_tree(submods)
+        self._setup_ui()
+        self._populate()
+```
+
+In `_setup_ui()`, add after `layout.addWidget(self._tree)`:
+
+```python
+        self._tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._tree.customContextMenuRequested.connect(self._on_context_menu)
+```
+
+Add the context menu methods:
+
+```python
+    def _on_context_menu(self, pos: QPoint) -> None:
+        """Show context menu with 'Edit Tags...' action."""
+        item = self._tree.itemAt(pos)
+        if item is None:
+            return
+        node = self._item_map.get(id(item))
+        if node is None or node.node_type == NodeType.ROOT:
+            return
+
+        menu = QMenu(self)
+        edit_tags_action = menu.addAction("Edit Tags...")
+        action = menu.exec(self._tree.viewport().mapToGlobal(pos))
+        if action == edit_tags_action:
+            self._edit_tags(item, node)
+
+    def _edit_tags(self, item: QTreeWidgetItem, node: TreeNode) -> None:
+        """Open tag edit dialog for the given node."""
+        if self._app_config is None:
+            return
+
+        # Determine current tags and override state
+        override_key = self._get_override_key(node)
+        is_override = override_key in self._app_config.tag_overrides
+
+        if node.node_type == NodeType.SUBMOD and node.submod:
+            current_tags = node.submod.tags.copy()
+        elif node.node_type == NodeType.MOD:
+            # Rollup from children
+            current_tags: set = set()
+            for rep in node.children:
+                for sub in rep.children:
+                    if sub.submod and sub.submod.tags:
+                        current_tags.update(sub.submod.tags)
+        else:
+            return  # No tag editing for replacer nodes
+
+        # Apply override if exists
+        if is_override:
+            override_names = self._app_config.tag_overrides[override_key]
+            current_tags = {
+                tag for tag in TagCategory
+                if tag.label.lower() in [n.lower() for n in override_names]
+            }
+
+        dialog = TagEditDialog(current_tags, is_override, self)
+        if dialog.exec() != TagEditDialog.DialogCode.Accepted:
+            return
+
+        if dialog.reset_requested:
+            # Remove override
+            self._app_config.tag_overrides.pop(override_key, None)
+            # Restore auto-detected tags on the tree item
+            if node.node_type == NodeType.SUBMOD and node.submod:
+                from oar_priority_manager.core.tag_engine import compute_tags
+                node.submod.tags = compute_tags(node.submod)
+                item.setData(0, TAG_DATA_ROLE, node.submod.tags)
+                item.setData(0, TAG_OVERRIDE_ROLE, None)
+        else:
+            # Save override
+            selected = dialog.selected_tags()
+            override_list = [tag.label.lower() for tag in sorted_tags(selected)]
+            self._app_config.tag_overrides[override_key] = override_list
+
+            # Update tree item
+            if node.node_type == NodeType.SUBMOD and node.submod:
+                node.submod.tags = selected
+            item.setData(0, TAG_DATA_ROLE, selected)
+            item.setData(0, TAG_OVERRIDE_ROLE, True)
+
+        # Refresh parent mod rollup if editing a submod
+        if node.node_type == NodeType.SUBMOD and node.parent and node.parent.parent:
+            self._refresh_mod_rollup(node.parent.parent)
+
+        self._tree.viewport().update()
+
+    def _get_override_key(self, node: TreeNode) -> str:
+        """Build the config key for tag overrides."""
+        if node.node_type == NodeType.SUBMOD and node.submod:
+            return f"{node.submod.mo2_mod}/{node.submod.replacer}/{node.submod.name}"
+        elif node.node_type == NodeType.MOD:
+            return f"mod:{node.display_name}"
+        return ""
+
+    def _refresh_mod_rollup(self, mod_node: TreeNode) -> None:
+        """Recompute and update tag rollup for a mod-level tree item."""
+        # Find the QTreeWidgetItem for this mod_node
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            if self._item_map.get(id(item)) is mod_node:
+                mod_tags: set[TagCategory] = set()
+                for rep in mod_node.children:
+                    for sub in rep.children:
+                        if sub.submod and sub.submod.tags:
+                            mod_tags.update(sub.submod.tags)
+                if mod_tags:
+                    display = sorted_tags(mod_tags)[:_MAX_MOD_PILLS]
+                    item.setData(0, TAG_DATA_ROLE, set(display))
+                else:
+                    item.setData(0, TAG_DATA_ROLE, None)
+                break
+```
+
+- [ ] **Step 3: Update MainWindow to pass app_config to TreePanel**
+
+Read `main_window.py` and find where `TreePanel` is constructed. Add `app_config=self._app_config` to the constructor call.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS. Some existing tests may need `app_config=None` added to TreePanel constructor calls if they use positional args — check and fix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oar_priority_manager/ui/tree_panel.py src/oar_priority_manager/ui/main_window.py
+git commit -m "feat: add context menu tag editing with override persistence (#73)"
+```
+
+---
+
+### Task 10: Details Panel Tags Section
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/details_panel.py`
+
+- [ ] **Step 1: Read the full details_panel.py**
+
+Read the file to see exactly where to insert tag display in `_render_submod()` and `_render_mod()`.
+
+- [ ] **Step 2: Add tag pill HTML rendering**
+
+Add a helper method to `DetailsPanel`:
+
+```python
+    @staticmethod
+    def _render_tag_pills(tags: set) -> str:
+        """Render tags as HTML pills for the details panel."""
+        from oar_priority_manager.core.tag_engine import TagCategory
+        from oar_priority_manager.ui.tag_delegate import sorted_tags
+
+        if not tags:
+            return '<span style="color:#666">None detected</span>'
+
+        pills = []
+        for tag in sorted_tags(tags):
+            if isinstance(tag, TagCategory):
+                pills.append(
+                    f'<span style="'
+                    f"background:{tag.color_bg};"
+                    f"color:{tag.color_fg};"
+                    f"border:1px solid {tag.color_border};"
+                    f"border-radius:6px;"
+                    f"padding:1px 6px;"
+                    f"font-size:10px;"
+                    f"font-weight:bold;"
+                    f'">{tag.label}</span>'
+                )
+        return " ".join(pills)
+```
+
+- [ ] **Step 3: Add tags to _render_submod**
+
+In `_render_submod()`, add a tags line in the HTML output (after the condition count line):
+
+```python
+        tags_html = self._render_tag_pills(node.submod.tags)
+        lines.append(f"<b>Tags:</b> {tags_html}")
+```
+
+- [ ] **Step 4: Add tags to _render_mod**
+
+In `_render_mod()`, compute rollup tags and display:
+
+```python
+        mod_tags: set = set()
+        for rep in node.children:
+            for sub in rep.children:
+                if sub.submod and sub.submod.tags:
+                    mod_tags.update(sub.submod.tags)
+        tags_html = self._render_tag_pills(mod_tags)
+        lines.append(f"<b>Tags:</b> {tags_html}")
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/oar_priority_manager/ui/details_panel.py
+git commit -m "feat: display tag pills in details panel (#73)"
+```
+
+---
+
+### Task 11: Search Index Tag Integration
+
+**Files:**
+- Modify: `src/oar_priority_manager/ui/tree_model.py`
+- Modify: `tests/unit/test_tree_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_tree_model.py`:
+
+```python
+class TestSearchIndexTags:
+    def test_search_by_tag_name(self):
+        """Searching 'combat' should match submods tagged Combat."""
+        from oar_priority_manager.core.tag_engine import TagCategory
+
+        sm = SubMod(
+            mo2_mod="Test Mod",
+            replacer="Rep",
+            name="test_sub",
+            description="",
+            priority=100,
+            source_priority=100,
+            disabled=False,
+            config_path=Path("/fake/config.json"),
+            override_source=OverrideSource.SOURCE,
+            override_is_ours=False,
+            raw_dict={},
+            tags={TagCategory.COMBAT},
+        )
+        root = build_tree([sm])
+        index = SearchIndex(root, {})
+        results = index.search("combat")
+        assert len(results) >= 1
+        assert any(r.node.submod is sm for r in results)
+
+    def test_search_tag_case_insensitive(self):
+        from oar_priority_manager.core.tag_engine import TagCategory
+
+        sm = SubMod(
+            mo2_mod="Test Mod",
+            replacer="Rep",
+            name="test_sub",
+            description="",
+            priority=100,
+            source_priority=100,
+            disabled=False,
+            config_path=Path("/fake/config.json"),
+            override_source=OverrideSource.SOURCE,
+            override_is_ours=False,
+            raw_dict={},
+            tags={TagCategory.NSFW},
+        )
+        root = build_tree([sm])
+        index = SearchIndex(root, {})
+        results = index.search("nsfw")
+        assert len(results) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_tree_model.py::TestSearchIndexTags -v`
+Expected: FAIL (tag names not indexed)
+
+- [ ] **Step 3: Extend SearchIndex to index tag names**
+
+In `src/oar_priority_manager/ui/tree_model.py`, in `SearchIndex._build()`, inside the `_walk` function, after the `self._submod_node_map[id(node.submod)] = node` line, add:
+
+```python
+                # Index tag names for tag-based search
+                if node.submod.tags:
+                    for tag in node.submod.tags:
+                        tag_result = SearchResult(
+                            display_text=f"[{tag.label}] {node.display_name}",
+                            node_type=node.node_type,
+                            node=node,
+                        )
+                        self._entries.append((tag.label.lower(), tag_result))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_tree_model.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/oar_priority_manager/ui/tree_model.py tests/unit/test_tree_model.py
+git commit -m "feat: extend search index to match tag names (#73)"
+```
+
+---
+
+### Task 12: Apply Tag Overrides on Load
+
+**Files:**
+- Modify: `src/oar_priority_manager/app/main.py`
+- Modify: `tests/unit/test_tag_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_tag_engine.py`:
+
+```python
+from oar_priority_manager.core.tag_engine import apply_overrides
+
+
+class TestApplyOverrides:
+    def test_override_replaces_auto_tags(self):
+        sm = _make_submod(
+            mo2_mod="Test Mod",
+            replacer="Rep",
+            name="sub1",
+            animations=["1hm_attack1.hkx", "1hm_attack2.hkx", "1hm_attack3.hkx"],
+        )
+        sm.tags = compute_tags(sm)
+        assert TagCategory.COMBAT in sm.tags
+
+        overrides = {"Test Mod/Rep/sub1": ["nsfw", "gender"]}
+        apply_overrides([sm], overrides)
+        assert sm.tags == {TagCategory.NSFW, TagCategory.GENDER}
+
+    def test_no_override_keeps_auto_tags(self):
+        sm = _make_submod(
+            animations=["1hm_attack1.hkx", "1hm_attack2.hkx", "1hm_attack3.hkx"],
+        )
+        sm.tags = compute_tags(sm)
+        original = sm.tags.copy()
+
+        apply_overrides([sm], {})
+        assert sm.tags == original
+
+    def test_override_key_format(self):
+        sm = _make_submod(
+            mo2_mod="My Mod",
+            replacer="MyRep",
+            name="MySub",
+        )
+        sm.tags = compute_tags(sm)
+
+        overrides = {"My Mod/MyRep/MySub": ["sneak"]}
+        apply_overrides([sm], overrides)
+        assert sm.tags == {TagCategory.SNEAK}
+
+    def test_unknown_tag_name_in_override_ignored(self):
+        sm = _make_submod(mo2_mod="Test", replacer="R", name="S")
+        sm.tags = compute_tags(sm)
+
+        overrides = {"Test/R/S": ["combat", "nonexistent_tag"]}
+        apply_overrides([sm], overrides)
+        assert sm.tags == {TagCategory.COMBAT}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_tag_engine.py::TestApplyOverrides -v`
+Expected: `ImportError: cannot import name 'apply_overrides'`
+
+- [ ] **Step 3: Implement apply_overrides**
+
+Add to `src/oar_priority_manager/core/tag_engine.py`:
+
+```python
+# Lookup for tag name -> TagCategory (case-insensitive)
+_TAG_BY_NAME: dict[str, TagCategory] = {
+    tag.label.lower(): tag for tag in TagCategory
+}
+
+
+def apply_overrides(
+    submods: list[SubMod],
+    overrides: dict[str, list[str]],
+) -> None:
+    """Apply manual tag overrides from AppConfig to submods.
+
+    Overrides completely replace auto-detected tags for matching submods.
+
+    Args:
+        submods: List of SubMod instances (tags field will be mutated).
+        overrides: Dict from override key to list of tag name strings.
+    """
+    if not overrides:
+        return
+
+    for sm in submods:
+        key = f"{sm.mo2_mod}/{sm.replacer}/{sm.name}"
+        if key in overrides:
+            tag_names = overrides[key]
+            sm.tags = {
+                _TAG_BY_NAME[name.lower()]
+                for name in tag_names
+                if name.lower() in _TAG_BY_NAME
+            }
+```
+
+- [ ] **Step 4: Wire into main.py**
+
+In `src/oar_priority_manager/app/main.py`, update the import:
+
+```python
+from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
+```
+
+In `run_scan()`, after the tag computation loop, add (needs `app_config` parameter):
+
+Actually, `run_scan` doesn't have access to `app_config`. Instead, wire it in `main()` after `run_scan()` returns. After line 89 (`submods, conflict_map, stacks = run_scan(instance_root)`), add:
+
+```python
+    apply_overrides(submods, app_config.tag_overrides)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/oar_priority_manager/core/tag_engine.py src/oar_priority_manager/app/main.py tests/unit/test_tag_engine.py
+git commit -m "feat: apply tag overrides from AppConfig on load (#73)"
+```
+
+---
+
+### Task 13: Final Integration Test and Cleanup
+
+**Files:**
+- Create: `tests/integration/test_tag_integration.py`
+
+- [ ] **Step 1: Write integration tests**
+
+Create `tests/integration/test_tag_integration.py`:
+
+```python
+"""Integration tests for category tags end-to-end.
+
+Tests the full pipeline: scan → extract conditions → compute tags → apply overrides.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from oar_priority_manager.app.config import AppConfig, load_config, save_config
+from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.tag_engine import (
+    TagCategory,
+    apply_overrides,
+    compute_tags,
+)
+from oar_priority_manager.ui.tree_model import SearchIndex, build_tree
+
+
+def _make_submod_with_conditions(
+    mo2_mod: str,
+    replacer: str,
+    name: str,
+    conditions: list,
+    animations: list[str] | None = None,
+) -> SubMod:
+    """Create a SubMod with conditions already extracted."""
+    sm = SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path(f"/fake/{mo2_mod}/{replacer}/{name}/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        animations=animations or [],
+        conditions=conditions,
+    )
+    present, negated = extract_condition_types(conditions)
+    sm.condition_types_present = present
+    sm.condition_types_negated = negated
+    sm.tags = compute_tags(sm)
+    return sm
+
+
+class TestEndToEnd:
+    def test_combat_mod_tagged_correctly(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Combat Animation Overhaul",
+            replacer="CAO",
+            name="power_attacks",
+            conditions=[
+                {"condition": "IsWeaponDrawn", "negated": False},
+            ],
+            animations=[
+                "1hm_attackpower.hkx",
+                "1hm_attackpowerfwd.hkx",
+                "1hm_attackpowerleft.hkx",
+            ],
+        )
+        assert TagCategory.COMBAT in sm.tags
+
+    def test_female_idle_mod_gets_two_tags(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Dynamic Female Weather Idles",
+            replacer="WeatherIdles",
+            name="rain_idle",
+            conditions=[
+                {"condition": "IsFemale", "negated": False},
+            ],
+            animations=[
+                "mt_idle.hkx",
+                "idle_front.hkx",
+            ],
+        )
+        assert TagCategory.GENDER in sm.tags
+        assert TagCategory.IDLE in sm.tags
+
+    def test_nsfw_detected_from_folder_name(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Dynamic Feminine Female Modesty Animations OAR",
+            replacer="KP_nudeNPC",
+            name="npc_both_fre",
+            conditions=[],
+        )
+        assert TagCategory.NSFW in sm.tags
+        assert TagCategory.GENDER in sm.tags
+
+
+class TestOverrideRoundTrip:
+    def test_save_load_overrides(self, tmp_path):
+        config = AppConfig(tag_overrides={
+            "TestMod/Rep/Sub": ["combat", "npc"],
+        })
+        path = tmp_path / "config.json"
+        save_config(config, path)
+
+        loaded = load_config(path)
+        assert loaded.tag_overrides == {"TestMod/Rep/Sub": ["combat", "npc"]}
+
+    def test_override_applied_to_submod(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="TestMod",
+            replacer="Rep",
+            name="Sub",
+            conditions=[],
+            animations=["mt_idle.hkx", "idle_front.hkx", "idle_rain.hkx"],
+        )
+        assert TagCategory.IDLE in sm.tags
+
+        apply_overrides([sm], {"TestMod/Rep/Sub": ["combat"]})
+        assert sm.tags == {TagCategory.COMBAT}
+        assert TagCategory.IDLE not in sm.tags
+
+
+class TestSearchWithTags:
+    def test_tag_search_finds_tagged_submod(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Some Random Mod Name",
+            replacer="Rep",
+            name="sub1",
+            conditions=[{"condition": "IsSneaking", "negated": False}],
+        )
+        root = build_tree([sm])
+        index = SearchIndex(root, {})
+        results = index.search("sneak")
+        assert any(r.node.submod is sm for r in results)
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `pytest tests/integration/test_tag_integration.py -v`
+Expected: All PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_tag_integration.py
+git commit -m "test: add integration tests for category tags pipeline (#73)"
+```
+
+- [ ] **Step 5: Run linter**
+
+Run: `ruff check src/oar_priority_manager/core/tag_engine.py src/oar_priority_manager/ui/tag_delegate.py src/oar_priority_manager/ui/tag_edit_dialog.py`
+Fix any issues found.
+
+- [ ] **Step 6: Final commit if lint fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: resolve lint issues in tag engine (#73)"
+```

--- a/docs/superpowers/specs/2026-04-12-conditions-panel-design.md
+++ b/docs/superpowers/specs/2026-04-12-conditions-panel-design.md
@@ -1,0 +1,156 @@
+# Conditions Panel — Formatted View Design
+
+**Issues:** #43 (formatted conditions display), #44 (raw JSON toggle)
+**Date:** 2026-04-12
+**Status:** Approved
+
+## Overview
+
+Replace the current raw-JSON-only conditions panel (right pane) with a formatted
+tree view that renders OAR condition structures as a human-readable AND/OR/NOT
+hierarchy. A toggle switches between the formatted view (default) and raw JSON
+for power users. PRESET references resolve on demand when the user clicks to
+expand them.
+
+## Current State
+
+`conditions_panel.py` is a simple `QTextEdit` that calls
+`json.dumps(submod.conditions, indent=2)`. No parsing, no formatting, no
+preset awareness. The panel header shows
+`"Conditions · {mo2_mod} / {submod_name}"`.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Layout | Hybrid: formatted tree + JSON toggle | Readable for browsing, raw JSON for debugging configs |
+| PRESET handling | Resolve on demand in UI | Keeps data model honest; preserves shared-preset relationships |
+| Non-submod selection | Blank placeholder | YAGNI — conditions only exist on submods |
+| Unknown condition types | Generic rendering | No known-types list to maintain; all conditions rendered uniformly |
+
+## Architecture
+
+### New module: `conditions_renderer.py`
+
+A pure-logic module that converts a condition dict/list into a list of
+`RenderedNode` dataclass instances. No Qt dependency — this is testable
+without a GUI.
+
+```
+RenderedNode:
+    text: str              # e.g. "IsSneaking"
+    node_type: str         # "AND", "OR", "leaf", "preset"
+    negated: bool
+    params: dict[str, str] # extra JSON keys as key=value pairs
+    children: list[RenderedNode]
+    preset_name: str | None
+```
+
+**Public API:**
+
+- `render_conditions(conditions: dict | list) -> list[RenderedNode]`
+  Recursively walks the OAR condition tree and produces a flat/nested list of
+  `RenderedNode` objects. Each node in the input maps to one `RenderedNode`:
+  - `{"condition": "AND", "conditions": [...]}` → AND group with children
+  - `{"condition": "OR", "conditions": [...]}` → OR group with children
+  - `{"condition": "PRESET", "Preset": "name"}` → preset reference node
+  - Any other `{"condition": "X", ...}` → leaf node; extra keys become `params`
+  - `{"negated": true}` → sets `negated=True` on the node
+
+- `resolve_preset(preset_name: str, presets: dict) -> list[RenderedNode] | None`
+  Given a preset name and a replacer's `conditionPresets` dict, returns the
+  rendered condition tree for that preset, or `None` if not found.
+
+### Updated module: `conditions_panel.py`
+
+The existing `ConditionsPanel` widget gains:
+
+1. **Formatted/JSON toggle** — A `QButtonGroup` with two checkable `QPushButton`s
+   in the header area, matching the segmented toggle pattern used in `tree_panel.py`
+   (issue #45) and `stacks_panel.py` (issue #69). "Formatted" is checked by default.
+
+2. **Formatted view** — A `QTreeWidget` (or `QScrollArea` with nested `QWidget`s)
+   that renders the `RenderedNode` tree with:
+   - AND groups: blue "ALL of:" label, children indented
+   - OR groups: purple "ANY of:" label, children indented with left border line
+   - Leaf conditions: green ✓ icon + name (or red ✗ + strikethrough + NOT badge
+     if negated)
+   - Parameters: muted key=value text below the condition name
+   - PRESET references: amber ⚙ card with preset name, click to expand/collapse
+   - Stats footer: condition count, type count, negated count, preset count
+
+3. **JSON view** — The existing `QTextEdit` with `json.dumps(indent=2)`, preserved
+   as-is.
+
+4. **Placeholder state** — When no submod is selected (mod/replacer/root node),
+   shows "Select a submod to view conditions."
+
+### Data flow for PRESET resolution
+
+1. Scanner already reads replacer-level `config.json` files. We need to store
+   `conditionPresets` from these configs on a model accessible to the UI.
+2. The `TreeNode` for a REPLACER already exists in `tree_model.py`. Add an
+   optional `presets: dict` field to `TreeNode` (or to a new lightweight model)
+   populated during `build_tree()` from the replacer's `config.json`.
+3. When the user expands a PRESET card, the panel walks up to the parent
+   REPLACER `TreeNode`, reads its `presets` dict, and calls
+   `resolve_preset(name, presets)` to get the rendered subtree.
+4. If the preset name is not found in the replacer's presets, show an inline
+   warning: "Preset 'X' not found in replacer config."
+
+### Scanner changes
+
+The scanner (`scanner.py`) already reads replacer-level `config.json` for other
+purposes. It needs to:
+
+1. Extract `conditionPresets` from the replacer config dict.
+2. Store them somewhere accessible — either on a new `Replacer` model, or as a
+   dict keyed by replacer path that the UI can look up.
+
+The minimal approach: add a `condition_presets: dict` field to the existing data
+flow. The `build_tree()` function in `tree_model.py` already groups submods by
+replacer — it can attach preset data to the REPLACER-level `TreeNode`.
+
+## Rendering Rules
+
+| Input | Rendered as |
+|---|---|
+| `{"condition": "AND", "conditions": [...]}` | Blue "ALL of:" label, children indented |
+| `{"condition": "OR", "conditions": [...]}` | Purple "ANY of:" label, children indented, left border line |
+| `{"condition": "X", "negated": false, ...}` | Green ✓ + condition name, extra keys as muted params |
+| `{"condition": "X", "negated": true, ...}` | Red ✗ + strikethrough name + NOT badge, extra keys as muted params |
+| `{"condition": "PRESET", "Preset": "name"}` | Amber ⚙ PRESET card with name, click to expand |
+| Top-level list `[...]` | Treated as implicit AND group |
+| Top-level dict `{"conditions": [...]}` | Treated as AND group (or whatever `type`/`condition` key says) |
+| Empty conditions | "No conditions defined" placeholder |
+
+### Parameter display
+
+Every key in a condition dict other than `condition`, `negated`, `conditions`,
+and `Preset` is treated as a parameter. Parameters are displayed as muted
+`key = "value"` pairs on a line below the condition name, joined by ` · `.
+
+### Stats footer
+
+Below the rendered tree, a muted line shows:
+`{n} conditions · {t} types · {neg} negated · {p} presets`
+
+Preset count only shown when > 0.
+
+## What this does NOT include
+
+- Condition editing (read-only display only)
+- Condition validation or type-specific rendering
+- Aggregate condition views for mod/replacer selection
+- Advanced condition filter builder (issues #49/#50 — separate design)
+
+## Files to create or modify
+
+| File | Action |
+|---|---|
+| `src/oar_priority_manager/ui/conditions_renderer.py` | **Create** — pure-logic renderer |
+| `src/oar_priority_manager/ui/conditions_panel.py` | **Modify** — add toggle, formatted view, preset expansion |
+| `src/oar_priority_manager/core/scanner.py` | **Modify** — extract conditionPresets from replacer configs |
+| `src/oar_priority_manager/ui/tree_model.py` | **Modify** — attach presets to REPLACER TreeNodes |
+| `tests/unit/test_conditions_renderer.py` | **Create** — unit tests for render_conditions and resolve_preset |
+| `tests/unit/test_conditions_panel.py` | **Create** — widget tests for toggle, formatted view, preset expand |

--- a/docs/superpowers/specs/2026-04-14-category-tags-design.md
+++ b/docs/superpowers/specs/2026-04-14-category-tags-design.md
@@ -1,0 +1,225 @@
+# Category Tags for Mods/Submods — Design Spec
+
+**Issue:** #73
+**Date:** 2026-04-14
+**Milestone:** Alpha 2
+
+## Overview
+
+Add auto-detected category tags (colored pills) to mods and submods in the tree panel, enabling quick visual identification of what each mod does. Tags are computed from animation filenames, condition types, and folder/mod name keywords, with manual override support. Tags also integrate into search and will serve as a filter dimension for the future advanced filter builder (#49/#50).
+
+## Tag Taxonomy
+
+10 categories derived from OAR's ~110 condition types and validated against 3,086 real config files across 64 installed mods:
+
+| Tag | Sort Order | Colors (bg / fg / border) |
+|---|---|---|
+| NSFW | 0 | `#5c2d4a` / `#f0a0d0` / `#8b446e` |
+| Combat | 1 | `#5c2d2d` / `#f0a0a0` / `#8b4444` |
+| Equipment | 2 | `#3d3d3d` / `#b0b0b0` / `#5a5a5a` |
+| Furniture | 3 | `#5c4a2d` / `#f0d0a0` / `#8b6e44` |
+| Gender | 4 | `#5c5c2d` / `#f0f0a0` / `#8b8b44` |
+| Idle | 5 | `#2d5c4a` / `#a0f0d0` / `#448b6e` |
+| Magic | 6 | `#4a2d5c` / `#d0a0f0` / `#6e448b` |
+| Movement | 7 | `#2d3a5c` / `#a0b8f0` / `#44578b` |
+| NPC | 8 | `#2d4a5c` / `#a0d0f0` / `#446e8b` |
+| Sneak | 9 | `#3d2d5c` / `#b8a0f0` / `#5b448b` |
+
+Visual style: muted/subtle pills with dark backgrounds, tinted text, and 1px borders. Designed to blend into the dark theme without competing with mod names.
+
+## Data Model
+
+### TagCategory Enum
+
+New enum in `core/tag_engine.py` with 10 values. Each member carries metadata:
+- `label`: display name (e.g. "Combat")
+- `color_bg`, `color_fg`, `color_border`: muted palette B hex colors
+- `sort_order`: integer controlling pill display order (NSFW first, then alphabetical)
+
+### SubMod Extension
+
+`core/models.py` — add field:
+- `tags: set[TagCategory]` (default: empty set) — populated by the tag engine during scan
+
+### AppConfig Extension
+
+`app/config.py` — add field:
+- `tag_overrides: dict[str, list[str]]` — keyed by submod unique path (`"ModName/ReplacerName/SubModName"`), values are tag name strings. Overrides completely replace auto-detected tags for that submod. Persisted in the existing `config.json`.
+
+Example in config.json:
+```json
+{
+  "tag_overrides": {
+    "Ashes of War - NPC's/ReplacerName/SubModName": ["combat", "npc"],
+    "Dynamic Feminine Female Modesty Animations OAR/KP_nudeNPC/npc_both_fre": ["nsfw", "gender", "sneak"]
+  }
+}
+```
+
+### Mod-Level Rollup
+
+Not stored. Computed on-the-fly by the tree model as the deduplicated union of all child submod tags. Avoids stale data when submods change.
+
+## Tag Engine (`core/tag_engine.py`)
+
+### Public API
+
+`compute_tags(submod: SubMod) -> set[TagCategory]` — pure function, no side effects.
+
+### Rule Pipeline
+
+Rules run in priority order. Each layer can add tags (they accumulate, not replace).
+
+#### Layer 1 — Folder/Mod Name Keywords (highest confidence)
+
+Scan `submod.mo2_mod`, `submod.replacer`, `submod.name` for whole-word keyword matches:
+
+| Tag | Keywords |
+|---|---|
+| NSFW | `nude`, `modesty`, `nsfw`, `adult`, `sexlab`, `ostim`, `pregnancy`, `inflation`, `flower girl`, `billyy`, `leito` |
+| Gender | `female`, `male` (whole word match only) |
+| NPC | `npc`, `children`, `child`, `cart driver` |
+| Sneak | `sneak` |
+| Combat | `combat`, `stagger`, `block`, `dodge`, `ashes of war`, `boss fight` |
+| Movement | `traversal`, `clamber`, `swimming`, `jump` |
+
+#### Layer 2 — Animation Filename Patterns (primary behavioral signal)
+
+Classify each animation filename by prefix/pattern, then vote by category:
+
+| Tag | Animation patterns |
+|---|---|
+| Combat | `*_attack*`, `*_block*`, `*_stagger*`, `*_recoil*`, `*_power*` |
+| Movement | `*_run*`, `*_walk*`, `*_sprint*`, `*_swim*`, `*_jump*` |
+| Sneak | `*sneak*` |
+| Idle | `*_idle*`, `mt_idle*` |
+| Furniture | `*_sit*`, `*_chair*`, `*_bed*`, `*_lean*` |
+| Equipment | `*_equip*`, `*_sheathe*`, `*_draw*`, `*_unequip*` |
+| Magic | `*_cast*`, `mlh_*`, `mrh_*` |
+
+**Voting threshold:** A tag is applied only if >=30% of a submod's animations match that category. This prevents a single stray animation from mis-tagging a submod.
+
+#### Layer 3 — Condition Types (secondary refinement)
+
+Only fires for tags NOT already assigned by layers 1-2. Uses `submod.condition_types_present` with a precondition filter:
+
+**Precondition filter heuristic:** If a submod has <=3 unique condition types, they're likely definitional (the purpose of the mod). If it has 8+, conditions are likely preconditions and only very distinctive ones count.
+
+Distinctive conditions (always count regardless of total):
+- `IsSneaking` → Sneak
+- `IsFemale` (without negation) → Gender
+- `IsChild` → NPC
+- `IsOnMount` → Movement
+
+Non-distinctive conditions (only count if <=3 total condition types):
+- `IsEquippedType` → Equipment
+- `IsWornInSlotHasKeyword` → Equipment
+- `IsInCombat`, `IsCombatState` → Combat
+- `IsAttacking`, `IsBlocking` → Combat
+- `IsRunning`, `IsSprinting` → Movement
+- `HasMagicEffect`, `HasSpell` → Magic
+- `IsActorBase` (non-player), `IsRace`, `IsClass`, `IsVoiceType` → NPC
+- `SitSleepState`, `CurrentFurniture*` → Furniture
+
+#### Layer 4 — Fallback
+
+If no tags assigned after all layers, the submod gets an empty set. No "Untagged" category — the absence of pills is signal enough.
+
+**Ignored conditions:** Non-standard plugin conditions (`IED_*`, `SDS_*`) and structural types (`AND`, `OR`, `PRESET`) are excluded from tag computation.
+
+## UI — Tree Panel Display
+
+### Pill Rendering
+
+Each tag rendered as a `QLabel`-style element with rich text, using palette B colors. Styled as inline pills with rounded corners (`border-radius: 10px`, `padding: 2px 8px`, `font-size: 11px`, `font-weight: 600`).
+
+### Custom Item Delegate
+
+A `QStyledItemDelegate` subclass paints pills inline after the display name. This avoids embedding QWidget instances in every tree row (which is slow with 3,000+ items) while keeping rendering fast.
+
+### Mod-Level Rows (Collapsed)
+
+Show deduplicated union of all child submod tags. Pills sorted by `TagCategory.sort_order`. Max 4 pills displayed — if more exist, show `+N` overflow indicator.
+
+### Submod-Level Rows (Expanded)
+
+Show that submod's own tags. No overflow limit (submods rarely have more than 2-3 tags).
+
+### Override Indicator
+
+If a submod/mod has user-overridden tags (from `AppConfig.tag_overrides`), display a small pencil icon next to the pills to indicate these are not auto-detected.
+
+## UI — Manual Tag Editing
+
+### Right-Click Context Menu
+
+Add "Edit Tags..." action to the existing tree context menu (both mod and submod rows). Opens a dialog with:
+- 10 checkboxes (one per `TagCategory`), each with the colored pill preview next to the label
+- "Reset to Auto" button — clears the override, reverts to auto-detected tags
+- OK / Cancel buttons
+
+**Mod-level editing:** Edits a mod-level override in `AppConfig.tag_overrides` (keyed by mod path). Only affects rolled-up display; individual submod auto-tags unchanged.
+
+**Submod-level editing:** Edits the submod's override directly.
+
+### Details Panel
+
+When a mod or submod is selected, the details panel shows a "Tags" section:
+- Current tags as colored pills
+- A `+` button that opens the same edit dialog
+- Pencil icon for overridden tags (same as tree panel)
+
+### Persistence
+
+Overrides saved to `AppConfig.tag_overrides` immediately on OK. They survive rescans — auto-detected tags regenerate on scan, but overrides take priority.
+
+## Filter Integration
+
+### Immediate (this feature)
+
+Extend `SearchIndex.search()` to match against tag names. Typing "combat" in the search bar matches submods tagged Combat, even if "combat" doesn't appear in their name or animations.
+
+### Deferred (to #49/#50)
+
+The advanced filter builder's three-bucket UI would include tags as a filter dimension alongside condition types and animation names. `TagCategory` enum is designed to plug in — each tag is typed and enumerable. Out of scope for this issue.
+
+### Not included
+
+No tree-level tag filtering toggle (e.g. "show only Combat mods") in the toolbar. Natural follow-up but adds scope beyond #73.
+
+## Testing
+
+### Unit Tests (`tests/unit/test_tag_engine.py`)
+
+- One test per tag category verifying detection rules fire correctly
+- Precondition filter: submod with `IsEquippedType` + 8 other conditions → NOT Equipment; submod with only `IsEquippedType` + `*_equip*` animations → Equipment
+- Voting threshold: 10 combat animations + 1 idle animation → Combat only, not Idle
+- Multi-tag: `IsFemale` + `IsSneaking` + sneak animations → Gender + Sneak
+- Manual override: overrides replace auto-detected tags; "Reset to Auto" clears override
+- Edge cases: empty conditions, empty animations, no matches → empty tag set
+- Non-standard conditions (`IED_*`, `SDS_*`, `PRESET`) → ignored
+
+### Integration Tests
+
+- End-to-end: scan fixture submod → compute tags → verify correct tags
+- AppConfig round-trip: save tag overrides → reload config → overrides preserved
+- Search integration: tag names searchable via search bar
+
+### No UI Tests
+
+Tree delegate and edit dialog are thin wrappers over the tag engine. Engine tests cover the logic; UI testing is manual.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `core/tag_engine.py` | **New** — TagCategory enum, compute_tags(), rule pipeline |
+| `core/models.py` | Add `tags: set[TagCategory]` field to SubMod |
+| `app/config.py` | Add `tag_overrides: dict[str, list[str]]` to AppConfig |
+| `ui/tree_model.py` | Add tag pill rendering via custom delegate, mod-level rollup |
+| `ui/tree_panel.py` | Wire delegate, add "Edit Tags..." context menu action |
+| `ui/details_panel.py` | Add Tags section with pills and `+` button |
+| `ui/tag_edit_dialog.py` | **New** — checkbox dialog for manual tag editing |
+| `core/search_index.py` | Extend search to match tag names |
+| `tests/unit/test_tag_engine.py` | **New** — tag engine unit tests |
+| `tests/integration/test_tag_integration.py` | **New** — end-to-end and config round-trip tests |

--- a/src/oar_priority_manager/app/config.py
+++ b/src/oar_priority_manager/app/config.py
@@ -26,6 +26,7 @@ class AppConfig:
     splitter_positions: list[int] = field(default_factory=list)
     search_history: list[str] = field(default_factory=list)
     last_selected_path: str = ""
+    tag_overrides: dict = field(default_factory=dict)
 
 
 def detect_instance_root(
@@ -106,6 +107,7 @@ def load_config(path: Path) -> AppConfig:
             splitter_positions=data.get("splitter_positions", []),
             search_history=data.get("search_history", []),
             last_selected_path=data.get("last_selected_path", ""),
+            tag_overrides=data.get("tag_overrides", {}),
         )
     except (json.JSONDecodeError, OSError):
         logger.warning("Corrupt config at %s, using defaults", path)

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -20,7 +20,7 @@ from oar_priority_manager.app.config import (
 )
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
 from oar_priority_manager.core.filter_engine import extract_condition_types
-from oar_priority_manager.core.tag_engine import compute_tags
+from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
 from oar_priority_manager.core.priority_resolver import build_stacks
 from oar_priority_manager.core.scanner import scan_mods
 
@@ -89,6 +89,7 @@ def main(argv: list[str] | None = None) -> int:
     app_config = load_config(config_path)
 
     submods, conflict_map, stacks = run_scan(instance_root)
+    apply_overrides(submods, app_config.tag_overrides)
     logger.info("Loaded %d submods, %d animation stacks", len(submods), len(stacks))
 
     # Force the native Windows platform plugin.  pytest-qt sets

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -20,6 +20,7 @@ from oar_priority_manager.app.config import (
 )
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
 from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.tag_engine import compute_tags
 from oar_priority_manager.core.priority_resolver import build_stacks
 from oar_priority_manager.core.scanner import scan_mods
 
@@ -59,6 +60,7 @@ def run_scan(instance_root: Path) -> tuple:
         present, negated = extract_condition_types(sm.conditions)
         sm.condition_types_present = present
         sm.condition_types_negated = negated
+        sm.tags = compute_tags(sm)
 
     return submods, conflict_map, stacks
 

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -20,9 +20,9 @@ from oar_priority_manager.app.config import (
 )
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
 from oar_priority_manager.core.filter_engine import extract_condition_types
-from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
 from oar_priority_manager.core.priority_resolver import build_stacks
 from oar_priority_manager.core.scanner import scan_mods
+from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
 
 logger = logging.getLogger(__name__)
 

--- a/src/oar_priority_manager/core/models.py
+++ b/src/oar_priority_manager/core/models.py
@@ -45,6 +45,9 @@ class SubMod:
     raw_dict: dict
     animations: list[str] = field(default_factory=list)
     conditions: dict = field(default_factory=dict)
+    # conditionPresets from the replacer-level config.json.
+    # Stored per-submod so it's available without needing the replacer path.
+    replacer_presets: dict = field(default_factory=dict)
     # Populated by filter_engine.py (Task 9). Empty until that module exists.
     condition_types_present: set[str] = field(default_factory=set)
     condition_types_negated: set[str] = field(default_factory=set)

--- a/src/oar_priority_manager/core/models.py
+++ b/src/oar_priority_manager/core/models.py
@@ -49,6 +49,8 @@ class SubMod:
     condition_types_present: set[str] = field(default_factory=set)
     condition_types_negated: set[str] = field(default_factory=set)
     warnings: list[str] = field(default_factory=list)
+    # Populated by tag_engine.py (Task 5). Empty until compute_tags is called.
+    tags: set = field(default_factory=set)
 
     def __eq__(self, other: object) -> bool:
         """Two SubMods are equal if they point to the same config.json."""

--- a/src/oar_priority_manager/core/scanner.py
+++ b/src/oar_priority_manager/core/scanner.py
@@ -62,6 +62,7 @@ def _build_submod(
     submod_folder: str,
     submod_path: Path,
     overwrite_dir: Path,
+    replacer_presets: dict,
 ) -> SubMod:
     """Build a SubMod record for one discovered submod, applying override precedence.
 
@@ -149,6 +150,7 @@ def _build_submod(
         override_is_ours=override_is_ours,
         raw_dict=raw_dict,
         conditions=conditions,
+        replacer_presets=replacer_presets,
         warnings=warnings,
     )
 
@@ -175,7 +177,20 @@ def scan_mods(
     submods: list[SubMod] = []
 
     for mo2_mod, replacer, submod_folder, submod_path in submod_dirs:
-        sm = _build_submod(mo2_mod, replacer, submod_folder, submod_path, overwrite_dir)
+        # Read replacer-level config.json for conditionPresets
+        replacer_dir = submod_path.parent
+        replacer_config_path = replacer_dir / "config.json"
+        replacer_presets: dict = {}
+        if replacer_config_path.is_file():
+            rep_dict, _ = parse_config(replacer_config_path)
+            raw_presets = rep_dict.get("conditionPresets", {})
+            if isinstance(raw_presets, dict):
+                replacer_presets = raw_presets
+
+        sm = _build_submod(
+            mo2_mod, replacer, submod_folder, submod_path,
+            overwrite_dir, replacer_presets,
+        )
         submods.append(sm)
         if on_progress is not None:
             on_progress(len(submods), total)

--- a/src/oar_priority_manager/core/scanner.py
+++ b/src/oar_priority_manager/core/scanner.py
@@ -184,7 +184,16 @@ def scan_mods(
         if replacer_config_path.is_file():
             rep_dict, _ = parse_config(replacer_config_path)
             raw_presets = rep_dict.get("conditionPresets", {})
-            if isinstance(raw_presets, dict):
+            if isinstance(raw_presets, list):
+                # Real OAR format: list of {"name": ..., "conditions": [...]}
+                replacer_presets = {
+                    p["name"]: p.get("conditions", p.get("Conditions", []))
+                    for p in raw_presets
+                    if isinstance(p, dict) and "name" in p
+                    and ("conditions" in p or "Conditions" in p)
+                }
+            elif isinstance(raw_presets, dict):
+                # Legacy / test-fixture format: dict keyed by name
                 replacer_presets = raw_presets
 
         sm = _build_submod(

--- a/src/oar_priority_manager/core/tag_engine.py
+++ b/src/oar_priority_manager/core/tag_engine.py
@@ -185,8 +185,80 @@ def _layer2_animations(
     return tags
 
 
+# Conditions ignored during tag computation (non-standard plugins, structural).
+_IGNORED_CONDITION_PREFIXES: tuple[str, ...] = ("IED_", "SDS_")
+_IGNORED_CONDITIONS: frozenset[str] = frozenset({"AND", "OR", "PRESET"})
+
+# Distinctive conditions — always count regardless of total condition count.
+_DISTINCTIVE_CONDITIONS: dict[str, TagCategory] = {
+    "IsSneaking": TagCategory.SNEAK,
+    "IsFemale": TagCategory.GENDER,
+    "IsChild": TagCategory.NPC,
+    "IsOnMount": TagCategory.MOVEMENT,
+}
+
+# Non-distinctive conditions — only count if submod has <= 3 unique condition types.
+_NON_DISTINCTIVE_CONDITIONS: dict[str, TagCategory] = {
+    "IsEquippedType": TagCategory.EQUIPMENT,
+    "IsWornInSlotHasKeyword": TagCategory.EQUIPMENT,
+    "IsInCombat": TagCategory.COMBAT,
+    "IsCombatState": TagCategory.COMBAT,
+    "IsAttacking": TagCategory.COMBAT,
+    "IsBlocking": TagCategory.COMBAT,
+    "IsRunning": TagCategory.MOVEMENT,
+    "IsSprinting": TagCategory.MOVEMENT,
+    "HasMagicEffect": TagCategory.MAGIC,
+    "HasSpell": TagCategory.MAGIC,
+    "IsActorBase": TagCategory.NPC,
+    "IsRace": TagCategory.NPC,
+    "IsClass": TagCategory.NPC,
+    "IsVoiceType": TagCategory.NPC,
+    "SitSleepState": TagCategory.FURNITURE,
+    "CurrentFurniture": TagCategory.FURNITURE,
+    "CurrentFurnitureHasKeyword": TagCategory.FURNITURE,
+}
+
+_FEW_CONDITIONS_THRESHOLD: int = 3
+
+
 def _layer3_conditions(
     submod: SubMod, existing: set[TagCategory]
 ) -> set[TagCategory]:
-    """Layer 3: condition type refinement with precondition filter."""
-    return set()
+    """Layer 3: condition type refinement with precondition filter.
+
+    Only adds tags NOT already present from layers 1-2. Distinctive
+    conditions always count; non-distinctive only count when the submod
+    has few unique condition types (likely definitional, not preconditions).
+
+    Args:
+        submod: The SubMod whose condition_types_present will be examined.
+        existing: Tags already assigned by layers 1-2.
+
+    Returns:
+        Set of new TagCategory values not already in existing.
+    """
+    relevant = {
+        ct for ct in submod.condition_types_present
+        if ct not in _IGNORED_CONDITIONS
+        and not any(ct.startswith(p) for p in _IGNORED_CONDITION_PREFIXES)
+    }
+
+    if not relevant:
+        return set()
+
+    tags: set[TagCategory] = set()
+    few_conditions = len(relevant) <= _FEW_CONDITIONS_THRESHOLD
+
+    for ct in relevant:
+        if ct in _DISTINCTIVE_CONDITIONS:
+            tag = _DISTINCTIVE_CONDITIONS[ct]
+            if ct == "IsFemale" and ct in submod.condition_types_negated:
+                continue
+            if tag not in existing:
+                tags.add(tag)
+        elif few_conditions and ct in _NON_DISTINCTIVE_CONDITIONS:
+            tag = _NON_DISTINCTIVE_CONDITIONS[ct]
+            if tag not in existing:
+                tags.add(tag)
+
+    return tags

--- a/src/oar_priority_manager/core/tag_engine.py
+++ b/src/oar_priority_manager/core/tag_engine.py
@@ -65,9 +65,58 @@ def compute_tags(submod: SubMod) -> set[TagCategory]:
     return tags
 
 
+# Module-level constant: keyword -> TagCategory mapping.
+_KEYWORD_RULES: list[tuple[list[str], TagCategory]] = [
+    # NSFW
+    (
+        [
+            "modesty", "nude", "naked", "nsfw", "adult", "sexlab",
+            "ostim", "pregnancy", "inflation", "flower girl", "billyy", "leito",
+        ],
+        TagCategory.NSFW,
+    ),
+    # Gender — whole-word only (handled by regex in _layer1_keywords)
+    (["female", "male"], TagCategory.GENDER),
+    # NPC — multi-word first
+    (["cart driver", "npc", "children", "child"], TagCategory.NPC),
+    # Sneak
+    (["sneak"], TagCategory.SNEAK),
+    # Combat — multi-word first
+    (
+        ["ashes of war", "boss fight", "combat", "stagger", "block", "dodge"],
+        TagCategory.COMBAT,
+    ),
+    # Movement
+    (["traversal", "clamber", "swimming", "jump"], TagCategory.MOVEMENT),
+]
+
+# Gender keywords need word-boundary matching to avoid "female" in "maleficent".
+_WHOLE_WORD_TAGS: frozenset[TagCategory] = frozenset({TagCategory.GENDER})
+
+
 def _layer1_keywords(submod: SubMod) -> set[TagCategory]:
-    """Layer 1: folder/mod name keyword matching."""
-    return set()
+    """Layer 1: folder/mod name keyword matching.
+
+    Scans mo2_mod, replacer, and name for keyword hits. Gender keywords
+    use whole-word matching; others use substring matching.
+    """
+    tags: set[TagCategory] = set()
+    text = f"{submod.mo2_mod} {submod.replacer} {submod.name}".lower()
+
+    for keywords, tag in _KEYWORD_RULES:
+        if tag in tags:
+            continue
+        for kw in keywords:
+            if tag in _WHOLE_WORD_TAGS:
+                if re.search(rf"\b{re.escape(kw)}\b", text):
+                    tags.add(tag)
+                    break
+            else:
+                if kw in text:
+                    tags.add(tag)
+                    break
+
+    return tags
 
 
 def _layer2_animations(

--- a/src/oar_priority_manager/core/tag_engine.py
+++ b/src/oar_priority_manager/core/tag_engine.py
@@ -221,6 +221,32 @@ _NON_DISTINCTIVE_CONDITIONS: dict[str, TagCategory] = {
 _FEW_CONDITIONS_THRESHOLD: int = 3
 
 
+_TAG_BY_NAME: dict[str, TagCategory] = {tag.label.lower(): tag for tag in TagCategory}
+
+
+def apply_overrides(submods: list[SubMod], overrides: dict[str, list[str]]) -> None:
+    """Apply tag overrides from config to the in-memory submod list.
+
+    Mutates each submod whose key appears in *overrides* by replacing its
+    ``tags`` with the set described by the override list.
+
+    Args:
+        submods: List of SubMod objects to patch in place.
+        overrides: Mapping of ``"mo2_mod/replacer/name"`` keys to lists of
+            lowercase tag label strings (e.g. ``["combat", "sneak"]``).
+    """
+    if not overrides:
+        return
+    for sm in submods:
+        key = f"{sm.mo2_mod}/{sm.replacer}/{sm.name}"
+        if key in overrides:
+            sm.tags = {
+                _TAG_BY_NAME[n.lower()]
+                for n in overrides[key]
+                if n.lower() in _TAG_BY_NAME
+            }
+
+
 def _layer3_conditions(
     submod: SubMod, existing: set[TagCategory]
 ) -> set[TagCategory]:

--- a/src/oar_priority_manager/core/tag_engine.py
+++ b/src/oar_priority_manager/core/tag_engine.py
@@ -119,11 +119,70 @@ def _layer1_keywords(submod: SubMod) -> set[TagCategory]:
     return tags
 
 
+# Animation filename patterns for each tag category.
+_ANIM_PATTERNS: list[tuple[list[str], TagCategory]] = [
+    (["_attack", "_block", "_stagger", "_recoil", "_power"], TagCategory.COMBAT),
+    (["_run", "_walk", "_sprint", "_swim", "_jump"], TagCategory.MOVEMENT),
+    (["sneak"], TagCategory.SNEAK),
+    (["_idle", "mt_idle", "idle_"], TagCategory.IDLE),
+    (["_sit", "_chair", "_bed", "_lean"], TagCategory.FURNITURE),
+    (["_equip", "_sheathe", "_draw", "_unequip"], TagCategory.EQUIPMENT),
+    (["_cast", "mlh_", "mrh_"], TagCategory.MAGIC),
+]
+
+_ANIM_VOTE_THRESHOLD: float = 0.30
+
+
+def _classify_animation(filename: str) -> set[TagCategory]:
+    """Classify a single animation filename into zero or more tag categories.
+
+    Args:
+        filename: Animation filename (with or without extension).
+
+    Returns:
+        Set of matching TagCategory values (may be empty).
+    """
+    name = filename.rsplit(".", 1)[0].lower() if "." in filename else filename.lower()
+    matched: set[TagCategory] = set()
+    for patterns, tag in _ANIM_PATTERNS:
+        for pattern in patterns:
+            if pattern in name:
+                matched.add(tag)
+                break
+    return matched
+
+
 def _layer2_animations(
     submod: SubMod, existing: set[TagCategory]
 ) -> set[TagCategory]:
-    """Layer 2: animation filename pattern voting."""
-    return set()
+    """Layer 2: animation filename pattern voting.
+
+    Each animation is classified, then a tag applies only if >= 30% match.
+
+    Args:
+        submod: The SubMod whose animations list will be examined.
+        existing: Tags already assigned by earlier layers (unused here but
+            present for pipeline signature consistency).
+
+    Returns:
+        Set of TagCategory values that met the voting threshold.
+    """
+    if not submod.animations:
+        return set()
+
+    total = len(submod.animations)
+    votes: dict[TagCategory, int] = {}
+
+    for anim in submod.animations:
+        for tag in _classify_animation(anim):
+            votes[tag] = votes.get(tag, 0) + 1
+
+    tags: set[TagCategory] = set()
+    for tag, count in votes.items():
+        if count / total >= _ANIM_VOTE_THRESHOLD:
+            tags.add(tag)
+
+    return tags
 
 
 def _layer3_conditions(

--- a/src/oar_priority_manager/core/tag_engine.py
+++ b/src/oar_priority_manager/core/tag_engine.py
@@ -1,0 +1,84 @@
+"""Category tag auto-detection engine for OAR Priority Manager.
+
+Computes category tags for submods based on a 3-layer rule pipeline:
+  1. Folder/mod name keywords (highest confidence)
+  2. Animation filename patterns (primary behavioral signal)
+  3. Condition types (secondary refinement with precondition filter)
+
+See design spec: docs/superpowers/specs/2026-04-14-category-tags-design.md
+"""
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from oar_priority_manager.core.models import SubMod
+
+
+class TagCategory(Enum):
+    """Category tag with display metadata.
+
+    Each member is a tuple of (label, sort_order, color_bg, color_fg, color_border).
+    """
+
+    NSFW = ("NSFW", 0, "#5c2d4a", "#f0a0d0", "#8b446e")
+    COMBAT = ("Combat", 1, "#5c2d2d", "#f0a0a0", "#8b4444")
+    EQUIPMENT = ("Equipment", 2, "#3d3d3d", "#b0b0b0", "#5a5a5a")
+    FURNITURE = ("Furniture", 3, "#5c4a2d", "#f0d0a0", "#8b6e44")
+    GENDER = ("Gender", 4, "#5c5c2d", "#f0f0a0", "#8b8b44")
+    IDLE = ("Idle", 5, "#2d5c4a", "#a0f0d0", "#448b6e")
+    MAGIC = ("Magic", 6, "#4a2d5c", "#d0a0f0", "#6e448b")
+    MOVEMENT = ("Movement", 7, "#2d3a5c", "#a0b8f0", "#44578b")
+    NPC = ("NPC", 8, "#2d4a5c", "#a0d0f0", "#446e8b")
+    SNEAK = ("Sneak", 9, "#3d2d5c", "#b8a0f0", "#5b448b")
+
+    def __init__(
+        self,
+        label: str,
+        sort_order: int,
+        color_bg: str,
+        color_fg: str,
+        color_border: str,
+    ) -> None:
+        self.label = label
+        self.sort_order = sort_order
+        self.color_bg = color_bg
+        self.color_fg = color_fg
+        self.color_border = color_border
+
+
+def compute_tags(submod: SubMod) -> set[TagCategory]:
+    """Compute category tags for a submod using the 3-layer rule pipeline.
+
+    Args:
+        submod: The SubMod to tag.
+
+    Returns:
+        Set of matching TagCategory values (may be empty).
+    """
+    tags: set[TagCategory] = set()
+    tags |= _layer1_keywords(submod)
+    tags |= _layer2_animations(submod, tags)
+    tags |= _layer3_conditions(submod, tags)
+    return tags
+
+
+def _layer1_keywords(submod: SubMod) -> set[TagCategory]:
+    """Layer 1: folder/mod name keyword matching."""
+    return set()
+
+
+def _layer2_animations(
+    submod: SubMod, existing: set[TagCategory]
+) -> set[TagCategory]:
+    """Layer 2: animation filename pattern voting."""
+    return set()
+
+
+def _layer3_conditions(
+    submod: SubMod, existing: set[TagCategory]
+) -> set[TagCategory]:
+    """Layer 3: condition type refinement with precondition filter."""
+    return set()

--- a/src/oar_priority_manager/ui/conditions_panel.py
+++ b/src/oar_priority_manager/ui/conditions_panel.py
@@ -1,39 +1,340 @@
-"""Conditions panel — read-only display of a competitor's condition tree.
+"""Conditions panel — formatted AND/OR/NOT tree + raw JSON toggle.
 
-See spec §7.5. Right pane of the main layout.
+See spec: docs/superpowers/specs/2026-04-12-conditions-panel-design.md
+Issues: #43 (formatted display), #44 (JSON toggle)
 """
-
 from __future__ import annotations
 
 import json
 
-from PySide6.QtWidgets import QLabel, QTextEdit, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from oar_priority_manager.core.models import SubMod
+from oar_priority_manager.ui.conditions_renderer import (
+    RenderedNode,
+    conditions_stats,
+    render_conditions,
+    resolve_preset,
+)
 
 
 class ConditionsPanel(QWidget):
-    """Right pane: conditions for the focused competitor."""
+    """Right pane: formatted condition tree with JSON toggle."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._current_submod: SubMod | None = None
+        self._show_formatted: bool = True
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # -- Header row: label + Formatted/JSON toggle --
+        header_row = QWidget()
+        header_layout = QHBoxLayout(header_row)
+        header_layout.setContentsMargins(4, 4, 4, 2)
 
         self._header = QLabel("Conditions")
-        layout.addWidget(self._header)
+        self._header.setTextFormat(Qt.TextFormat.RichText)
+        header_layout.addWidget(self._header, stretch=1)
 
-        self._text = QTextEdit()
-        self._text.setReadOnly(True)
-        layout.addWidget(self._text)
+        # Segmented toggle matching tree_panel.py / stacks_panel.py pattern
+        _seg_checked = (
+            "QPushButton:checked {"
+            "  background: #3a3a5a;"
+            "  font-weight: bold;"
+            "  border: 1px solid #5a5a8a;"
+            "}"
+        )
+        _seg_unchecked = (
+            "QPushButton {"
+            "  background: #2a2a2a;"
+            "  border: 1px solid #444;"
+            "  padding: 3px 10px;"
+            "}"
+            "QPushButton:hover { background: #333; }"
+        )
+
+        self._formatted_btn = QPushButton("Formatted")
+        self._formatted_btn.setCheckable(True)
+        self._formatted_btn.setChecked(True)
+        self._formatted_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-left-radius: 4px;"
+            "  border-bottom-left-radius: 4px;"
+            "  border-right: none; }"
+        )
+
+        self._json_btn = QPushButton("JSON")
+        self._json_btn.setCheckable(True)
+        self._json_btn.setChecked(False)
+        self._json_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-right-radius: 4px;"
+            "  border-bottom-right-radius: 4px; }"
+        )
+
+        self._toggle_group = QButtonGroup(self)
+        self._toggle_group.setExclusive(True)
+        self._toggle_group.addButton(self._formatted_btn)
+        self._toggle_group.addButton(self._json_btn)
+
+        self._formatted_btn.clicked.connect(lambda: self._set_mode(True))
+        self._json_btn.clicked.connect(lambda: self._set_mode(False))
+
+        header_layout.addWidget(self._formatted_btn)
+        header_layout.addWidget(self._json_btn)
+
+        layout.addWidget(header_row)
+
+        # -- Formatted view (scroll area with rendered tree) --
+        self._formatted_view = QScrollArea()
+        self._formatted_view.setWidgetResizable(True)
+        self._formatted_content = QWidget()
+        self._formatted_layout = QVBoxLayout(self._formatted_content)
+        self._formatted_layout.setContentsMargins(8, 8, 8, 8)
+        self._formatted_layout.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop
+        )
+        self._formatted_view.setWidget(self._formatted_content)
+        layout.addWidget(self._formatted_view)
+
+        # -- JSON view (existing QTextEdit, hidden by default) --
+        self._json_view = QTextEdit()
+        self._json_view.setReadOnly(True)
+        self._json_view.hide()
+        layout.addWidget(self._json_view)
+
+        # -- Stats footer --
+        self._stats_label = QLabel("")
+        self._stats_label.setStyleSheet("color: #565f89; padding: 4px 8px;")
+        layout.addWidget(self._stats_label)
+
+    def _set_mode(self, formatted: bool) -> None:
+        """Switch between formatted and JSON view modes."""
+        if self._show_formatted == formatted:
+            return
+        self._show_formatted = formatted
+        self._formatted_view.setVisible(formatted)
+        self._json_view.setVisible(not formatted)
 
     def update_focus(self, submod: SubMod | None) -> None:
-        """Update conditions display for the focused competitor."""
+        """Update display for the focused competitor submod."""
+        self._current_submod = submod
+
         if submod is None:
             self._header.setText("Conditions")
-            self._text.clear()
+            self._clear_formatted()
+            self._json_view.clear()
+            self._stats_label.setText("")
+            self._add_placeholder("Select a submod to view conditions.")
             return
 
-        self._header.setText(f"<b>Conditions</b> · {submod.mo2_mod} / {submod.name}")
-        # Raw JSON display (Tier 2: formatted REQUIRED/ONE OF/EXCLUDED view)
-        self._text.setPlainText(json.dumps(submod.conditions, indent=2))
+        self._header.setText(
+            f"<b>Conditions</b> · {submod.mo2_mod} / {submod.name}"
+        )
+
+        # JSON view (always updated, even if hidden)
+        self._json_view.setPlainText(json.dumps(submod.conditions, indent=2))
+
+        # Formatted view
+        nodes = render_conditions(submod.conditions)
+        self._clear_formatted()
+
+        if not nodes:
+            self._add_placeholder("No conditions defined.")
+            self._stats_label.setText("")
+            return
+
+        self._render_nodes(nodes, self._formatted_layout, indent=0)
+
+        # Stats footer
+        stats = conditions_stats(nodes)
+        parts = [
+            f"{stats['conditions']} conditions",
+            f"{stats['types']} types",
+            f"{stats['negated']} negated",
+        ]
+        if stats["presets"] > 0:
+            parts.append(f"{stats['presets']} presets")
+        self._stats_label.setText(" · ".join(parts))
+
+    def _clear_formatted(self) -> None:
+        """Remove all widgets from the formatted view layout."""
+        while self._formatted_layout.count():
+            child = self._formatted_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+    def _add_placeholder(self, text: str) -> None:
+        """Add a placeholder label to the formatted view."""
+        label = QLabel(text)
+        label.setStyleSheet("color: #565f89; padding: 8px;")
+        self._formatted_layout.addWidget(label)
+
+    def _render_nodes(
+        self,
+        nodes: list[RenderedNode],
+        parent_layout: QVBoxLayout,
+        indent: int,
+    ) -> None:
+        """Recursively render RenderedNode trees into QLabels."""
+        for node in nodes:
+            if node.node_type in ("AND", "OR"):
+                self._render_group(node, parent_layout, indent)
+            elif node.node_type == "preset":
+                self._render_preset(node, parent_layout, indent)
+            else:
+                self._render_leaf(node, parent_layout, indent)
+
+    def _render_group(
+        self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
+    ) -> None:
+        """Render an AND/OR group with its children."""
+        label_text = "ALL of:" if node.node_type == "AND" else "ANY of:"
+        color = "#7aa2f7" if node.node_type == "AND" else "#bb9af7"
+
+        group_label = QLabel(f"<b style='color:{color};'>{label_text}</b>")
+        group_label.setTextFormat(Qt.TextFormat.RichText)
+        group_label.setContentsMargins(indent * 20, 2, 0, 0)
+        parent_layout.addWidget(group_label)
+
+        # Render children at increased indent
+        self._render_nodes(node.children, parent_layout, indent + 1)
+
+    def _render_leaf(
+        self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
+    ) -> None:
+        """Render a single leaf condition with icon, name, and params."""
+        if node.negated:
+            icon = "<span style='color:#f7768e;'>✗</span>"
+            name_html = (
+                f"<span style='color:#c0caf5; text-decoration:line-through;"
+                f" opacity:0.7;'>{node.text}</span>"
+                f" <span style='background:#3a1a1a; color:#f7768e;"
+                f" padding:1px 6px; border-radius:3px; font-size:11px;'>"
+                f"NOT</span>"
+            )
+        else:
+            icon = "<span style='color:#9ece6a;'>✓</span>"
+            name_html = f"<span style='color:#c0caf5;'>{node.text}</span>"
+
+        html = f"{icon} {name_html}"
+
+        # Add parameters line if any
+        if node.params:
+            param_parts = [f'{k} = "{v}"' for k, v in node.params.items()]
+            params_str = " · ".join(param_parts)
+            html += (
+                f"<br><span style='color:#565f89; font-size:11px;"
+                f" margin-left:22px;'>{params_str}</span>"
+            )
+
+        label = QLabel(html)
+        label.setTextFormat(Qt.TextFormat.RichText)
+        label.setContentsMargins(indent * 20, 2, 0, 2)
+        parent_layout.addWidget(label)
+
+    def _render_preset(
+        self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
+    ) -> None:
+        """Render a PRESET reference as a clickable expandable card."""
+        preset_name = node.preset_name or "Unknown"
+
+        # Create a container widget for the preset card
+        card = QWidget()
+        card.setStyleSheet(
+            "background: #2a2a3a; border: 1px solid #444; border-radius: 6px;"
+        )
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(10, 8, 10, 8)
+
+        # Header row
+        header = QLabel(
+            f"<span style='color:#e0af68;'>⚙</span>"
+            f" <b style='color:#e0af68;'>PRESET:</b>"
+            f" <span style='color:#c0caf5;'>{preset_name}</span>"
+            f" <span style='color:#565f89; font-size:11px;'>"
+            f"▸ expand</span>"
+        )
+        header.setTextFormat(Qt.TextFormat.RichText)
+        header.setCursor(Qt.CursorShape.PointingHandCursor)
+        card_layout.addWidget(header)
+
+        # Expanded content container (hidden initially)
+        expanded = QWidget()
+        expanded.hide()
+        expanded_layout = QVBoxLayout(expanded)
+        expanded_layout.setContentsMargins(8, 4, 0, 0)
+        card_layout.addWidget(expanded)
+
+        # Wire up click to toggle expand/collapse
+        def _toggle_preset(
+            _event: object = None,
+            *,
+            exp: QWidget = expanded,
+            hdr: QLabel = header,
+            pname: str = preset_name,
+            exp_layout: QVBoxLayout = expanded_layout,
+        ) -> None:
+            if exp.isVisible():
+                exp.hide()
+                hdr.setText(
+                    f"<span style='color:#e0af68;'>⚙</span>"
+                    f" <b style='color:#e0af68;'>PRESET:</b>"
+                    f" <span style='color:#c0caf5;'>{pname}</span>"
+                    f" <span style='color:#565f89; font-size:11px;'>"
+                    f"▸ expand</span>"
+                )
+            else:
+                # Resolve preset on demand
+                if exp_layout.count() == 0:
+                    self._populate_preset(pname, exp_layout)
+                exp.show()
+                hdr.setText(
+                    f"<span style='color:#e0af68;'>⚙</span>"
+                    f" <b style='color:#e0af68;'>PRESET:</b>"
+                    f" <span style='color:#c0caf5;'>{pname}</span>"
+                    f" <span style='color:#565f89; font-size:11px;'>"
+                    f"▾ collapse</span>"
+                )
+
+        header.mousePressEvent = _toggle_preset
+
+        card.setContentsMargins(indent * 20, 4, 0, 4)
+        parent_layout.addWidget(card)
+
+    def _populate_preset(
+        self, preset_name: str, layout: QVBoxLayout
+    ) -> None:
+        """Resolve and render a preset's conditions into the given layout."""
+        presets = {}
+        if self._current_submod is not None:
+            presets = getattr(self._current_submod, "replacer_presets", {})
+
+        nodes = resolve_preset(preset_name, presets)
+        if nodes is None:
+            warning = QLabel(
+                f"<span style='color:#f7768e;'>Preset '{preset_name}'"
+                f" not found in replacer config.</span>"
+            )
+            warning.setTextFormat(Qt.TextFormat.RichText)
+            layout.addWidget(warning)
+            return
+
+        self._render_nodes(nodes, layout, indent=0)

--- a/src/oar_priority_manager/ui/conditions_panel.py
+++ b/src/oar_priority_manager/ui/conditions_panel.py
@@ -205,17 +205,78 @@ class ConditionsPanel(QWidget):
     def _render_group(
         self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int
     ) -> None:
-        """Render an AND/OR group with its children."""
+        """Render a collapsible AND/OR group with a clickable header.
+
+        Groups start expanded by default so the full condition tree is
+        visible on load.  Clicking the header toggles child visibility,
+        and the arrow glyph (▾/▸) reflects the current state.
+
+        Args:
+            node: The AND/OR RenderedNode to render.
+            parent_layout: The parent layout to add this group into.
+            indent: Current indentation level (multiples of 20 px).
+        """
         label_text = "ALL of:" if node.node_type == "AND" else "ANY of:"
         color = "#7aa2f7" if node.node_type == "AND" else "#bb9af7"
+        child_count = len(node.children)
 
-        group_label = QLabel(f"<b style='color:{color};'>{label_text}</b>")
-        group_label.setTextFormat(Qt.TextFormat.RichText)
-        group_label.setContentsMargins(indent * 20, 2, 0, 0)
-        parent_layout.addWidget(group_label)
+        def _expanded_html(
+            lbl: str = label_text,
+            clr: str = color,
+            n: int = child_count,
+        ) -> str:
+            return (
+                f"<b style='color:{clr};'>▾ {lbl}</b>"
+                f" <span style='color:#565f89; font-size:11px;'>"
+                f"({n})</span>"
+            )
 
-        # Render children at increased indent
-        self._render_nodes(node.children, parent_layout, indent + 1)
+        def _collapsed_html(
+            lbl: str = label_text,
+            clr: str = color,
+            n: int = child_count,
+        ) -> str:
+            return (
+                f"<b style='color:{clr};'>▸ {lbl}</b>"
+                f" <span style='color:#565f89; font-size:11px;'>"
+                f"({n})</span>"
+            )
+
+        header = QLabel(_expanded_html())
+        header.setTextFormat(Qt.TextFormat.RichText)
+        header.setCursor(Qt.CursorShape.PointingHandCursor)
+        header.setContentsMargins(indent * 20, 2, 0, 0)
+        parent_layout.addWidget(header)
+
+        # Children container — visible by default (expanded)
+        children_widget = QWidget()
+        children_layout = QVBoxLayout(children_widget)
+        children_layout.setContentsMargins(0, 0, 0, 0)
+        children_layout.setSpacing(0)
+        parent_layout.addWidget(children_widget)
+
+        # Render children into the container at increased indent
+        self._render_nodes(node.children, children_layout, indent + 1)
+
+        def _toggle(
+            _event: object = None,
+            *,
+            cw: QWidget = children_widget,
+            hdr: QLabel = header,
+        ) -> None:
+            # Use isHidden() rather than isVisible(): isVisible() returns
+            # False for widgets that have never been shown in a top-level
+            # window, so it cannot distinguish "explicitly hidden" from
+            # "not yet displayed".  isHidden() reflects only explicit
+            # hide()/show() calls, which is what we need here.
+            if not cw.isHidden():
+                cw.hide()
+                hdr.setText(_collapsed_html())
+            else:
+                cw.show()
+                hdr.setText(_expanded_html())
+
+        header.mousePressEvent = _toggle
 
     def _render_leaf(
         self, node: RenderedNode, parent_layout: QVBoxLayout, indent: int

--- a/src/oar_priority_manager/ui/conditions_renderer.py
+++ b/src/oar_priority_manager/ui/conditions_renderer.py
@@ -1,0 +1,153 @@
+"""Pure-logic renderer for OAR condition trees.
+
+Converts nested OAR condition dicts/lists into RenderedNode dataclass trees.
+No Qt dependency — this module is testable without a GUI.
+
+See spec: docs/superpowers/specs/2026-04-12-conditions-panel-design.md
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Keys that are structural (not user-visible parameters).
+_STRUCTURAL_KEYS: frozenset[str] = frozenset({
+    "condition", "negated", "conditions", "Preset",
+})
+
+# OAR group-node condition types.
+_GROUP_TYPES: frozenset[str] = frozenset({"AND", "OR"})
+
+
+@dataclass
+class RenderedNode:
+    """One node in the rendered condition tree.
+
+    Attributes:
+        text: Display label — condition type name or group label.
+        node_type: One of "AND", "OR", "leaf", "preset".
+        negated: True if this leaf condition is negated.
+        params: Extra JSON keys (excluding structural ones) as key=value.
+        children: Child nodes (populated for AND/OR groups).
+        preset_name: The preset name (only for node_type="preset").
+    """
+
+    text: str
+    node_type: str
+    negated: bool = False
+    params: dict[str, str] = field(default_factory=dict)
+    children: list[RenderedNode] = field(default_factory=list)
+    preset_name: str | None = None
+
+
+def render_conditions(conditions: dict | list) -> list[RenderedNode]:
+    """Convert an OAR condition tree into a list of RenderedNode trees.
+
+    Handles both top-level list format and top-level dict format.
+    Returns an empty list for empty/invalid input.
+
+    Args:
+        conditions: The raw OAR conditions — either a list of condition
+            dicts or a single dict with a "conditions" key.
+
+    Returns:
+        A list of RenderedNode instances representing the tree.
+    """
+    if isinstance(conditions, list):
+        return [
+            node for item in conditions if (node := _render_node(item)) is not None
+        ]
+
+    if isinstance(conditions, dict):
+        if not conditions:
+            return []
+        # Dict with a "conditions" key is a group node
+        if "conditions" in conditions:
+            group_type = conditions.get("condition", "AND")
+            if group_type not in _GROUP_TYPES:
+                group_type = "AND"
+            children_raw = conditions.get("conditions", [])
+            children = [
+                node
+                for item in children_raw
+                if (node := _render_node(item)) is not None
+            ]
+            return [RenderedNode(
+                text=group_type,
+                node_type=group_type,
+                children=children,
+            )]
+        # Dict without "conditions" key — single leaf node
+        node = _render_node(conditions)
+        return [node] if node is not None else []
+
+    return []
+
+
+def _render_node(item: object) -> RenderedNode | None:
+    """Render a single condition dict into a RenderedNode.
+
+    Returns None for non-dict items (defensive skip).
+    """
+    if not isinstance(item, dict):
+        return None
+
+    condition_type = item.get("condition")
+    if not isinstance(condition_type, str):
+        return None
+
+    # PRESET reference
+    if condition_type == "PRESET":
+        preset_name = item.get("Preset", "")
+        return RenderedNode(
+            text=f"PRESET: {preset_name}",
+            node_type="preset",
+            preset_name=preset_name if isinstance(preset_name, str) else "",
+        )
+
+    # AND/OR group node
+    if condition_type in _GROUP_TYPES and "conditions" in item:
+        children_raw = item.get("conditions", [])
+        children = [
+            node
+            for child in children_raw
+            if (node := _render_node(child)) is not None
+        ]
+        return RenderedNode(
+            text=condition_type,
+            node_type=condition_type,
+            children=children,
+        )
+
+    # Leaf condition
+    negated = bool(item.get("negated", False))
+    params = {
+        k: str(v) for k, v in item.items() if k not in _STRUCTURAL_KEYS
+    }
+    return RenderedNode(
+        text=condition_type,
+        node_type="leaf",
+        negated=negated,
+        params=params,
+    )
+
+
+def resolve_preset(
+    preset_name: str, presets: dict
+) -> list[RenderedNode] | None:
+    """Resolve a PRESET reference using the replacer's conditionPresets.
+
+    Args:
+        preset_name: The name of the preset to look up.
+        presets: The conditionPresets dict from the replacer config.
+            Keys are preset names, values are condition dicts/lists.
+
+    Returns:
+        A list of RenderedNode trees for the preset's conditions,
+        or None if the preset name is not found.
+    """
+    if not isinstance(presets, dict):
+        return None
+    preset_data = presets.get(preset_name)
+    if preset_data is None:
+        return None
+    return render_conditions(preset_data)

--- a/src/oar_priority_manager/ui/conditions_renderer.py
+++ b/src/oar_priority_manager/ui/conditions_renderer.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 # Keys that are structural (not user-visible parameters).
+# "Conditions" (capital-C) is the real OAR format for AND/OR child lists.
+# "requiredVersion" and "disabled" appear on almost every real condition but
+# carry no user-meaningful semantic — omit them from the params display.
 _STRUCTURAL_KEYS: frozenset[str] = frozenset({
-    "condition", "negated", "conditions", "Preset",
+    "condition", "negated", "conditions", "Conditions", "Preset",
+    "requiredVersion", "disabled",
 })
 
 # OAR group-node condition types.
@@ -60,12 +64,14 @@ def render_conditions(conditions: dict | list) -> list[RenderedNode]:
     if isinstance(conditions, dict):
         if not conditions:
             return []
-        # Dict with a "conditions" key is a group node
-        if "conditions" in conditions:
+        # Dict with a "conditions"/"Conditions" key is a group node.
+        # Real OAR data uses capital-C "Conditions"; support both.
+        children_key = "Conditions" if "Conditions" in conditions else "conditions"
+        if children_key in conditions:
             group_type = conditions.get("condition", "AND")
             if group_type not in _GROUP_TYPES:
                 group_type = "AND"
-            children_raw = conditions.get("conditions", [])
+            children_raw = conditions.get(children_key, [])
             children = [
                 node
                 for item in children_raw
@@ -76,7 +82,7 @@ def render_conditions(conditions: dict | list) -> list[RenderedNode]:
                 node_type=group_type,
                 children=children,
             )]
-        # Dict without "conditions" key — single leaf node
+        # Dict without "conditions"/"Conditions" key — single leaf node
         node = _render_node(conditions)
         return [node] if node is not None else []
 
@@ -104,9 +110,11 @@ def _render_node(item: object) -> RenderedNode | None:
             preset_name=preset_name if isinstance(preset_name, str) else "",
         )
 
-    # AND/OR group node
-    if condition_type in _GROUP_TYPES and "conditions" in item:
-        children_raw = item.get("conditions", [])
+    # AND/OR group node.
+    # Real OAR uses capital-C "Conditions"; support both case variants.
+    children_key = "Conditions" if "Conditions" in item else "conditions"
+    if condition_type in _GROUP_TYPES and children_key in item:
+        children_raw = item.get(children_key, [])
         children = [
             node
             for child in children_raw

--- a/src/oar_priority_manager/ui/conditions_renderer.py
+++ b/src/oar_priority_manager/ui/conditions_renderer.py
@@ -131,6 +131,46 @@ def _render_node(item: object) -> RenderedNode | None:
     )
 
 
+def conditions_stats(nodes: list[RenderedNode]) -> dict[str, int]:
+    """Compute summary statistics for a rendered condition tree.
+
+    Walks the tree and counts leaf conditions, unique types, negated
+    leaves, and preset references.
+
+    Args:
+        nodes: The top-level list of RenderedNode from render_conditions().
+
+    Returns:
+        Dict with keys: "conditions", "types", "negated", "presets".
+    """
+    types: set[str] = set()
+    total = 0
+    negated = 0
+    presets = 0
+
+    def _walk(node_list: list[RenderedNode]) -> None:
+        nonlocal total, negated, presets
+        for node in node_list:
+            if node.node_type == "preset":
+                presets += 1
+            elif node.node_type in ("AND", "OR"):
+                _walk(node.children)
+            else:
+                # leaf
+                total += 1
+                types.add(node.text)
+                if node.negated:
+                    negated += 1
+
+    _walk(nodes)
+    return {
+        "conditions": total,
+        "types": len(types),
+        "negated": negated,
+        "presets": presets,
+    }
+
+
 def resolve_preset(
     preset_name: str, presets: dict
 ) -> list[RenderedNode] | None:

--- a/src/oar_priority_manager/ui/details_panel.py
+++ b/src/oar_priority_manager/ui/details_panel.py
@@ -113,6 +113,16 @@ class DetailsPanel(QWidget):
             lines.append(
                 f"<span style='color:red'>Disabled: {n_disabled}</span>"
             )
+
+        # Aggregate warnings from all descendant submods
+        n_with_warnings = sum(1 for sm in all_submods if sm.has_warnings)
+        if n_with_warnings:
+            lines.append(
+                f"<span style='color:#e66'>"
+                f"&#9888; {n_with_warnings} submod(s) have warnings"
+                f"</span>"
+            )
+
         return "<br>".join(lines)
 
     def _render_replacer(self, node: TreeNode) -> str:
@@ -159,6 +169,16 @@ class DetailsPanel(QWidget):
         lines.append(
             f"Priority overrides: <b>{n_overridden}</b> of {n_submods} submods"
         )
+
+        # Aggregate warnings from all child submods
+        n_with_warnings = sum(1 for sm in all_submods if sm.has_warnings)
+        if n_with_warnings:
+            lines.append(
+                f"<span style='color:#e66'>"
+                f"&#9888; {n_with_warnings} submod(s) have warnings"
+                f"</span>"
+            )
+
         return "<br>".join(lines)
 
     def _render_submod(self, node: TreeNode) -> str:
@@ -192,6 +212,21 @@ class DetailsPanel(QWidget):
         # Overridden badge
         if submod.is_overridden:
             lines.append("<span style='color:#ccaa00'><b>OVERRIDDEN</b></span>")
+
+        # External override badge — near the top so it's immediately visible
+        if (
+            submod.override_source == OverrideSource.OVERWRITE
+            and not submod.override_is_ours
+        ):
+            lines.append(
+                "<span style='background-color:#3a2800; color:orange'>"
+                "<b>&nbsp;&#9888; EXTERNAL OVERRIDE&nbsp;</b>"
+                "</span>"
+                "<span style='color:#cc8800'>"
+                " &mdash; Priority was changed by another tool or manual edit,"
+                " not by this app"
+                "</span>"
+            )
 
         # Description (optional)
         if submod.description:
@@ -231,14 +266,11 @@ class DetailsPanel(QWidget):
         source_label = _override_source_label(submod.override_source)
         lines.append(f"<span style='color:gray'>{source_label}</span>")
 
-        # External override badge
-        if (
-            submod.override_source == OverrideSource.OVERWRITE
-            and not submod.override_is_ours
-        ):
-            lines.append(
-                "<span style='color:orange'><b>&#9888; EXTERNAL OVERRIDE</b></span>"
-            )
+        # Warnings section — parse errors and validation issues
+        if submod.warnings:
+            lines.append("<br><span style='color:#e66'><b>&#9888; Warnings</b></span>")
+            for warning in submod.warnings:
+                lines.append(f"<span style='color:#e66'>&#8226; {warning}</span>")
 
         return "<br>".join(lines)
 

--- a/src/oar_priority_manager/ui/details_panel.py
+++ b/src/oar_priority_manager/ui/details_panel.py
@@ -113,6 +113,16 @@ class DetailsPanel(QWidget):
             lines.append(
                 f"<span style='color:red'>Disabled: {n_disabled}</span>"
             )
+
+        # Rollup tag pills from all descendant submods
+        mod_tags: set = set()
+        for rep in node.children:
+            for sub in rep.children:
+                if sub.submod and sub.submod.tags:
+                    mod_tags.update(sub.submod.tags)
+        tags_html = self._render_tag_pills(mod_tags)
+        lines.append(f"<b>Tags:</b> {tags_html}")
+
         return "<br>".join(lines)
 
     def _render_replacer(self, node: TreeNode) -> str:
@@ -227,6 +237,10 @@ class DetailsPanel(QWidget):
         n_types = len(submod.condition_types_present)
         lines.append(f"Conditions: {n_conditions} entries · {n_types} types")
 
+        # Tag pills
+        tags_html = self._render_tag_pills(submod.tags)
+        lines.append(f"<b>Tags:</b> {tags_html}")
+
         # Override source label
         source_label = _override_source_label(submod.override_source)
         lines.append(f"<span style='color:gray'>{source_label}</span>")
@@ -241,6 +255,40 @@ class DetailsPanel(QWidget):
             )
 
         return "<br>".join(lines)
+
+
+    @staticmethod
+    def _render_tag_pills(tags: set) -> str:
+        """Render tags as HTML pills for the details panel.
+
+        Args:
+            tags: A set of TagCategory values (or any tag objects) to render.
+
+        Returns:
+            An HTML string of inline pill spans, or a grey "None detected"
+            placeholder when the set is empty.
+        """
+        from oar_priority_manager.core.tag_engine import TagCategory
+        from oar_priority_manager.ui.tag_delegate import sorted_tags
+
+        if not tags:
+            return '<span style="color:#666">None detected</span>'
+
+        pills = []
+        for tag in sorted_tags(tags):
+            if isinstance(tag, TagCategory):
+                pills.append(
+                    f'<span style="'
+                    f"background:{tag.color_bg};"
+                    f"color:{tag.color_fg};"
+                    f"border:1px solid {tag.color_border};"
+                    f"border-radius:6px;"
+                    f"padding:1px 6px;"
+                    f"font-size:10px;"
+                    f"font-weight:bold;"
+                    f'">{tag.label}</span>'
+                )
+        return " ".join(pills)
 
 
 # ------------------------------------------------------------------

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -9,7 +9,15 @@ from pathlib import Path
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QKeySequence, QShortcut
-from PySide6.QtWidgets import QHBoxLayout, QMainWindow, QPushButton, QSplitter, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
 
 from oar_priority_manager.app.config import AppConfig
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
@@ -46,6 +54,9 @@ class MainWindow(QMainWindow):
         self._stacks = stacks
         self._config = app_config
         self._instance_root = instance_root
+        # Tracks whether the search filter should hide non-matches (True)
+        # or dim them (False, the default).  Updated via SearchBar.filter_mode_changed.
+        self._hide_mode: bool = False
 
         self._setup_ui()
         self._connect_signals()
@@ -115,6 +126,7 @@ class MainWindow(QMainWindow):
         self._tree_panel.selection_changed.connect(self._on_tree_selection)
         self._search_bar.search_changed.connect(self._on_search)
         self._search_bar.refresh_requested.connect(self._on_refresh)
+        self._search_bar.filter_mode_changed.connect(self._on_filter_mode_changed)
         self._stacks_panel.action_triggered.connect(self._on_action)
         self._stacks_panel.competitor_focused.connect(self._on_competitor_focused)
 
@@ -130,6 +142,17 @@ class MainWindow(QMainWindow):
         if submod:
             self._conditions_panel.update_focus(submod)
 
+    def _on_filter_mode_changed(self, hide_mode: bool) -> None:
+        """Update the stored hide/dim mode (issued by SearchBar.filter_mode_changed).
+
+        The SearchBar also re-emits search_changed after this signal, so the
+        active filter is automatically re-applied with the new mode.
+
+        Args:
+            hide_mode: True = hide non-matching items, False = dim them.
+        """
+        self._hide_mode = hide_mode
+
     def _on_search(self, query: str) -> None:
         """Filter tree based on search query (spec §7.2)."""
         if not query.strip():
@@ -140,7 +163,102 @@ class MainWindow(QMainWindow):
         index = SearchIndex(self._tree_panel.tree_root, self._conflict_map)
         results = index.search(query)
         matching = {id(r.node) for r in results}
-        self._tree_panel.filter_tree(matching)
+        self._tree_panel.filter_tree(matching, hide_mode=self._hide_mode)
+
+    def _confirm_action(self, action: str, submod: SubMod, value: object) -> bool:
+        """Show a preview dialog for the proposed priority change and return True if confirmed.
+
+        Computes what the new priorities would be WITHOUT applying them, formats a
+        human-readable summary with current → new values, and asks the user to
+        confirm via QMessageBox.question.
+
+        Args:
+            action: One of "move_to_top", "move_to_top_replacer", "move_to_top_mod",
+                    "set_exact", or "shift".
+            submod: The target submod the action was triggered for.
+            value:  Action-specific parameter (int priority for "set_exact",
+                    int delta for "shift", None for move_to_top variants).
+
+        Returns:
+            True if the user clicked OK/Yes; False if they cancelled.
+        """
+        from oar_priority_manager.core.priority_resolver import (
+            PriorityOverflowError,
+            move_to_top,
+            set_exact,
+        )
+
+        try:
+            if action == "move_to_top":
+                preview = move_to_top(submod, self._conflict_map, scope="submod")
+                if not preview:
+                    # Already winning — nothing to confirm; let _on_action handle gracefully.
+                    return True
+                new_p = preview[submod]
+                msg = (
+                    f"Move {submod.name} to top\n\n"
+                    f"Current priority: {submod.priority}\n"
+                    f"New priority:     {new_p}"
+                )
+
+            elif action == "move_to_top_replacer":
+                preview = move_to_top(submod, self._conflict_map, scope="replacer")
+                if not preview:
+                    return True
+                lines = [f"Move replacer '{submod.replacer}' to top\n"]
+                lines.append(f"{'Submod':<30}  {'Current':>10}  {'New':>10}")
+                lines.append("-" * 54)
+                for sm, new_p in sorted(preview.items(), key=lambda kv: kv[0].name):
+                    lines.append(f"{sm.name:<30}  {sm.priority:>10}  {new_p:>10}")
+                lines.append(f"\n{len(preview)} submod(s) will be updated.")
+                msg = "\n".join(lines)
+
+            elif action == "move_to_top_mod":
+                preview = move_to_top(submod, self._conflict_map, scope="mod")
+                if not preview:
+                    return True
+                lines = [f"Move mod '{submod.mo2_mod}' to top\n"]
+                lines.append(f"{'Submod':<30}  {'Current':>10}  {'New':>10}")
+                lines.append("-" * 54)
+                for sm, new_p in sorted(preview.items(), key=lambda kv: kv[0].name):
+                    lines.append(f"{sm.name:<30}  {sm.priority:>10}  {new_p:>10}")
+                lines.append(f"\n{len(preview)} submod(s) will be updated.")
+                msg = "\n".join(lines)
+
+            elif action == "set_exact" and isinstance(value, int):
+                # set_exact is a pure function — call it only to validate range.
+                set_exact(submod, value)
+                msg = (
+                    f"Set {submod.name} priority\n\n"
+                    f"Current priority: {submod.priority}\n"
+                    f"New priority:     {value}"
+                )
+
+            elif action == "shift" and isinstance(value, int):
+                new_p = submod.priority + value
+                direction = f"+{value}" if value >= 0 else str(value)
+                msg = (
+                    f"Shift {submod.name} priority by {direction}\n\n"
+                    f"Current priority: {submod.priority}\n"
+                    f"New priority:     {new_p}"
+                )
+
+            else:
+                # Unknown action — pass through without a dialog.
+                return True
+
+        except PriorityOverflowError as e:
+            # Surface overflow immediately so _on_action doesn't need to re-catch it.
+            QMessageBox.warning(self, "Priority Overflow", str(e))
+            return False
+
+        reply = QMessageBox.question(
+            self,
+            "Confirm Priority Change",
+            msg,
+            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+        )
+        return reply == QMessageBox.StandardButton.Ok
 
     def _on_action(self, action: str, submod: SubMod, value: object) -> None:
         """Handle priority mutation actions from the stacks panel (spec §6.3 step 5)."""
@@ -150,6 +268,9 @@ class MainWindow(QMainWindow):
             move_to_top,
             set_exact,
         )
+
+        if not self._confirm_action(action, submod, value):
+            return
 
         try:
             if action == "move_to_top":
@@ -181,7 +302,6 @@ class MainWindow(QMainWindow):
             )
 
         except PriorityOverflowError as e:
-            from PySide6.QtWidgets import QMessageBox
             QMessageBox.warning(self, "Priority Overflow", str(e))
 
     def _on_clear_overrides(self) -> None:

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -129,6 +129,9 @@ class MainWindow(QMainWindow):
         self._search_bar.filter_mode_changed.connect(self._on_filter_mode_changed)
         self._stacks_panel.action_triggered.connect(self._on_action)
         self._stacks_panel.competitor_focused.connect(self._on_competitor_focused)
+        self._stacks_panel.navigate_to_submod.connect(  # issue #60
+            self._on_navigate_to_submod
+        )
 
     def _on_tree_selection(self, node) -> None:
         self._details_panel.update_selection(node)
@@ -141,6 +144,20 @@ class MainWindow(QMainWindow):
         """Update conditions panel when a competitor row is clicked (spec §7.5)."""
         if submod:
             self._conditions_panel.update_focus(submod)
+
+    def _on_navigate_to_submod(self, submod: SubMod) -> None:
+        """Navigate to a competitor submod in the tree panel (issue #60).
+
+        Called when the user selects "Go to in tree" from the right-click
+        context menu on a competitor row.  Delegates to
+        ``TreePanel.select_submod``, which scrolls the tree to the item
+        and fires the ``selection_changed`` signal so the rest of the UI
+        updates consistently.
+
+        Args:
+            submod: The competitor ``SubMod`` to navigate to.
+        """
+        self._tree_panel.select_submod(submod)
 
     def _on_filter_mode_changed(self, hide_mode: bool) -> None:
         """Update the stored hide/dim mode (issued by SearchBar.filter_mode_changed).

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -82,7 +82,7 @@ class MainWindow(QMainWindow):
 
         # Left column: tree + details (vertical split)
         self._left_splitter = QSplitter(Qt.Orientation.Vertical)
-        self._tree_panel = TreePanel(self._submods)
+        self._tree_panel = TreePanel(self._submods, app_config=self._config)
         self._details_panel = DetailsPanel()
         self._left_splitter.addWidget(self._tree_panel)
         self._left_splitter.addWidget(self._details_panel)
@@ -263,6 +263,11 @@ class MainWindow(QMainWindow):
             present, negated = extract_condition_types(sm.conditions)
             sm.condition_types_present = present
             sm.condition_types_negated = negated
+
+        from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
+        for sm in self._submods:
+            sm.tags = compute_tags(sm)
+        apply_overrides(self._submods, self._config.tag_overrides)
 
         self._tree_panel.refresh(self._submods)
         self._stacks_panel.refresh(self._conflict_map)

--- a/src/oar_priority_manager/ui/search_bar.py
+++ b/src/oar_priority_manager/ui/search_bar.py
@@ -10,11 +10,13 @@ from PySide6.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QWidget
 
 
 class SearchBar(QWidget):
-    """Top-bar search input with Advanced button and Refresh button."""
+    """Top-bar search input with Advanced button, Hide toggle, and Refresh button."""
 
     search_changed = Signal(str)
     refresh_requested = Signal()
     advanced_requested = Signal()
+    # Emitted when the hide/dim mode changes. True = hide mode, False = dim mode.
+    filter_mode_changed = Signal(bool)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -26,6 +28,17 @@ class SearchBar(QWidget):
         self._input.textChanged.connect(self.search_changed.emit)
         layout.addWidget(self._input, stretch=1)
 
+        # Hide/Dim toggle: unchecked = dim (default), checked = hide
+        self._hide_btn = QPushButton("Hide")
+        self._hide_btn.setCheckable(True)
+        self._hide_btn.setChecked(False)
+        self._hide_btn.setToolTip(
+            "When checked, non-matching items are hidden entirely.\n"
+            "When unchecked, non-matching items are dimmed (default)."
+        )
+        self._hide_btn.clicked.connect(self._on_filter_mode_changed)
+        layout.addWidget(self._hide_btn)
+
         self._advanced_btn = QPushButton("Advanced...")
         self._advanced_btn.clicked.connect(self.advanced_requested.emit)
         layout.addWidget(self._advanced_btn)
@@ -33,6 +46,23 @@ class SearchBar(QWidget):
         self._refresh_btn = QPushButton("Refresh")
         self._refresh_btn.clicked.connect(self.refresh_requested.emit)
         layout.addWidget(self._refresh_btn)
+
+    def _on_filter_mode_changed(self) -> None:
+        """Handle the Hide toggle being clicked.
+
+        Emits both ``filter_mode_changed`` (so the window can update state)
+        and ``search_changed`` (so the active filter re-applies immediately
+        with the new mode).
+        """
+        hide_mode = self._hide_btn.isChecked()
+        self.filter_mode_changed.emit(hide_mode)
+        # Re-emit the current query so the filter re-applies in the new mode.
+        self.search_changed.emit(self._input.text())
+
+    @property
+    def hide_mode(self) -> bool:
+        """Return True when the Hide button is currently checked."""
+        return self._hide_btn.isChecked()
 
     def focus_search(self) -> None:
         """Focus the search input and select all text."""

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -14,6 +14,7 @@ Issues addressed:
   #61 — Target badge label showing which submod action buttons apply to
   #68 — Action buttons moved to toolbar row
   #69 — Relative/Absolute replaced with segmented toggle control
+  #74 — Collapse same-mod competitor rows into a single summary row
 """
 
 from __future__ import annotations
@@ -180,6 +181,102 @@ def _make_competitor_row(
 
 
 # ---------------------------------------------------------------------------
+# Helper widget: collapsible same-mod sibling group (issue #74)
+# ---------------------------------------------------------------------------
+
+class _ModGroupRow(QWidget):
+    """A clickable summary row that collapses/expands same-mod sibling rows.
+
+    Rendered as a sub-header inside a ``_StackSection`` when more than one
+    submod from the same MO2 mod appears in the competitor list.  Individual
+    sibling rows are stored as children and toggled on click.
+
+    Args:
+        mod_name: The MO2 mod name used as the group label.
+        sibling_count: Number of sibling submods in the group (excluding the
+            "you" row, which is always visible outside the group).
+        collapsed: Initial collapsed state.  Defaults to ``True`` so groups
+            start collapsed and the panel stays compact.
+        parent: Optional parent widget.
+    """
+
+    def __init__(
+        self,
+        mod_name: str,
+        sibling_count: int,
+        collapsed: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._collapsed = collapsed
+        self._mod_name = mod_name
+        self._sibling_count = sibling_count
+        self._child_rows: list[QWidget] = []
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Summary button — acts as the toggle handle
+        self._btn = QPushButton()
+        self._btn.setFlat(True)
+        self._btn.setStyleSheet(
+            "QPushButton { text-align: left; padding: 2px 8px;"
+            "  color: #8ab; font-style: italic; }"
+            "QPushButton:hover { background: rgba(255,255,255,0.05); }"
+        )
+        self._btn.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._btn.clicked.connect(self._toggle)
+        layout.addWidget(self._btn)
+
+        # Container for child rows
+        self._child_container = QWidget()
+        self._child_layout = QVBoxLayout(self._child_container)
+        self._child_layout.setContentsMargins(0, 0, 0, 0)
+        self._child_layout.setSpacing(1)
+        layout.addWidget(self._child_container)
+
+        self._update_label()
+        self._child_container.setVisible(not self._collapsed)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def add_child_row(self, row_widget: QWidget) -> None:
+        """Append a sibling competitor row to this group's child container.
+
+        Args:
+            row_widget: The competitor row widget to add.
+        """
+        self._child_rows.append(row_widget)
+        self._child_layout.addWidget(row_widget)
+
+    @property
+    def is_collapsed(self) -> bool:
+        """Whether the group is currently collapsed."""
+        return self._collapsed
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _toggle(self) -> None:
+        self._collapsed = not self._collapsed
+        self._child_container.setVisible(not self._collapsed)
+        self._update_label()
+
+    def _update_label(self) -> None:
+        arrow = "▸" if self._collapsed else "▾"
+        noun = "sibling" if self._sibling_count == 1 else "siblings"
+        self._btn.setText(
+            f"{arrow} {self._mod_name} ({self._sibling_count} {noun})"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Main panel
 # ---------------------------------------------------------------------------
 
@@ -203,6 +300,8 @@ class StacksPanel(QWidget):
         self._current_submod: SubMod | None = None
         self._relative_mode = True
         self._collapsed: dict[str, bool] = {}  # anim -> collapsed state (issue #35)
+        # Keyed by f"{anim}:{mo2_mod}" — persists expand/collapse across refreshes
+        self._mod_group_collapsed: dict[str, bool] = {}  # issue #74
         self._setup_ui()
 
     # ------------------------------------------------------------------
@@ -577,7 +676,42 @@ class StacksPanel(QWidget):
         section._header_btn.clicked.disconnect()
         section._header_btn.clicked.connect(_patched_toggle)
 
-        # Competitor rows
+        # ---- Competitor rows with same-mod grouping (issue #74) ----
+        # Competitors from the same MO2 mod as the selected submod are grouped
+        # into a collapsible _ModGroupRow.  Cross-mod competitors remain as
+        # individual rows.  The "you" row is always rendered outside the group.
+        selected_mod = selected.mo2_mod
+
+        # Count how many competitors share the selected submod's MO2 mod
+        # (excluding the selected submod itself) to decide whether to group.
+        same_mod_siblings = [
+            c for c in competitors if c.mo2_mod == selected_mod and c is not selected
+        ]
+        use_group = len(same_mod_siblings) > 0
+
+        # Build the _ModGroupRow once if needed so sibling rows can be added to it.
+        group_row: _ModGroupRow | None = None
+        group_inserted = False  # track whether the group widget is in the section yet
+
+        if use_group:
+            state_key = f"{anim}:{selected_mod}"
+            initial_collapsed = self._mod_group_collapsed.get(state_key, True)
+            group_row = _ModGroupRow(
+                mod_name=selected_mod,
+                sibling_count=len(same_mod_siblings),
+                collapsed=initial_collapsed,
+            )
+
+            # Persist state changes back to _mod_group_collapsed
+            def _on_group_toggle(
+                *,
+                gr: _ModGroupRow = group_row,
+                key: str = state_key,
+            ) -> None:
+                self._mod_group_collapsed[key] = gr.is_collapsed
+
+            group_row._btn.clicked.connect(_on_group_toggle)
+
         for i, comp in enumerate(competitors):
             is_you = comp is selected
             rank_num = i + 1
@@ -615,7 +749,24 @@ class StacksPanel(QWidget):
                 )
             )
 
-            section.add_row(row)
+            # Route row into the correct container (issue #74):
+            #   - "you" row: always goes directly into the section (always visible)
+            #   - Same-mod sibling: routed into the group's child container
+            #   - Cross-mod competitor: goes directly into the section
+            if is_you:
+                # The "you" row is always visible — never hidden inside the group
+                section.add_row(row)
+            elif use_group and comp.mo2_mod == selected_mod:
+                # Same-mod sibling: insert group header before first sibling row,
+                # then add this row as a child of the group.
+                assert group_row is not None  # guaranteed by use_group
+                if not group_inserted:
+                    section.add_row(group_row)
+                    group_inserted = True
+                group_row.add_child_row(row)
+            else:
+                # Cross-mod competitor: individual row, no grouping
+                section.add_row(row)
 
         return section
 

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -610,8 +610,8 @@ class StacksPanel(QWidget):
                 Qt.ContextMenuPolicy.CustomContextMenu
             )
             row.customContextMenuRequested.connect(
-                lambda pos, c=_comp: self._show_competitor_context_menu(
-                    row, pos, c
+                lambda pos, c=_comp, r=row: self._show_competitor_context_menu(
+                    r, pos, c
                 )
             )
 

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -10,6 +10,7 @@ Issues addressed:
   #46 — Shift by N button
   #47 — Animation filter input
   #48 — Collapse-winning toggle button
+  #61 — Target badge label showing which submod action buttons apply to
   #68 — Action buttons moved to toolbar row
   #69 — Relative/Absolute replaced with segmented toggle control
 """
@@ -277,6 +278,22 @@ class StacksPanel(QWidget):
         # Spacer between toggle and action buttons
         toolbar.addSpacing(12)
 
+        # -- Target badge: shows which submod the action buttons apply to --
+        # (issue #61) Prevents confusion when clicking competitor rows updates
+        # the conditions panel but actions still target the tree selection.
+        self._target_label = QLabel()
+        self._target_label.setMaximumWidth(300)
+        self._target_label.setWordWrap(False)
+        self._target_label.setTextFormat(Qt.TextFormat.RichText)
+        self._target_label.setToolTip(
+            "The action buttons (Move to Top, Set Exact, etc.) apply to this"
+            " submod, even when a competitor row is highlighted."
+        )
+        self._update_target_label(None)
+        toolbar.addWidget(self._target_label)
+
+        toolbar.addSpacing(8)
+
         # -- Action buttons inlined into toolbar (issue #68) --
         self._move_to_top_btn = QPushButton("Move to Top")
         self._move_to_top_btn.clicked.connect(
@@ -368,9 +385,16 @@ class StacksPanel(QWidget):
         """Update stacks display for the selected submod.
 
         Disables action buttons when the submod has warnings (spec §9) or
-        when no submod is selected.
+        when no submod is selected.  Also refreshes the target badge so
+        the toolbar always shows which submod the action buttons apply to
+        (issue #61).
+
+        Args:
+            submod: The newly selected SubMod, or ``None`` to clear.
         """
         self._current_submod = submod
+        # Update target badge (issue #61)
+        self._update_target_label(submod)
         # Disable action buttons when submod has warnings (spec §9)
         has_warnings = submod.has_warnings if submod else True
         enabled = not has_warnings and submod is not None
@@ -402,6 +426,38 @@ class StacksPanel(QWidget):
         """Refresh display using updated conflict map."""
         self._conflict_map = conflict_map
         self._refresh_display()
+
+    # ------------------------------------------------------------------
+    # Internal: target label (issue #61)
+    # ------------------------------------------------------------------
+
+    def _update_target_label(self, submod: SubMod | None) -> None:
+        """Update the toolbar target badge to reflect the action target.
+
+        When a submod is selected the label reads
+        ``"▸ Actions apply to: <b>SubModName</b>"`` in muted grey.
+        When nothing is selected it shows ``"No submod selected"`` in
+        dim grey so the badge is always present but visually quiet.
+
+        Args:
+            submod: The currently selected SubMod, or ``None`` when
+                nothing is selected.
+        """
+        if submod is None:
+            self._target_label.setText(
+                "<span style='color:#666;'>No submod selected</span>"
+            )
+        else:
+            # Elide long names to keep the toolbar compact.  Qt rich-text
+            # labels do not support built-in elision, so we truncate the
+            # raw name string before embedding it.
+            name = submod.name
+            if len(name) > 40:  # noqa: PLR2004
+                name = name[:37] + "…"
+            self._target_label.setText(
+                f"<span style='color:#aaa;'>&#9656; Actions apply to:"
+                f" <b>{name}</b></span>"
+            )
 
     # ------------------------------------------------------------------
     # Internal: mode toggle

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -7,6 +7,9 @@ Issues addressed:
   #34 — Rank badge colours (green for #1, grey for rest; red bg for losing rows)
   #35 — Expand/collapse animation sections
   #36 — Clickable competitor rows emitting competitor_focused signal
+  #46 — Shift by N button
+  #47 — Animation filter input
+  #48 — Collapse-winning toggle button
   #68 — Action buttons moved to toolbar row
   #69 — Relative/Absolute replaced with segmented toggle control
 """
@@ -18,7 +21,9 @@ from PySide6.QtWidgets import (
     QButtonGroup,
     QFrame,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
+    QLineEdit,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -301,9 +306,34 @@ class StacksPanel(QWidget):
         )
         toolbar.addWidget(self._move_mod_btn)
 
+        # -- Shift by N button (issue #46) --
+        self._shift_btn = QPushButton("Shift…")
+        self._shift_btn.setToolTip("Shift priority by a relative amount")
+        self._shift_btn.clicked.connect(self._on_shift)
+        toolbar.addWidget(self._shift_btn)
+
+        # -- Hide Winning toggle (issue #48) --
+        self._collapse_winning_btn = QPushButton("Hide Winning")
+        self._collapse_winning_btn.setCheckable(True)
+        self._collapse_winning_btn.setToolTip(
+            "Collapse sections where the selected submod is already #1"
+        )
+        self._collapse_winning_btn.toggled.connect(self._on_collapse_winning)
+        toolbar.addWidget(self._collapse_winning_btn)
+
         # No trailing stretch — toolbar fills naturally; action btns are right
         # of the spacer and the segmented toggle anchors to the left.
         layout.addWidget(toolbar_widget)
+
+        # ---- Animation filter input (issue #47) ----
+        # Placed below the toolbar row, above the header label, so it targets
+        # the scroll area content without cluttering the action-button row.
+        self._anim_filter = QLineEdit()
+        self._anim_filter.setPlaceholderText("Filter animations…")
+        self._anim_filter.setMaximumHeight(28)
+        self._anim_filter.setClearButtonEnabled(True)
+        self._anim_filter.textChanged.connect(self._on_anim_filter)
+        layout.addWidget(self._anim_filter)
 
         # ---- Toast notification (issue #37, spec §7.4) ----
         self._toast = QLabel()
@@ -348,6 +378,7 @@ class StacksPanel(QWidget):
         self._set_exact_btn.setEnabled(enabled)
         self._move_rep_btn.setEnabled(enabled)
         self._move_mod_btn.setEnabled(enabled)
+        self._shift_btn.setEnabled(enabled)  # issue #46
         self._refresh_display()
 
     def show_toast(self, message: str) -> None:
@@ -463,6 +494,11 @@ class StacksPanel(QWidget):
         header_text = f"{anim} · {len(competitors)} competitors · {status}"
         section = _StackSection(header_text)
 
+        # Store metadata needed by filter (issue #47) and hide-winning
+        # (issue #48) without subclassing _StackSection.
+        section.anim_name = anim  # type: ignore[attr-defined]
+        section.is_winning = rank == 0  # type: ignore[attr-defined]
+
         # Restore collapsed state (issue #35)
         if self._collapsed.get(anim, False):
             # Simulate collapse without extra toggle machinery
@@ -515,7 +551,7 @@ class StacksPanel(QWidget):
     # ------------------------------------------------------------------
 
     def _on_set_exact(self) -> None:
-        from PySide6.QtWidgets import QInputDialog
+        """Open a dialog to set the selected submod's priority to an exact value."""
         if self._current_submod is None:
             return
         value, ok = QInputDialog.getInt(
@@ -526,3 +562,84 @@ class StacksPanel(QWidget):
         )
         if ok:
             self.action_triggered.emit("set_exact", self._current_submod, value)
+
+    # ------------------------------------------------------------------
+    # Shift dialog (issue #46)
+    # ------------------------------------------------------------------
+
+    def _on_shift(self) -> None:
+        """Open a dialog to shift the selected submod's priority by a delta.
+
+        Prompts the user for a positive or negative integer offset, then
+        emits ``action_triggered("shift", submod, delta)`` on confirmation.
+        """
+        if self._current_submod is None:
+            return
+        value, ok = QInputDialog.getInt(
+            self, "Shift Priority",
+            "Shift priority by:",
+            value=0,
+            min=-2_147_483_648, max=2_147_483_647,
+        )
+        if ok:
+            self.action_triggered.emit("shift", self._current_submod, value)
+
+    # ------------------------------------------------------------------
+    # Animation filter (issue #47)
+    # ------------------------------------------------------------------
+
+    def _on_anim_filter(self, query: str) -> None:
+        """Show only stack sections whose animation name contains *query*.
+
+        Iterates every ``_StackSection`` widget currently in the scroll
+        area's content layout and toggles visibility based on a
+        case-insensitive substring match.  An empty query restores all
+        sections.
+
+        Args:
+            query: The filter string typed by the user.
+        """
+        q = query.lower()
+        for i in range(self._content_layout.count()):
+            item = self._content_layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if not isinstance(widget, _StackSection):
+                continue
+            anim_name: str = getattr(widget, "anim_name", "")
+            visible = not q or q in anim_name.lower()
+            widget.setVisible(visible)
+
+    # ------------------------------------------------------------------
+    # Collapse-winning toggle (issue #48)
+    # ------------------------------------------------------------------
+
+    def _on_collapse_winning(self, checked: bool) -> None:
+        """Collapse or expand sections based on whether the submod is winning.
+
+        When *checked* is ``True``, every section where the selected
+        submod is rank #1 (``section.is_winning is True``) is collapsed
+        so the user can focus on conflicting animations.  When *checked*
+        is ``False``, all sections are expanded.
+
+        Args:
+            checked: ``True`` to hide winning sections, ``False`` to
+                restore all.
+        """
+        for i in range(self._content_layout.count()):
+            item = self._content_layout.itemAt(i)
+            if item is None:
+                continue
+            widget = item.widget()
+            if not isinstance(widget, _StackSection):
+                continue
+            is_winning: bool = getattr(widget, "is_winning", False)
+            if checked and is_winning:
+                # Collapse: force content hidden without toggling state
+                # so the header arrow stays consistent.
+                if widget._expanded:
+                    widget._toggle()
+            elif not checked and not widget._expanded:
+                # Expand all sections back.
+                widget._toggle()

--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -10,6 +10,7 @@ Issues addressed:
   #46 — Shift by N button
   #47 — Animation filter input
   #48 — Collapse-winning toggle button
+  #60 — Right-click context menu "Go to in tree" on competitor rows
   #61 — Target badge label showing which submod action buttons apply to
   #68 — Action buttons moved to toolbar row
   #69 — Relative/Absolute replaced with segmented toggle control
@@ -25,6 +26,7 @@ from PySide6.QtWidgets import (
     QInputDialog,
     QLabel,
     QLineEdit,
+    QMenu,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -188,6 +190,8 @@ class StacksPanel(QWidget):
     competitor_focused = Signal(object)
     # Emitted when user triggers a priority action: (action_name, submod, value)
     action_triggered = Signal(str, object, object)
+    # Emitted when user right-clicks a competitor and chooses "Go to in tree"
+    navigate_to_submod = Signal(object)  # issue #60
 
     def __init__(
         self,
@@ -598,9 +602,51 @@ class StacksPanel(QWidget):
                 relative_mode=self._relative_mode,
                 on_click=lambda checked=False, c=_comp: self.competitor_focused.emit(c),
             )
+
+            # Right-click "Go to in tree" context menu (issue #60).
+            # Context menu policy is set here (not inside _make_competitor_row)
+            # because the module-level helper has no access to self or signals.
+            row.setContextMenuPolicy(
+                Qt.ContextMenuPolicy.CustomContextMenu
+            )
+            row.customContextMenuRequested.connect(
+                lambda pos, c=_comp: self._show_competitor_context_menu(
+                    row, pos, c
+                )
+            )
+
             section.add_row(row)
 
         return section
+
+    # ------------------------------------------------------------------
+    # Competitor context menu (issue #60)
+    # ------------------------------------------------------------------
+
+    def _show_competitor_context_menu(
+        self,
+        row: QPushButton,
+        pos,
+        comp: SubMod,
+    ) -> None:
+        """Show a right-click context menu on a competitor row.
+
+        Presents a single "Go to in tree" action that emits
+        ``navigate_to_submod`` so the main window can select the
+        corresponding item in the tree panel.
+
+        Args:
+            row: The competitor row button the menu is anchored to.
+            pos: The local position of the right-click (from
+                ``customContextMenuRequested``).
+            comp: The competitor ``SubMod`` this row represents.
+        """
+        menu = QMenu(row)
+        action = menu.addAction("Go to in tree")
+        action.triggered.connect(
+            lambda: self.navigate_to_submod.emit(comp)
+        )
+        menu.exec(row.mapToGlobal(pos))
 
     # ------------------------------------------------------------------
     # Set Exact dialog

--- a/src/oar_priority_manager/ui/tag_delegate.py
+++ b/src/oar_priority_manager/ui/tag_delegate.py
@@ -18,7 +18,7 @@ TAG_OVERRIDE_ROLE: int = Qt.ItemDataRole.UserRole + 101
 
 # Pill layout constants
 _PILL_H_PAD: int = 6
-_PILL_V_PAD: int = 2
+_PILL_V_PAD: int = 1
 _PILL_GAP: int = 6
 _PILL_RADIUS: int = 6
 _PILL_FONT_SIZE: int = 9
@@ -124,7 +124,7 @@ class TagDelegate(QStyledItemDelegate):
         option: QStyleOptionViewItem,
         index,
     ) -> QSize:
-        """Expand width to accommodate pills."""
+        """Expand width to accommodate pills and ensure vertical breathing room."""
         size = super().sizeHint(option, index)
         tags = self._get_tags(index)
         if tags:
@@ -132,4 +132,9 @@ class TagDelegate(QStyledItemDelegate):
             for tag in tags:
                 extra += self._pill_width(tag.label) + _PILL_GAP
             size.setWidth(size.width() + extra)
+            # Ensure enough vertical space so pills don't touch between rows
+            pill_h = self._pill_fm.height() + 2 * _PILL_V_PAD
+            min_height = pill_h + 6  # 3px breathing room above and below
+            if size.height() < min_height:
+                size.setHeight(min_height)
         return size

--- a/src/oar_priority_manager/ui/tag_delegate.py
+++ b/src/oar_priority_manager/ui/tag_delegate.py
@@ -19,7 +19,7 @@ TAG_OVERRIDE_ROLE: int = Qt.ItemDataRole.UserRole + 101
 # Pill layout constants
 _PILL_H_PAD: int = 6
 _PILL_V_PAD: int = 2
-_PILL_GAP: int = 3
+_PILL_GAP: int = 6
 _PILL_RADIUS: int = 6
 _PILL_FONT_SIZE: int = 9
 _PILL_LEFT_MARGIN: int = 8
@@ -32,7 +32,7 @@ def sorted_tags(tags: set[TagCategory]) -> list[TagCategory]:
 
 
 class TagDelegate(QStyledItemDelegate):
-    """Delegate that paints tag pills to the right of the item text."""
+    """Delegate that paints tag pills after the item text."""
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
@@ -75,15 +75,12 @@ class TagDelegate(QStyledItemDelegate):
         pill_h = self._pill_fm.height() + 2 * _PILL_V_PAD
         y = rect.top() + (rect.height() - pill_h) // 2
 
-        # Calculate total pills width to right-align
-        total_width = 0
-        for tag in tags:
-            total_width += self._pill_width(tag.label) + _PILL_GAP
-        if is_override:
-            total_width += self._pill_fm.horizontalAdvance("\u270E ") + _PILL_GAP
-        total_width -= _PILL_GAP
-
-        x = rect.right() - total_width - _PILL_LEFT_MARGIN
+        # Left-align pills after the display text
+        display_text = index.data(Qt.ItemDataRole.DisplayRole) or ""
+        text_fm = option.fontMetrics
+        text_width = text_fm.horizontalAdvance(display_text)
+        # Account for item indentation and icon space
+        x = option.rect.left() + text_width + _PILL_LEFT_MARGIN
 
         # Draw override indicator (pencil)
         if is_override:

--- a/src/oar_priority_manager/ui/tag_delegate.py
+++ b/src/oar_priority_manager/ui/tag_delegate.py
@@ -1,0 +1,138 @@
+"""Custom tree item delegate that paints category tag pills.
+
+Renders colored pills after the display name in each tree row.
+Uses TagCategory color metadata for the muted palette.
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QRect, QSize, Qt
+from PySide6.QtGui import QBrush, QColor, QFont, QFontMetrics, QPainter, QPen
+from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
+
+from oar_priority_manager.core.tag_engine import TagCategory
+
+# Custom data role to store tags on QTreeWidgetItem
+TAG_DATA_ROLE: int = Qt.ItemDataRole.UserRole + 100
+# Custom data role to store override indicator
+TAG_OVERRIDE_ROLE: int = Qt.ItemDataRole.UserRole + 101
+
+# Pill layout constants
+_PILL_H_PAD: int = 6
+_PILL_V_PAD: int = 2
+_PILL_GAP: int = 3
+_PILL_RADIUS: int = 6
+_PILL_FONT_SIZE: int = 9
+_PILL_LEFT_MARGIN: int = 8
+_MAX_MOD_PILLS: int = 4
+
+
+def sorted_tags(tags: set[TagCategory]) -> list[TagCategory]:
+    """Sort tags by sort_order for consistent display."""
+    return sorted(tags, key=lambda t: t.sort_order)
+
+
+class TagDelegate(QStyledItemDelegate):
+    """Delegate that paints tag pills to the right of the item text."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._pill_font = QFont()
+        self._pill_font.setPixelSize(_PILL_FONT_SIZE)
+        self._pill_font.setBold(True)
+        self._pill_fm = QFontMetrics(self._pill_font)
+
+    def _get_tags(self, index) -> list[TagCategory]:
+        """Retrieve sorted tags from item data."""
+        tags = index.data(TAG_DATA_ROLE)
+        if not tags:
+            return []
+        return sorted_tags(tags) if isinstance(tags, set) else []
+
+    def _pill_width(self, label: str) -> int:
+        """Width of a single pill including padding."""
+        return self._pill_fm.horizontalAdvance(label) + 2 * _PILL_H_PAD
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index,
+    ) -> None:
+        """Paint the default item, then overlay tag pills."""
+        super().paint(painter, option, index)
+
+        tags = self._get_tags(index)
+        if not tags:
+            return
+
+        is_override = index.data(TAG_OVERRIDE_ROLE)
+
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setFont(self._pill_font)
+
+        rect = option.rect
+        pill_h = self._pill_fm.height() + 2 * _PILL_V_PAD
+        y = rect.top() + (rect.height() - pill_h) // 2
+
+        # Calculate total pills width to right-align
+        total_width = 0
+        for tag in tags:
+            total_width += self._pill_width(tag.label) + _PILL_GAP
+        if is_override:
+            total_width += self._pill_fm.horizontalAdvance("\u270E ") + _PILL_GAP
+        total_width -= _PILL_GAP
+
+        x = rect.right() - total_width - _PILL_LEFT_MARGIN
+
+        # Draw override indicator (pencil)
+        if is_override:
+            painter.setPen(QColor("#888888"))
+            painter.drawText(
+                x,
+                y + _PILL_V_PAD + self._pill_fm.ascent(),
+                "\u270E",
+            )
+            x += self._pill_fm.horizontalAdvance("\u270E ") + _PILL_GAP
+
+        # Draw each pill
+        for tag in tags:
+            w = self._pill_width(tag.label)
+            pill_rect = QRect(x, y, w, pill_h)
+
+            # Background
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QBrush(QColor(tag.color_bg)))
+            painter.drawRoundedRect(pill_rect, _PILL_RADIUS, _PILL_RADIUS)
+
+            # Border
+            painter.setPen(QPen(QColor(tag.color_border), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(pill_rect, _PILL_RADIUS, _PILL_RADIUS)
+
+            # Text
+            painter.setPen(QColor(tag.color_fg))
+            painter.drawText(
+                pill_rect,
+                Qt.AlignmentFlag.AlignCenter,
+                tag.label,
+            )
+
+            x += w + _PILL_GAP
+
+        painter.restore()
+
+    def sizeHint(
+        self,
+        option: QStyleOptionViewItem,
+        index,
+    ) -> QSize:
+        """Expand width to accommodate pills."""
+        size = super().sizeHint(option, index)
+        tags = self._get_tags(index)
+        if tags:
+            extra = _PILL_LEFT_MARGIN
+            for tag in tags:
+                extra += self._pill_width(tag.label) + _PILL_GAP
+            size.setWidth(size.width() + extra)
+        return size

--- a/src/oar_priority_manager/ui/tag_edit_dialog.py
+++ b/src/oar_priority_manager/ui/tag_edit_dialog.py
@@ -1,0 +1,118 @@
+"""Dialog for manually editing category tags on a mod or submod.
+
+Displays checkboxes for each TagCategory with colored pill previews.
+Provides a "Reset to Auto" button to clear manual overrides.
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from oar_priority_manager.core.tag_engine import TagCategory
+from oar_priority_manager.ui.tag_delegate import sorted_tags
+
+
+def _pill_html(tag: TagCategory) -> str:
+    """Render a single tag as an HTML pill span."""
+    return (
+        f'<span style="'
+        f"background:{tag.color_bg};"
+        f"color:{tag.color_fg};"
+        f"border:1px solid {tag.color_border};"
+        f"border-radius:6px;"
+        f"padding:1px 6px;"
+        f"font-size:10px;"
+        f"font-weight:bold;"
+        f'">{tag.label}</span>'
+    )
+
+
+class TagEditDialog(QDialog):
+    """Modal dialog for editing tags on a tree node.
+
+    Args:
+        current_tags: The currently active tags (auto or override).
+        is_override: Whether the current tags are a manual override.
+        parent: Parent widget.
+    """
+
+    def __init__(
+        self,
+        current_tags: set[TagCategory],
+        is_override: bool,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Edit Tags")
+        self.setMinimumWidth(300)
+        self._reset_requested = False
+
+        layout = QVBoxLayout(self)
+
+        # Info label
+        if is_override:
+            info = QLabel(
+                '<span style="color:#888">These tags are manually set. '
+                'Click "Reset to Auto" to revert to auto-detected tags.</span>'
+            )
+        else:
+            info = QLabel(
+                '<span style="color:#888">Check/uncheck tags to override '
+                "auto-detection for this item.</span>"
+            )
+        info.setTextFormat(Qt.TextFormat.RichText)
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        # Checkboxes — one per tag category
+        self._checkboxes: dict[TagCategory, QCheckBox] = {}
+        for tag in sorted_tags(set(TagCategory)):
+            row = QHBoxLayout()
+            cb = QCheckBox()
+            cb.setChecked(tag in current_tags)
+            self._checkboxes[tag] = cb
+            row.addWidget(cb)
+
+            pill_label = QLabel(_pill_html(tag))
+            pill_label.setTextFormat(Qt.TextFormat.RichText)
+            row.addWidget(pill_label)
+
+            row.addStretch()
+            layout.addLayout(row)
+
+        # Reset button
+        reset_btn = QPushButton("Reset to Auto")
+        reset_btn.setToolTip("Clear manual override and revert to auto-detected tags")
+        reset_btn.clicked.connect(self._on_reset)
+        layout.addWidget(reset_btn)
+
+        # OK / Cancel
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def _on_reset(self) -> None:
+        """Handle Reset to Auto button click."""
+        self._reset_requested = True
+        self.accept()
+
+    @property
+    def reset_requested(self) -> bool:
+        """True if user clicked Reset to Auto instead of OK."""
+        return self._reset_requested
+
+    def selected_tags(self) -> set[TagCategory]:
+        """Return the set of checked tag categories."""
+        return {tag for tag, cb in self._checkboxes.items() if cb.isChecked()}

--- a/src/oar_priority_manager/ui/tree_model.py
+++ b/src/oar_priority_manager/ui/tree_model.py
@@ -176,6 +176,16 @@ class SearchIndex:
                 # Register for animation-filename lookups
                 self._submod_node_map[id(node.submod)] = node
 
+                # Index tag names for tag-based search
+                if node.submod.tags:
+                    for tag in node.submod.tags:
+                        tag_result = SearchResult(
+                            display_text=f"[{tag.label}] {node.display_name}",
+                            node_type=node.node_type,
+                            node=node,
+                        )
+                        self._entries.append((tag.label.lower(), tag_result))
+
             for child in node.children:
                 _walk(child)
 

--- a/src/oar_priority_manager/ui/tree_model.py
+++ b/src/oar_priority_manager/ui/tree_model.py
@@ -44,6 +44,8 @@ class TreeNode:
         parent: The parent TreeNode (None for ROOT).
         auto_expand: True when this REPLACER node is the sole replacer
             under its parent MOD — the UI should expand it automatically.
+        condition_presets: conditionPresets dict from the replacer-level
+            config.json. Populated only on REPLACER nodes; empty for others.
     """
 
     display_name: str
@@ -52,6 +54,7 @@ class TreeNode:
     submod: SubMod | None = None
     parent: TreeNode | None = field(default=None, repr=False)
     auto_expand: bool = False
+    condition_presets: dict = field(default_factory=dict)
 
 
 def build_tree(submods: list[SubMod]) -> TreeNode:
@@ -92,11 +95,15 @@ def build_tree(submods: list[SubMod]) -> TreeNode:
 
         # Build REPLACER nodes sorted alphabetically
         for rep_name in sorted(replacer_dict.keys()):
+            # Get presets from first submod in this replacer (all share the same)
+            first_submod = replacer_dict[rep_name][0]
+            rep_presets = getattr(first_submod, "replacer_presets", {})
             rep_node = TreeNode(
                 display_name=rep_name,
                 node_type=NodeType.REPLACER,
                 parent=mod_node,
                 auto_expand=single_replacer,
+                condition_presets=rep_presets,
             )
 
             # Build SUBMOD nodes sorted by priority descending

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -7,14 +7,26 @@ from __future__ import annotations
 
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QButtonGroup,
+    QHBoxLayout,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
 from oar_priority_manager.core.models import SubMod
 from oar_priority_manager.ui.tree_model import TreeNode, build_tree
 
 
 class TreePanel(QWidget):
-    """Tree panel: Mod → Replacer → Submod hierarchy with status icons."""
+    """Tree panel: Mod → Replacer → Submod hierarchy with status icons.
+
+    A toolbar at the top provides a Name/Priority sort toggle (issue #45).
+    """
 
     # Emitted when a tree node is selected: the TreeNode itself (or None)
     selection_changed = Signal(object)
@@ -23,23 +35,122 @@ class TreePanel(QWidget):
         super().__init__(parent)
         self._submods = submods
         self._root = build_tree(submods)
+        # False = sort by name (default), True = sort by priority
+        self._sort_by_priority: bool = False
         self._setup_ui()
         self._populate()
 
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # -- Sort toolbar (issue #45) --
+        # Two checkable QPushButtons styled to match the segmented toggle
+        # used in stacks_panel (issue #69 pattern).
+        toolbar = QWidget()
+        toolbar_layout = QHBoxLayout(toolbar)
+        toolbar_layout.setContentsMargins(4, 4, 4, 2)
+        toolbar_layout.setSpacing(0)
+
+        _seg_checked = (
+            "QPushButton:checked {"
+            "  background: #3a3a5a;"
+            "  font-weight: bold;"
+            "  border: 1px solid #5a5a8a;"
+            "}"
+        )
+        _seg_unchecked = (
+            "QPushButton {"
+            "  background: #2a2a2a;"
+            "  border: 1px solid #444;"
+            "  padding: 3px 10px;"
+            "}"
+            "QPushButton:hover { background: #333; }"
+        )
+
+        self._name_btn = QPushButton("Name")
+        self._name_btn.setCheckable(True)
+        self._name_btn.setChecked(True)
+        self._name_btn.setToolTip("Sort mods alphabetically (default)")
+        self._name_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-left-radius: 4px;"
+            "  border-bottom-left-radius: 4px;"
+            "  border-right: none; }"
+        )
+
+        self._priority_btn = QPushButton("Priority")
+        self._priority_btn.setCheckable(True)
+        self._priority_btn.setChecked(False)
+        self._priority_btn.setToolTip(
+            "Sort mods by their highest submod priority (descending)"
+        )
+        self._priority_btn.setStyleSheet(
+            _seg_unchecked + _seg_checked
+            + "QPushButton { border-radius: 0px;"
+            "  border-top-right-radius: 4px;"
+            "  border-bottom-right-radius: 4px; }"
+        )
+
+        # QButtonGroup enforces mutual exclusivity
+        self._sort_group = QButtonGroup(self)
+        self._sort_group.setExclusive(True)
+        self._sort_group.addButton(self._name_btn)
+        self._sort_group.addButton(self._priority_btn)
+
+        self._name_btn.clicked.connect(lambda: self._set_sort(False))
+        self._priority_btn.clicked.connect(lambda: self._set_sort(True))
+
+        toolbar_layout.addWidget(self._name_btn)
+        toolbar_layout.addWidget(self._priority_btn)
+        toolbar_layout.addStretch()
+
+        layout.addWidget(toolbar)
 
         self._tree = QTreeWidget()
         self._tree.setHeaderHidden(True)
         self._tree.currentItemChanged.connect(self._on_selection)
         layout.addWidget(self._tree)
 
+    def _set_sort(self, by_priority: bool) -> None:
+        """Switch between name sort and priority sort and re-populate.
+
+        Args:
+            by_priority: True to sort mod nodes by their highest submod
+                priority descending; False for the default alpha sort.
+        """
+        if self._sort_by_priority == by_priority:
+            return
+        self._sort_by_priority = by_priority
+        self._populate()
+
+    def _sorted_mod_nodes(self) -> list[TreeNode]:
+        """Return mod-level children in the current sort order.
+
+        Name mode: alphabetical by display_name (the order from build_tree).
+        Priority mode: descending by the maximum submod priority across all
+            replacers, so the "most important" mod floats to the top.
+        """
+        if not self._sort_by_priority:
+            return list(self._root.children)
+
+        def _max_priority(mod_node: TreeNode) -> int:
+            best = 0
+            for rep in mod_node.children:
+                for sub in rep.children:
+                    if sub.submod is not None and sub.submod.priority > best:
+                        best = sub.submod.priority
+            return best
+
+        return sorted(self._root.children, key=_max_priority, reverse=True)
+
     def _populate(self) -> None:
         self._tree.clear()
         self._item_map: dict[int, TreeNode] = {}
 
-        for mod_node in self._root.children:
+        for mod_node in self._sorted_mod_nodes():
             mod_item = QTreeWidgetItem([mod_node.display_name])
             self._item_map[id(mod_item)] = mod_node
 
@@ -80,18 +191,25 @@ class TreePanel(QWidget):
         """Return the root TreeNode for use by SearchIndex."""
         return self._root
 
-    def filter_tree(self, matching_nodes: set[int] | None) -> None:
-        """Filter the tree to highlight matching nodes.
+    def filter_tree(
+        self, matching_nodes: set[int] | None, hide_mode: bool = False
+    ) -> None:
+        """Filter the tree to highlight or hide non-matching nodes.
 
         Args:
             matching_nodes: Set of ``id()`` values of matching TreeNodes,
                 or None to clear any active filter and show all items normally.
+            hide_mode: When False (default), non-matching items are dimmed
+                (grey foreground). When True, non-matching items are hidden
+                entirely and matching items plus their ancestors are shown.
         """
         normal_color = QApplication.palette().windowText().color()
         dim_color = QColor(160, 160, 160)
 
         if matching_nodes is None:
-            # Clear filter — restore all items to the default palette color.
+            # Clear filter — restore all items to the default palette color
+            # and make sure nothing is hidden.
+            self._unhide_all()
             self._set_all_colors(normal_color)
             return
 
@@ -114,17 +232,37 @@ class TreePanel(QWidget):
             _add_ancestors(node)
             _add_descendants(node)
 
-        # Walk every QTreeWidgetItem and apply color + expand parents.
+        # Walk every QTreeWidgetItem and apply visibility/color.
         def _apply(item: QTreeWidgetItem) -> None:
             node = self._item_map.get(id(item))
-            if node is not None and id(node) in visible:
-                item.setForeground(0, normal_color)
-                # Ensure parents of matching items are expanded for visibility.
-                parent = item.parent()
-                if parent is not None:
-                    parent.setExpanded(True)
+            is_visible = node is not None and id(node) in visible
+
+            if hide_mode:
+                item.setHidden(not is_visible)
             else:
-                item.setForeground(0, dim_color)
+                # Dim mode: ensure nothing is hidden (may have been set by a
+                # prior hide-mode run), then tint non-matching items grey.
+                item.setHidden(False)
+                if is_visible:
+                    item.setForeground(0, normal_color)
+                    # Expand parents of matching items for visibility.
+                    parent = item.parent()
+                    if parent is not None:
+                        parent.setExpanded(True)
+                else:
+                    item.setForeground(0, dim_color)
+
+            for i in range(item.childCount()):
+                _apply(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            _apply(self._tree.topLevelItem(i))
+
+    def _unhide_all(self) -> None:
+        """Recursively ensure every item is visible (clears hide-mode state)."""
+
+        def _apply(item: QTreeWidgetItem) -> None:
+            item.setHidden(False)
             for i in range(item.childCount()):
                 _apply(item.child(i))
 

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -10,6 +10,14 @@ from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from oar_priority_manager.core.models import SubMod
+from oar_priority_manager.core.tag_engine import TagCategory
+from oar_priority_manager.ui.tag_delegate import (
+    TAG_DATA_ROLE,
+    TAG_OVERRIDE_ROLE,
+    TagDelegate,
+    _MAX_MOD_PILLS,
+    sorted_tags,
+)
 from oar_priority_manager.ui.tree_model import TreeNode, build_tree
 
 
@@ -32,6 +40,8 @@ class TreePanel(QWidget):
 
         self._tree = QTreeWidget()
         self._tree.setHeaderHidden(True)
+        self._tag_delegate = TagDelegate(self._tree)
+        self._tree.setItemDelegate(self._tag_delegate)
         self._tree.currentItemChanged.connect(self._on_selection)
         layout.addWidget(self._tree)
 
@@ -57,11 +67,23 @@ class TreePanel(QWidget):
                         icon = "✓"
                     sub_item = QTreeWidgetItem([f"{icon} {sub_node.display_name}"])
                     self._item_map[id(sub_item)] = sub_node
+                    if sm and sm.tags:
+                        sub_item.setData(0, TAG_DATA_ROLE, sm.tags)
                     rep_item.addChild(sub_item)
 
                 mod_item.addChild(rep_item)
                 if rep_node.auto_expand:
                     rep_item.setExpanded(True)
+
+            # Compute mod-level rollup tags (union of all submod tags)
+            mod_tags: set[TagCategory] = set()
+            for rep_node in mod_node.children:
+                for sub_node in rep_node.children:
+                    if sub_node.submod and sub_node.submod.tags:
+                        mod_tags.update(sub_node.submod.tags)
+            if mod_tags:
+                display_tags = sorted_tags(mod_tags)[:_MAX_MOD_PILLS]
+                mod_item.setData(0, TAG_DATA_ROLE, set(display_tags))
 
             self._tree.addTopLevelItem(mod_item)
 

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -5,10 +5,18 @@ See spec §7.3. Full implementation in Task 14.
 
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QPoint, Qt, Signal
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QMenu,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
+from oar_priority_manager.app.config import AppConfig
 from oar_priority_manager.core.models import SubMod
 from oar_priority_manager.core.tag_engine import TagCategory
 from oar_priority_manager.ui.tag_delegate import (
@@ -18,7 +26,8 @@ from oar_priority_manager.ui.tag_delegate import (
     _MAX_MOD_PILLS,
     sorted_tags,
 )
-from oar_priority_manager.ui.tree_model import TreeNode, build_tree
+from oar_priority_manager.ui.tag_edit_dialog import TagEditDialog
+from oar_priority_manager.ui.tree_model import NodeType, TreeNode, build_tree
 
 
 class TreePanel(QWidget):
@@ -27,9 +36,15 @@ class TreePanel(QWidget):
     # Emitted when a tree node is selected: the TreeNode itself (or None)
     selection_changed = Signal(object)
 
-    def __init__(self, submods: list[SubMod], parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        submods: list[SubMod],
+        app_config: AppConfig | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self._submods = submods
+        self._app_config = app_config
         self._root = build_tree(submods)
         self._setup_ui()
         self._populate()
@@ -44,6 +59,8 @@ class TreePanel(QWidget):
         self._tree.setItemDelegate(self._tag_delegate)
         self._tree.currentItemChanged.connect(self._on_selection)
         layout.addWidget(self._tree)
+        self._tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._tree.customContextMenuRequested.connect(self._on_context_menu)
 
     def _populate(self) -> None:
         self._tree.clear()
@@ -164,8 +181,125 @@ class TreePanel(QWidget):
         for i in range(self._tree.topLevelItemCount()):
             _apply(self._tree.topLevelItem(i))
 
-    def refresh(self, submods: list[SubMod]) -> None:
-        """Refresh tree from new submod data."""
+    def _on_context_menu(self, pos: QPoint) -> None:
+        """Show context menu with 'Edit Tags...' action."""
+        item = self._tree.itemAt(pos)
+        if item is None:
+            return
+        node = self._item_map.get(id(item))
+        if node is None or node.node_type == NodeType.ROOT:
+            return
+
+        menu = QMenu(self)
+        edit_tags_action = menu.addAction("Edit Tags...")
+        action = menu.exec(self._tree.viewport().mapToGlobal(pos))
+        if action == edit_tags_action:
+            self._edit_tags(item, node)
+
+    def _edit_tags(self, item: QTreeWidgetItem, node: TreeNode) -> None:
+        """Open tag edit dialog for the given node.
+
+        Args:
+            item: The QTreeWidgetItem that was right-clicked.
+            node: The corresponding TreeNode.
+        """
+        if self._app_config is None:
+            return
+
+        override_key = self._get_override_key(node)
+        is_override = override_key in self._app_config.tag_overrides
+
+        if node.node_type == NodeType.SUBMOD and node.submod:
+            current_tags = node.submod.tags.copy()
+        elif node.node_type == NodeType.MOD:
+            current_tags: set = set()
+            for rep in node.children:
+                for sub in rep.children:
+                    if sub.submod and sub.submod.tags:
+                        current_tags.update(sub.submod.tags)
+        else:
+            return  # No tag editing for replacer nodes
+
+        if is_override:
+            override_names = self._app_config.tag_overrides[override_key]
+            current_tags = {
+                tag for tag in TagCategory
+                if tag.label.lower() in [n.lower() for n in override_names]
+            }
+
+        dialog = TagEditDialog(current_tags, is_override, self)
+        if dialog.exec() != TagEditDialog.DialogCode.Accepted:
+            return
+
+        if dialog.reset_requested:
+            self._app_config.tag_overrides.pop(override_key, None)
+            if node.node_type == NodeType.SUBMOD and node.submod:
+                from oar_priority_manager.core.tag_engine import compute_tags
+                node.submod.tags = compute_tags(node.submod)
+                item.setData(0, TAG_DATA_ROLE, node.submod.tags)
+                item.setData(0, TAG_OVERRIDE_ROLE, None)
+        else:
+            selected = dialog.selected_tags()
+            override_list = [tag.label.lower() for tag in sorted_tags(selected)]
+            self._app_config.tag_overrides[override_key] = override_list
+
+            if node.node_type == NodeType.SUBMOD and node.submod:
+                node.submod.tags = selected
+            item.setData(0, TAG_DATA_ROLE, selected)
+            item.setData(0, TAG_OVERRIDE_ROLE, True)
+
+        if node.node_type == NodeType.SUBMOD and node.parent and node.parent.parent:
+            self._refresh_mod_rollup(node.parent.parent)
+
+        self._tree.viewport().update()
+
+    def _get_override_key(self, node: TreeNode) -> str:
+        """Build the config key for tag overrides.
+
+        Args:
+            node: The tree node to derive a key for.
+
+        Returns:
+            A ``/``-separated key string suitable for use in
+            ``AppConfig.tag_overrides``.
+        """
+        if node.node_type == NodeType.SUBMOD and node.submod:
+            return f"{node.submod.mo2_mod}/{node.submod.replacer}/{node.submod.name}"
+        elif node.node_type == NodeType.MOD:
+            return f"mod:{node.display_name}"
+        return ""
+
+    def _refresh_mod_rollup(self, mod_node: TreeNode) -> None:
+        """Recompute and update tag rollup for a mod-level tree item.
+
+        Args:
+            mod_node: The MOD-level TreeNode whose rollup should be refreshed.
+        """
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            if self._item_map.get(id(item)) is mod_node:
+                mod_tags: set[TagCategory] = set()
+                for rep in mod_node.children:
+                    for sub in rep.children:
+                        if sub.submod and sub.submod.tags:
+                            mod_tags.update(sub.submod.tags)
+                if mod_tags:
+                    display = sorted_tags(mod_tags)[:_MAX_MOD_PILLS]
+                    item.setData(0, TAG_DATA_ROLE, set(display))
+                else:
+                    item.setData(0, TAG_DATA_ROLE, None)
+                break
+
+    def refresh(self, submods: list[SubMod], app_config: AppConfig | None = None) -> None:
+        """Refresh tree from new submod data.
+
+        Args:
+            submods: Updated list of SubMod objects to display.
+            app_config: Optional updated config; replaces the stored reference
+                if provided.
+        """
         self._submods = submods
+        if app_config is not None:
+            self._app_config = app_config
         self._root = build_tree(submods)
         self._populate()

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -280,6 +280,63 @@ class TreePanel(QWidget):
         for i in range(self._tree.topLevelItemCount()):
             _apply(self._tree.topLevelItem(i))
 
+    def select_submod(self, submod: SubMod) -> None:
+        """Select and scroll to a submod in the tree by identity (issue #60).
+
+        Iterates ``_item_map`` looking for the ``QTreeWidgetItem`` whose
+        associated ``TreeNode`` holds a reference to *submod* (identity
+        check, not equality).  When found, the item is programmatically
+        selected (which fires ``currentItemChanged`` → ``selection_changed``)
+        and scrolled into view.  If the submod is not present in the current
+        tree (e.g. the tree has been rebuilt since the stacks panel was last
+        refreshed), this method is a no-op.
+
+        Args:
+            submod: The ``SubMod`` instance to navigate to.
+        """
+        for item_id, node in self._item_map.items():
+            if node.submod is submod:
+                # Locate the QTreeWidgetItem by its Python id key.
+                # We must walk the tree to find the actual item object because
+                # _item_map stores id(item) → node, not item → node.
+                item = self._find_item_by_id(item_id)
+                if item is not None:
+                    self._tree.setCurrentItem(item)
+                    self._tree.scrollToItem(
+                        item,
+                        QTreeWidget.ScrollHint.EnsureVisible,
+                    )
+                return
+
+    def _find_item_by_id(
+        self, target_id: int
+    ) -> QTreeWidgetItem | None:
+        """Return the ``QTreeWidgetItem`` whose ``id()`` equals *target_id*.
+
+        Walks the full tree hierarchy depth-first.  Returns ``None`` if no
+        item with the given id is found.
+
+        Args:
+            target_id: The ``id()`` value of the desired item.
+
+        Returns:
+            The matching ``QTreeWidgetItem``, or ``None``.
+        """
+        def _walk(item: QTreeWidgetItem) -> QTreeWidgetItem | None:
+            if id(item) == target_id:
+                return item
+            for i in range(item.childCount()):
+                result = _walk(item.child(i))
+                if result is not None:
+                    return result
+            return None
+
+        for i in range(self._tree.topLevelItemCount()):
+            result = _walk(self._tree.topLevelItem(i))
+            if result is not None:
+                return result
+        return None
+
     def refresh(self, submods: list[SubMod]) -> None:
         """Refresh tree from new submod data."""
         self._submods = submods

--- a/src/oar_priority_manager/ui/tree_panel.py
+++ b/src/oar_priority_manager/ui/tree_panel.py
@@ -20,10 +20,10 @@ from oar_priority_manager.app.config import AppConfig
 from oar_priority_manager.core.models import SubMod
 from oar_priority_manager.core.tag_engine import TagCategory
 from oar_priority_manager.ui.tag_delegate import (
+    _MAX_MOD_PILLS,
     TAG_DATA_ROLE,
     TAG_OVERRIDE_ROLE,
     TagDelegate,
-    _MAX_MOD_PILLS,
     sorted_tags,
 )
 from oar_priority_manager.ui.tag_edit_dialog import TagEditDialog

--- a/tests/integration/test_tag_integration.py
+++ b/tests/integration/test_tag_integration.py
@@ -1,0 +1,131 @@
+"""Integration tests for category tags end-to-end.
+
+Tests the full pipeline: scan → extract conditions → compute tags → apply overrides.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from oar_priority_manager.app.config import AppConfig, load_config, save_config
+from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.tag_engine import (
+    TagCategory,
+    apply_overrides,
+    compute_tags,
+)
+from oar_priority_manager.ui.tree_model import SearchIndex, build_tree
+
+
+def _make_submod_with_conditions(
+    mo2_mod: str,
+    replacer: str,
+    name: str,
+    conditions: list,
+    animations: list[str] | None = None,
+) -> SubMod:
+    """Create a SubMod with conditions already extracted."""
+    sm = SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path(f"/fake/{mo2_mod}/{replacer}/{name}/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        animations=animations or [],
+        conditions=conditions,
+    )
+    present, negated = extract_condition_types(conditions)
+    sm.condition_types_present = present
+    sm.condition_types_negated = negated
+    sm.tags = compute_tags(sm)
+    return sm
+
+
+class TestEndToEnd:
+    def test_combat_mod_tagged_correctly(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Combat Animation Overhaul",
+            replacer="CAO",
+            name="power_attacks",
+            conditions=[
+                {"condition": "IsWeaponDrawn", "negated": False},
+            ],
+            animations=[
+                "1hm_attackpower.hkx",
+                "1hm_attackpowerfwd.hkx",
+                "1hm_attackpowerleft.hkx",
+            ],
+        )
+        assert TagCategory.COMBAT in sm.tags
+
+    def test_female_idle_mod_gets_two_tags(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Dynamic Female Weather Idles",
+            replacer="WeatherIdles",
+            name="rain_idle",
+            conditions=[
+                {"condition": "IsFemale", "negated": False},
+            ],
+            animations=[
+                "mt_idle.hkx",
+                "idle_front.hkx",
+            ],
+        )
+        assert TagCategory.GENDER in sm.tags
+        assert TagCategory.IDLE in sm.tags
+
+    def test_nsfw_detected_from_folder_name(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Dynamic Feminine Female Modesty Animations OAR",
+            replacer="KP_nudeNPC",
+            name="npc_both_fre",
+            conditions=[],
+        )
+        assert TagCategory.NSFW in sm.tags
+        assert TagCategory.GENDER in sm.tags
+
+
+class TestOverrideRoundTrip:
+    def test_save_load_overrides(self, tmp_path):
+        config = AppConfig(tag_overrides={
+            "TestMod/Rep/Sub": ["combat", "npc"],
+        })
+        path = tmp_path / "config.json"
+        save_config(config, path)
+
+        loaded = load_config(path)
+        assert loaded.tag_overrides == {"TestMod/Rep/Sub": ["combat", "npc"]}
+
+    def test_override_applied_to_submod(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="TestMod",
+            replacer="Rep",
+            name="Sub",
+            conditions=[],
+            animations=["mt_idle.hkx", "idle_front.hkx", "idle_rain.hkx"],
+        )
+        assert TagCategory.IDLE in sm.tags
+
+        apply_overrides([sm], {"TestMod/Rep/Sub": ["combat"]})
+        assert sm.tags == {TagCategory.COMBAT}
+        assert TagCategory.IDLE not in sm.tags
+
+
+class TestSearchWithTags:
+    def test_tag_search_finds_tagged_submod(self):
+        sm = _make_submod_with_conditions(
+            mo2_mod="Some Random Mod Name",
+            replacer="Rep",
+            name="sub1",
+            conditions=[{"condition": "IsSneaking", "negated": False}],
+        )
+        root = build_tree([sm])
+        index = SearchIndex(root, {})
+        results = index.search("sneak")
+        assert any(r.node.submod is sm for r in results)

--- a/tests/unit/test_conditions_panel.py
+++ b/tests/unit/test_conditions_panel.py
@@ -1,0 +1,114 @@
+"""Tests for ui/conditions_panel.py — formatted conditions view + JSON toggle."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.ui.conditions_panel import ConditionsPanel
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Ensure a QApplication exists for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_submod(
+    conditions=None, name="TestSub", mo2_mod="TestMod", replacer_presets=None
+):
+    """Build a minimal SubMod for testing."""
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer="TestReplacer",
+        name=name,
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path("/fake/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        conditions=conditions if conditions is not None else [],
+        replacer_presets=replacer_presets if replacer_presets is not None else {},
+    )
+
+
+class TestConditionsPanelInit:
+    def test_default_shows_placeholder(self, qapp):
+        panel = ConditionsPanel()
+        assert panel._formatted_view is not None
+        assert panel._json_view is not None
+
+    def test_formatted_is_default_mode(self, qapp):
+        panel = ConditionsPanel()
+        assert panel._formatted_btn.isChecked() is True
+        assert panel._json_btn.isChecked() is False
+
+
+class TestConditionsPanelUpdate:
+    def test_update_none_shows_placeholder(self, qapp):
+        panel = ConditionsPanel()
+        panel.update_focus(None)
+        # Header resets to "Conditions"; the placeholder label in the
+        # formatted layout contains "Select a submod..."
+        assert panel._header.text() == "Conditions"
+        # At least one widget in the formatted layout (the placeholder label)
+        assert panel._formatted_layout.count() >= 1
+
+    def test_update_with_submod_shows_header(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[{"condition": "IsFemale", "negated": False}]
+        )
+        panel.update_focus(sm)
+        assert "TestMod" in panel._header.text()
+        assert "TestSub" in panel._header.text()
+
+    def test_update_with_empty_conditions(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(conditions=[])
+        panel.update_focus(sm)
+        # Should have at least the placeholder in the formatted layout
+        assert panel._formatted_layout.count() >= 1
+
+    def test_json_toggle_shows_raw_json(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[{"condition": "IsFemale", "negated": False}]
+        )
+        panel.update_focus(sm)
+        panel._json_btn.click()
+        assert "IsFemale" in panel._json_view.toPlainText()
+
+    def test_formatted_toggle_returns_to_tree(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[{"condition": "IsFemale", "negated": False}]
+        )
+        panel.update_focus(sm)
+        panel._json_btn.click()
+        panel._formatted_btn.click()
+        assert panel._formatted_btn.isChecked() is True
+
+
+class TestConditionsPanelStats:
+    def test_stats_footer_shows_counts(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[
+                {"condition": "IsFemale", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+                {"condition": "HasShield", "negated": True},
+            ]
+        )
+        panel.update_focus(sm)
+        footer_text = panel._stats_label.text()
+        assert "3" in footer_text
+        assert "1" in footer_text

--- a/tests/unit/test_conditions_panel.py
+++ b/tests/unit/test_conditions_panel.py
@@ -112,3 +112,47 @@ class TestConditionsPanelStats:
         footer_text = panel._stats_label.text()
         assert "3" in footer_text
         assert "1" in footer_text
+
+
+class TestPresetExpansion:
+    def test_preset_resolves_from_submod_replacer_presets(self, qapp):
+        panel = ConditionsPanel()
+        presets = {
+            "Combat Ready": [
+                {"condition": "IsWeaponDrawn", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+            ]
+        }
+        sm = _make_submod(
+            conditions=[
+                {"condition": "PRESET", "Preset": "Combat Ready"},
+            ],
+            replacer_presets=presets,
+        )
+        panel.update_focus(sm)
+        # The formatted view should contain a preset card widget
+        assert panel._formatted_layout.count() >= 1
+
+    def test_missing_preset_shows_warning(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[
+                {"condition": "PRESET", "Preset": "Nonexistent"},
+            ],
+            replacer_presets={},
+        )
+        panel.update_focus(sm)
+        assert panel._formatted_layout.count() >= 1
+
+    def test_stats_footer_includes_presets(self, qapp):
+        panel = ConditionsPanel()
+        sm = _make_submod(
+            conditions=[
+                {"condition": "IsFemale", "negated": False},
+                {"condition": "PRESET", "Preset": "Combat Ready"},
+            ],
+            replacer_presets={"Combat Ready": [{"condition": "IsInCombat"}]},
+        )
+        panel.update_focus(sm)
+        footer_text = panel._stats_label.text()
+        assert "1 presets" in footer_text or "preset" in footer_text.lower()

--- a/tests/unit/test_conditions_panel.py
+++ b/tests/unit/test_conditions_panel.py
@@ -114,6 +114,105 @@ class TestConditionsPanelStats:
         assert "1" in footer_text
 
 
+class TestGroupCollapsibility:
+    """AND/OR group headers must be clickable and start expanded."""
+
+    def _make_and_conditions(self):
+        """Return conditions with a top-level AND group."""
+        return [
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": False},
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            }
+        ]
+
+    def _find_group_header(self, panel):
+        """Return the first QLabel whose text starts with the AND arrow."""
+        from PySide6.QtWidgets import QLabel
+        from PySide6.QtCore import Qt
+
+        def _search(widget):
+            for child in widget.findChildren(QLabel):
+                txt = child.text()
+                if "ALL of:" in txt or "ANY of:" in txt:
+                    return child
+            return None
+
+        return _search(panel._formatted_content)
+
+    def _find_children_widget(self, panel):
+        """Return the first non-header QWidget inside the formatted content."""
+        from PySide6.QtWidgets import QWidget, QLabel
+
+        # The children_widget is a QWidget added directly to
+        # _formatted_layout right after the header label.
+        layout = panel._formatted_layout
+        for i in range(layout.count()):
+            item = layout.itemAt(i)
+            w = item.widget() if item else None
+            if w is not None and not isinstance(w, QLabel):
+                return w
+        return None
+
+    def test_group_header_is_clickable(self, qapp):
+        """Group header QLabel must have PointingHandCursor set."""
+        from PySide6.QtCore import Qt
+
+        panel = ConditionsPanel()
+        sm = _make_submod(conditions=self._make_and_conditions())
+        panel.update_focus(sm)
+
+        header = self._find_group_header(panel)
+        assert header is not None, "No group header label found"
+        assert header.cursor().shape() == Qt.CursorShape.PointingHandCursor
+
+    def test_group_starts_expanded(self, qapp):
+        """Children widget must not be hidden immediately after update_focus.
+
+        QWidget.isVisible() returns False for widgets that have never been
+        rendered in a top-level window, so we check isHidden() instead —
+        which reflects only explicit hide() calls, not window-show state.
+        """
+        panel = ConditionsPanel()
+        sm = _make_submod(conditions=self._make_and_conditions())
+        panel.update_focus(sm)
+
+        children = self._find_children_widget(panel)
+        assert children is not None, "No children container widget found"
+        assert not children.isHidden(), "Group should start expanded (not hidden)"
+
+    def test_clicking_header_toggles_children_visibility(self, qapp):
+        """Clicking the header once hides children; again shows them.
+
+        Uses isHidden() rather than isVisible() because the panel is never
+        shown in a top-level window during tests — isVisible() would return
+        False even after show() in that case.
+        """
+        panel = ConditionsPanel()
+        sm = _make_submod(conditions=self._make_and_conditions())
+        panel.update_focus(sm)
+
+        header = self._find_group_header(panel)
+        children = self._find_children_widget(panel)
+        assert header is not None
+        assert children is not None
+
+        # First click — should collapse (hide children)
+        header.mousePressEvent(None)
+        assert children.isHidden(), (
+            "Children should be hidden after first click"
+        )
+
+        # Second click — should expand (show children)
+        header.mousePressEvent(None)
+        assert not children.isHidden(), (
+            "Children should not be hidden after second click"
+        )
+
+
 class TestPresetExpansion:
     def test_preset_resolves_from_submod_replacer_presets(self, qapp):
         panel = ConditionsPanel()

--- a/tests/unit/test_conditions_renderer.py
+++ b/tests/unit/test_conditions_renderer.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from oar_priority_manager.ui.conditions_renderer import (
-    RenderedNode,
     conditions_stats,
     render_conditions,
     resolve_preset,
@@ -69,6 +68,42 @@ class TestRenderConditions:
         assert group.children[0].text == "IsFemale"
         assert group.children[1].text == "IsInCombat"
 
+    def test_and_group_capital_conditions_key(self):
+        """Real OAR data uses capital-C 'Conditions' in AND/OR groups."""
+        conditions = [
+            {
+                "condition": "AND",
+                "requiredVersion": "1.0.0.0",
+                "Conditions": [
+                    {"condition": "IsFemale", "requiredVersion": "1.0.0.0"},
+                    {"condition": "IsInCombat", "requiredVersion": "1.0.0.0"},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        group = result[0]
+        assert group.node_type == "AND"
+        assert len(group.children) == 2
+        assert group.children[0].text == "IsFemale"
+        assert group.children[1].text == "IsInCombat"
+
+    def test_or_group_capital_conditions_key(self):
+        """Real OAR OR groups also use capital-C 'Conditions'."""
+        conditions = [
+            {
+                "condition": "OR",
+                "requiredVersion": "1.0.0.0",
+                "Conditions": [
+                    {"condition": "IsFemale", "requiredVersion": "1.0.0.0"},
+                    {"condition": "IsInCombat", "requiredVersion": "1.0.0.0"},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        assert result[0].node_type == "OR"
+        assert len(result[0].children) == 2
+
     def test_or_group(self):
         conditions = [
             {
@@ -106,6 +141,32 @@ class TestRenderConditions:
         assert len(or_node.children[0].children) == 2
         assert or_node.children[1].text == "IsInCombat"
 
+    def test_nested_real_oar_format(self):
+        """Nested AND/OR with capital-C Conditions and requiredVersion throughout."""
+        conditions = [
+            {
+                "condition": "OR",
+                "requiredVersion": "1.0.0.0",
+                "Conditions": [
+                    {
+                        "condition": "AND",
+                        "requiredVersion": "1.0.0.0",
+                        "Conditions": [
+                            {"condition": "IsFemale", "requiredVersion": "1.0.0.0"},
+                            {"condition": "IsSneaking", "requiredVersion": "1.0.0.0"},
+                        ],
+                    },
+                    {"condition": "IsInCombat", "requiredVersion": "1.0.0.0"},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        or_node = result[0]
+        assert or_node.node_type == "OR"
+        assert or_node.children[0].node_type == "AND"
+        assert len(or_node.children[0].children) == 2
+        assert or_node.children[1].text == "IsInCombat"
+
     def test_preset_reference(self):
         conditions = [
             {"condition": "PRESET", "Preset": "Combat Ready Stance"}
@@ -128,6 +189,22 @@ class TestRenderConditions:
         assert result[0].node_type == "AND"
         assert result[0].children[0].text == "IsFemale"
 
+    def test_top_level_dict_with_capital_conditions_key(self):
+        """Top-level dict using capital-C 'Conditions' (real OAR format)."""
+        conditions = {
+            "condition": "OR",
+            "requiredVersion": "1.0.0.0",
+            "Conditions": [
+                {"condition": "IsFemale", "requiredVersion": "1.0.0.0"},
+                {"condition": "IsInCombat", "requiredVersion": "1.0.0.0"},
+            ],
+        }
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].node_type == "OR"
+        assert len(result[0].children) == 2
+        assert result[0].children[0].text == "IsFemale"
+
     def test_top_level_dict_bare_conditions_key(self):
         """Dict with just a conditions key, no condition type — implicit AND."""
         conditions = {
@@ -138,6 +215,45 @@ class TestRenderConditions:
         result = render_conditions(conditions)
         assert len(result) == 1
         assert result[0].node_type == "AND"
+
+    def test_required_version_filtered_from_leaf_params(self):
+        """requiredVersion is structural noise and must not appear in params."""
+        conditions = [
+            {
+                "condition": "IsFemale",
+                "requiredVersion": "1.0.0.0",
+                "negated": False,
+            }
+        ]
+        result = render_conditions(conditions)
+        assert "requiredVersion" not in result[0].params
+
+    def test_disabled_filtered_from_leaf_params(self):
+        """disabled is OAR metadata and must not appear in params."""
+        conditions = [
+            {
+                "condition": "IsInCombat",
+                "requiredVersion": "1.0.0.0",
+                "disabled": True,
+            }
+        ]
+        result = render_conditions(conditions)
+        assert "disabled" not in result[0].params
+        assert "requiredVersion" not in result[0].params
+
+    def test_user_meaningful_params_still_visible(self):
+        """formID and pluginName are user-meaningful and must still appear."""
+        conditions = [
+            {
+                "condition": "HasPerk",
+                "requiredVersion": "1.0.0.0",
+                "negated": False,
+                "formID": "0x00012345",
+                "pluginName": "Skyrim.esm",
+            }
+        ]
+        result = render_conditions(conditions)
+        assert result[0].params == {"formID": "0x00012345", "pluginName": "Skyrim.esm"}
 
     def test_missing_negated_defaults_false(self):
         conditions = [{"condition": "IsFemale"}]
@@ -259,7 +375,7 @@ class TestPresetDataFlow:
     """Integration-style tests verifying presets flow from scanner to TreeNode."""
 
     def test_tree_node_has_condition_presets_field(self):
-        from oar_priority_manager.ui.tree_model import TreeNode, NodeType
+        from oar_priority_manager.ui.tree_model import NodeType, TreeNode
         node = TreeNode(
             display_name="test",
             node_type=NodeType.REPLACER,
@@ -268,6 +384,6 @@ class TestPresetDataFlow:
         assert node.condition_presets == {"Combat": [{"condition": "IsInCombat"}]}
 
     def test_tree_node_default_empty_presets(self):
-        from oar_priority_manager.ui.tree_model import TreeNode, NodeType
+        from oar_priority_manager.ui.tree_model import NodeType, TreeNode
         node = TreeNode(display_name="test", node_type=NodeType.MOD)
         assert node.condition_presets == {}

--- a/tests/unit/test_conditions_renderer.py
+++ b/tests/unit/test_conditions_renderer.py
@@ -253,3 +253,21 @@ class TestConditionsStats:
         assert stats["conditions"] == 3
         assert stats["types"] == 3
         assert stats["negated"] == 1
+
+
+class TestPresetDataFlow:
+    """Integration-style tests verifying presets flow from scanner to TreeNode."""
+
+    def test_tree_node_has_condition_presets_field(self):
+        from oar_priority_manager.ui.tree_model import TreeNode, NodeType
+        node = TreeNode(
+            display_name="test",
+            node_type=NodeType.REPLACER,
+            condition_presets={"Combat": [{"condition": "IsInCombat"}]},
+        )
+        assert node.condition_presets == {"Combat": [{"condition": "IsInCombat"}]}
+
+    def test_tree_node_default_empty_presets(self):
+        from oar_priority_manager.ui.tree_model import TreeNode, NodeType
+        node = TreeNode(display_name="test", node_type=NodeType.MOD)
+        assert node.condition_presets == {}

--- a/tests/unit/test_conditions_renderer.py
+++ b/tests/unit/test_conditions_renderer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from oar_priority_manager.ui.conditions_renderer import (
     RenderedNode,
+    conditions_stats,
     render_conditions,
+    resolve_preset,
 )
 
 
@@ -147,3 +149,107 @@ class TestRenderConditions:
         result = render_conditions(conditions)
         assert len(result) == 1
         assert result[0].text == "IsFemale"
+
+
+class TestResolvePreset:
+    def test_resolve_existing_preset(self):
+        presets = {
+            "Combat Ready": [
+                {"condition": "IsWeaponDrawn", "negated": False},
+                {"condition": "IsInCombat", "negated": False},
+            ]
+        }
+        result = resolve_preset("Combat Ready", presets)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].text == "IsWeaponDrawn"
+        assert result[1].text == "IsInCombat"
+
+    def test_resolve_missing_preset_returns_none(self):
+        presets = {"Combat Ready": [{"condition": "IsWeaponDrawn", "negated": False}]}
+        result = resolve_preset("Nonexistent", presets)
+        assert result is None
+
+    def test_resolve_empty_presets_dict(self):
+        result = resolve_preset("Anything", {})
+        assert result is None
+
+    def test_resolve_invalid_presets_type(self):
+        result = resolve_preset("Anything", "not a dict")
+        assert result is None
+
+    def test_resolve_preset_with_nested_group(self):
+        presets = {
+            "Weapon Check": {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsWeaponDrawn", "negated": False},
+                    {"condition": "IsMounted", "negated": True},
+                ],
+            }
+        }
+        result = resolve_preset("Weapon Check", presets)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].node_type == "AND"
+        assert len(result[0].children) == 2
+
+
+class TestConditionsStats:
+    def test_empty_tree(self):
+        stats = conditions_stats([])
+        assert stats == {"conditions": 0, "types": 0, "negated": 0, "presets": 0}
+
+    def test_flat_leaves(self):
+        nodes = render_conditions([
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "IsInCombat", "negated": False},
+            {"condition": "HasShield", "negated": True},
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["conditions"] == 3
+        assert stats["types"] == 3
+        assert stats["negated"] == 1
+        assert stats["presets"] == 0
+
+    def test_duplicate_types_counted_once(self):
+        nodes = render_conditions([
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "IsFemale", "negated": True},
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["conditions"] == 2
+        assert stats["types"] == 1
+        assert stats["negated"] == 1
+
+    def test_with_presets(self):
+        nodes = render_conditions([
+            {"condition": "IsFemale", "negated": False},
+            {"condition": "PRESET", "Preset": "Combat Ready"},
+            {"condition": "PRESET", "Preset": "Weapon Check"},
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["presets"] == 2
+        assert stats["conditions"] == 1
+        assert stats["types"] == 1
+
+    def test_nested_groups(self):
+        nodes = render_conditions([
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": False},
+                    {
+                        "condition": "OR",
+                        "conditions": [
+                            {"condition": "HasPerk", "negated": False},
+                            {"condition": "HasKeyword", "negated": True},
+                        ],
+                    },
+                ],
+            },
+        ])
+        stats = conditions_stats(nodes)
+        assert stats["conditions"] == 3
+        assert stats["types"] == 3
+        assert stats["negated"] == 1

--- a/tests/unit/test_conditions_renderer.py
+++ b/tests/unit/test_conditions_renderer.py
@@ -1,0 +1,149 @@
+"""Tests for ui/conditions_renderer.py — pure-logic condition tree renderer."""
+from __future__ import annotations
+
+from oar_priority_manager.ui.conditions_renderer import (
+    RenderedNode,
+    render_conditions,
+)
+
+
+class TestRenderConditions:
+    def test_empty_list_returns_empty(self):
+        result = render_conditions([])
+        assert result == []
+
+    def test_empty_dict_returns_empty(self):
+        result = render_conditions({})
+        assert result == []
+
+    def test_single_leaf_condition(self):
+        conditions = [{"condition": "IsFemale", "negated": False}]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        node = result[0]
+        assert node.text == "IsFemale"
+        assert node.node_type == "leaf"
+        assert node.negated is False
+        assert node.params == {}
+        assert node.children == []
+
+    def test_negated_leaf(self):
+        conditions = [{"condition": "HasShield", "negated": True}]
+        result = render_conditions(conditions)
+        assert result[0].negated is True
+
+    def test_leaf_with_extra_params(self):
+        conditions = [
+            {
+                "condition": "HasPerk",
+                "negated": False,
+                "formID": "0x00012345",
+                "pluginName": "Skyrim.esm",
+            }
+        ]
+        result = render_conditions(conditions)
+        node = result[0]
+        assert node.params == {
+            "formID": "0x00012345",
+            "pluginName": "Skyrim.esm",
+        }
+
+    def test_and_group(self):
+        conditions = [
+            {
+                "condition": "AND",
+                "conditions": [
+                    {"condition": "IsFemale", "negated": False},
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        group = result[0]
+        assert group.node_type == "AND"
+        assert group.text == "AND"
+        assert len(group.children) == 2
+        assert group.children[0].text == "IsFemale"
+        assert group.children[1].text == "IsInCombat"
+
+    def test_or_group(self):
+        conditions = [
+            {
+                "condition": "OR",
+                "conditions": [
+                    {"condition": "HasKeyword", "negated": False},
+                    {"condition": "HasPerk", "negated": False},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        assert result[0].node_type == "OR"
+        assert len(result[0].children) == 2
+
+    def test_nested_and_inside_or(self):
+        conditions = [
+            {
+                "condition": "OR",
+                "conditions": [
+                    {
+                        "condition": "AND",
+                        "conditions": [
+                            {"condition": "IsFemale", "negated": False},
+                            {"condition": "IsSneaking", "negated": False},
+                        ],
+                    },
+                    {"condition": "IsInCombat", "negated": False},
+                ],
+            }
+        ]
+        result = render_conditions(conditions)
+        or_node = result[0]
+        assert or_node.node_type == "OR"
+        assert or_node.children[0].node_type == "AND"
+        assert len(or_node.children[0].children) == 2
+        assert or_node.children[1].text == "IsInCombat"
+
+    def test_preset_reference(self):
+        conditions = [
+            {"condition": "PRESET", "Preset": "Combat Ready Stance"}
+        ]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        node = result[0]
+        assert node.node_type == "preset"
+        assert node.preset_name == "Combat Ready Stance"
+
+    def test_top_level_dict_with_conditions_key(self):
+        conditions = {
+            "condition": "AND",
+            "conditions": [
+                {"condition": "IsFemale", "negated": False},
+            ],
+        }
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].node_type == "AND"
+        assert result[0].children[0].text == "IsFemale"
+
+    def test_top_level_dict_bare_conditions_key(self):
+        """Dict with just a conditions key, no condition type — implicit AND."""
+        conditions = {
+            "conditions": [
+                {"condition": "IsFemale", "negated": False},
+            ],
+        }
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].node_type == "AND"
+
+    def test_missing_negated_defaults_false(self):
+        conditions = [{"condition": "IsFemale"}]
+        result = render_conditions(conditions)
+        assert result[0].negated is False
+
+    def test_non_dict_items_skipped(self):
+        conditions = ["invalid", 42, {"condition": "IsFemale", "negated": False}]
+        result = render_conditions(conditions)
+        assert len(result) == 1
+        assert result[0].text == "IsFemale"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -76,3 +76,29 @@ class TestAppConfig:
         bad.write_text("not json!", encoding="utf-8")
         loaded = load_config(bad)
         assert loaded.relative_or_absolute == "relative"
+
+
+class TestTagOverrides:
+    def test_tag_overrides_default_empty(self):
+        config = AppConfig()
+        assert config.tag_overrides == {}
+
+    def test_tag_overrides_round_trip(self, tmp_path: Path):
+        config = AppConfig(tag_overrides={
+            "TestMod/Replacer/Sub1": ["combat", "npc"],
+            "OtherMod/Rep/Sub2": ["nsfw"],
+        })
+        path = tmp_path / "config.json"
+        save_config(config, path)
+        loaded = load_config(path)
+        assert loaded.tag_overrides == {
+            "TestMod/Replacer/Sub1": ["combat", "npc"],
+            "OtherMod/Rep/Sub2": ["nsfw"],
+        }
+
+    def test_tag_overrides_missing_from_file(self, tmp_path: Path):
+        """Old config files without tag_overrides should load with empty dict."""
+        path = tmp_path / "config.json"
+        path.write_text('{"submod_sort": "priority"}', encoding="utf-8")
+        loaded = load_config(path)
+        assert loaded.tag_overrides == {}

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -207,3 +207,98 @@ class TestNameAndDescription:
         # Name/description come from config.json per OAR §4
         assert submods[0].name == "config_name"
         assert submods[0].description == "config_desc"
+
+
+class TestReplacerPresets:
+    """Scanner converts conditionPresets to a dict keyed by name."""
+
+    def test_presets_as_list_converted_to_dict(self, tmp_instance: Path):
+        """Real OAR format: conditionPresets is a list of {name, conditions} objects."""
+        replacer_dir = (
+            tmp_instance / "mods" / "ModA" / OAR_REL / "ReplacerA"
+        )
+        replacer_dir.mkdir(parents=True)
+        replacer_config = {
+            "conditionPresets": [
+                {
+                    "name": "Malignis_Base",
+                    "conditions": [{"condition": "IsFemale", "requiredVersion": "1.0.0.0"}],
+                },
+                {
+                    "name": "Malignis_Dungeon",
+                    "conditions": [{"condition": "IsInCombat", "requiredVersion": "1.0.0.0"}],
+                },
+            ]
+        }
+        (replacer_dir / "config.json").write_text(
+            json.dumps(replacer_config), encoding="utf-8"
+        )
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "ReplacerA", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        presets = submods[0].replacer_presets
+        assert isinstance(presets, dict)
+        assert set(presets.keys()) == {"Malignis_Base", "Malignis_Dungeon"}
+        assert presets["Malignis_Base"] == [
+            {"condition": "IsFemale", "requiredVersion": "1.0.0.0"}
+        ]
+        assert presets["Malignis_Dungeon"] == [
+            {"condition": "IsInCombat", "requiredVersion": "1.0.0.0"}
+        ]
+
+    def test_presets_as_dict_kept_as_is(self, tmp_instance: Path):
+        """Legacy/test-fixture format: conditionPresets already a dict — pass through."""
+        replacer_dir = (
+            tmp_instance / "mods" / "ModA" / OAR_REL / "ReplacerA"
+        )
+        replacer_dir.mkdir(parents=True)
+        replacer_config = {
+            "conditionPresets": {
+                "MyPreset": [{"condition": "IsFemale"}],
+            }
+        }
+        (replacer_dir / "config.json").write_text(
+            json.dumps(replacer_config), encoding="utf-8"
+        )
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "ReplacerA", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert submods[0].replacer_presets == {"MyPreset": [{"condition": "IsFemale"}]}
+
+    def test_preset_list_entry_missing_conditions_skipped(self, tmp_instance: Path):
+        """Malformed list entries (no 'conditions' or 'Conditions' key) are skipped."""
+        replacer_dir = (
+            tmp_instance / "mods" / "ModA" / OAR_REL / "ReplacerA"
+        )
+        replacer_dir.mkdir(parents=True)
+        replacer_config = {
+            "conditionPresets": [
+                {"name": "Good", "conditions": [{"condition": "IsFemale"}]},
+                {"name": "Bad"},   # no conditions key
+                "not_a_dict",      # not a dict at all
+            ]
+        }
+        (replacer_dir / "config.json").write_text(
+            json.dumps(replacer_config), encoding="utf-8"
+        )
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "ReplacerA", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert submods[0].replacer_presets == {
+            "Good": [{"condition": "IsFemale"}]
+        }
+
+    def test_no_replacer_config_gives_empty_presets(self, tmp_instance: Path):
+        """When there is no replacer-level config.json, presets are empty."""
+        make_submod_dir(
+            tmp_instance / "mods", "ModA", "ReplacerA", "sub1",
+            config=make_config_json(name="sub1", priority=100),
+        )
+        submods = scan_mods(tmp_instance / "mods", tmp_instance / "overwrite")
+        assert submods[0].replacer_presets == {}

--- a/tests/unit/test_stacks_panel.py
+++ b/tests/unit/test_stacks_panel.py
@@ -1,0 +1,414 @@
+"""Unit tests for StacksPanel toolbar enhancements.
+
+Covers the three new controls added in issues #46, #47, and #48:
+  #46 — Shift… button and _on_shift dialog
+  #47 — Animation filter QLineEdit
+  #48 — Hide Winning checkable toggle
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.ui.stacks_panel import StacksPanel, _StackSection
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_submod(
+    name: str = "sub",
+    priority: int = 100,
+    animations: list[str] | None = None,
+    has_warnings: bool = False,
+) -> SubMod:
+    """Build a minimal SubMod for testing.
+
+    Args:
+        name: Submod name.
+        priority: Priority integer.
+        animations: List of animation filenames; defaults to
+            ``["mt_idle.hkx"]``.
+        has_warnings: When ``True``, adds a dummy warning string.
+
+    Returns:
+        A fully constructed SubMod.
+    """
+    return SubMod(
+        mo2_mod="Test Mod",
+        replacer="rep",
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=False,
+        config_path=Path(
+            "C:/mods/Test/meshes/actors/character/animations"
+            "/OpenAnimationReplacer/rep/sub/config.json"
+        ),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": name, "priority": priority},
+        animations=animations if animations is not None else ["mt_idle.hkx"],
+        conditions={},
+        condition_types_present=set(),
+        condition_types_negated=set(),
+        warnings=["warn"] if has_warnings else [],
+    )
+
+
+def _make_panel(qtbot, conflict_map=None) -> StacksPanel:
+    """Construct a StacksPanel and register it with qtbot.
+
+    Args:
+        qtbot: The pytest-qt bot fixture.
+        conflict_map: Optional dict to pass as the conflict map; defaults
+            to an empty dict.
+
+    Returns:
+        A visible StacksPanel widget.
+    """
+    panel = StacksPanel(conflict_map or {})
+    qtbot.addWidget(panel)
+    panel.show()
+    return panel
+
+
+def _iter_sections(panel: StacksPanel) -> list[_StackSection]:
+    """Return all _StackSection widgets currently in the panel's scroll area.
+
+    Args:
+        panel: The StacksPanel to inspect.
+
+    Returns:
+        A list of _StackSection widgets (may be empty).
+    """
+    sections = []
+    layout = panel._content_layout
+    for i in range(layout.count()):
+        item = layout.itemAt(i)
+        if item and isinstance(item.widget(), _StackSection):
+            sections.append(item.widget())
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Issue #46 — Shift… button
+# ---------------------------------------------------------------------------
+
+class TestShiftButton:
+    """Tests for the Shift… toolbar button (issue #46)."""
+
+    def test_shift_btn_exists(self, qtbot):
+        """StacksPanel exposes a _shift_btn attribute."""
+        panel = _make_panel(qtbot)
+        assert hasattr(panel, "_shift_btn")
+
+    def test_shift_btn_disabled_with_no_selection(self, qtbot):
+        """Shift button is disabled when no submod is selected."""
+        panel = _make_panel(qtbot)
+        panel.update_selection(None)
+        assert not panel._shift_btn.isEnabled()
+
+    def test_shift_btn_disabled_when_submod_has_warnings(self, qtbot):
+        """Shift button is disabled when the selected submod has warnings."""
+        sm = _make_submod(has_warnings=True)
+        panel = _make_panel(qtbot)
+        panel.update_selection(sm)
+        assert not panel._shift_btn.isEnabled()
+
+    def test_shift_btn_enabled_when_valid_submod(self, qtbot):
+        """Shift button is enabled when a warning-free submod is selected."""
+        sm = _make_submod()
+        panel = _make_panel(qtbot, conflict_map={"mt_idle.hkx": [sm]})
+        panel.update_selection(sm)
+        assert panel._shift_btn.isEnabled()
+
+    def test_shift_emits_action_on_ok(self, qtbot):
+        """Clicking Shift and confirming the dialog emits action_triggered."""
+        sm = _make_submod(priority=100)
+        panel = _make_panel(qtbot, conflict_map={"mt_idle.hkx": [sm]})
+        panel.update_selection(sm)
+
+        received: list[tuple] = []
+        panel.action_triggered.connect(
+            lambda action, submod, val: received.append((action, submod, val))
+        )
+
+        with patch(
+            "oar_priority_manager.ui.stacks_panel.QInputDialog.getInt",
+            return_value=(50, True),
+        ):
+            panel._on_shift()
+
+        assert len(received) == 1
+        action, submod, value = received[0]
+        assert action == "shift"
+        assert submod is sm
+        assert value == 50
+
+    def test_shift_does_not_emit_on_cancel(self, qtbot):
+        """Cancelling the Shift dialog does not emit action_triggered."""
+        sm = _make_submod()
+        panel = _make_panel(qtbot, conflict_map={"mt_idle.hkx": [sm]})
+        panel.update_selection(sm)
+
+        received: list[tuple] = []
+        panel.action_triggered.connect(
+            lambda action, submod, val: received.append((action, submod, val))
+        )
+
+        with patch(
+            "oar_priority_manager.ui.stacks_panel.QInputDialog.getInt",
+            return_value=(0, False),
+        ):
+            panel._on_shift()
+
+        assert received == []
+
+    def test_shift_does_nothing_when_no_submod(self, qtbot):
+        """_on_shift is a no-op when _current_submod is None."""
+        panel = _make_panel(qtbot)
+        # Ensure no exception and no signal emission
+        received: list = []
+        panel.action_triggered.connect(lambda *a: received.append(a))
+        panel._on_shift()
+        assert received == []
+
+    def test_shift_negative_value_emits_correctly(self, qtbot):
+        """Negative shift delta is forwarded unchanged in the signal."""
+        sm = _make_submod(priority=200)
+        panel = _make_panel(qtbot, conflict_map={"mt_idle.hkx": [sm]})
+        panel.update_selection(sm)
+
+        received: list[tuple] = []
+        panel.action_triggered.connect(
+            lambda action, submod, val: received.append((action, submod, val))
+        )
+
+        with patch(
+            "oar_priority_manager.ui.stacks_panel.QInputDialog.getInt",
+            return_value=(-100, True),
+        ):
+            panel._on_shift()
+
+        assert received[0][2] == -100
+
+
+# ---------------------------------------------------------------------------
+# Issue #47 — Animation filter input
+# ---------------------------------------------------------------------------
+
+class TestAnimFilter:
+    """Tests for the animation filter QLineEdit (issue #47)."""
+
+    def test_filter_widget_exists(self, qtbot):
+        """StacksPanel exposes a _anim_filter attribute."""
+        panel = _make_panel(qtbot)
+        assert hasattr(panel, "_anim_filter")
+
+    def test_filter_max_height(self, qtbot):
+        """Filter input is compact — max height is at most 28px."""
+        panel = _make_panel(qtbot)
+        assert panel._anim_filter.maximumHeight() <= 28
+
+    def test_filter_shows_all_when_empty(self, qtbot):
+        """All sections are visible when the filter query is empty."""
+        sm = _make_submod(animations=["mt_idle.hkx", "mt_run.hkx"])
+        conflict_map = {
+            "mt_idle.hkx": [sm],
+            "mt_run.hkx": [sm],
+        }
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(sm)
+
+        panel._on_anim_filter("")
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 2
+        assert all(s.isVisible() for s in sections)
+
+    def test_filter_hides_non_matching_sections(self, qtbot):
+        """Sections whose anim_name does not contain the query are hidden."""
+        sm = _make_submod(animations=["mt_idle.hkx", "mt_run.hkx"])
+        conflict_map = {
+            "mt_idle.hkx": [sm],
+            "mt_run.hkx": [sm],
+        }
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(sm)
+
+        panel._on_anim_filter("idle")
+
+        sections = _iter_sections(panel)
+        visible = [s for s in sections if s.isVisible()]
+        hidden = [s for s in sections if not s.isVisible()]
+        assert len(visible) == 1
+        assert visible[0].anim_name == "mt_idle.hkx"
+        assert len(hidden) == 1
+        assert hidden[0].anim_name == "mt_run.hkx"
+
+    def test_filter_is_case_insensitive(self, qtbot):
+        """Filter match is case-insensitive."""
+        sm = _make_submod(animations=["mt_IDLE.hkx"])
+        conflict_map = {"mt_IDLE.hkx": [sm]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(sm)
+
+        panel._on_anim_filter("idle")
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 1
+        assert sections[0].isVisible()
+
+    def test_filter_restores_all_on_clear(self, qtbot):
+        """Clearing the filter after a query restores all sections."""
+        sm = _make_submod(animations=["mt_idle.hkx", "mt_run.hkx"])
+        conflict_map = {
+            "mt_idle.hkx": [sm],
+            "mt_run.hkx": [sm],
+        }
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(sm)
+
+        panel._on_anim_filter("idle")
+        panel._on_anim_filter("")
+
+        sections = _iter_sections(panel)
+        assert all(s.isVisible() for s in sections)
+
+    def test_anim_name_stored_on_section(self, qtbot):
+        """Each built section has an anim_name attribute matching its animation."""
+        sm = _make_submod(animations=["mt_idle.hkx", "mt_run.hkx"])
+        conflict_map = {
+            "mt_idle.hkx": [sm],
+            "mt_run.hkx": [sm],
+        }
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(sm)
+
+        sections = _iter_sections(panel)
+        anim_names = {s.anim_name for s in sections}
+        assert anim_names == {"mt_idle.hkx", "mt_run.hkx"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #48 — Collapse-winning toggle
+# ---------------------------------------------------------------------------
+
+class TestCollapseWinning:
+    """Tests for the Hide Winning checkable button (issue #48)."""
+
+    def test_collapse_winning_btn_exists(self, qtbot):
+        """StacksPanel exposes a _collapse_winning_btn attribute."""
+        panel = _make_panel(qtbot)
+        assert hasattr(panel, "_collapse_winning_btn")
+
+    def test_collapse_winning_btn_is_checkable(self, qtbot):
+        """The Hide Winning button is a checkable toggle."""
+        panel = _make_panel(qtbot)
+        assert panel._collapse_winning_btn.isCheckable()
+
+    def test_is_winning_stored_on_section(self, qtbot):
+        """Sections where the selected submod is rank #1 have is_winning=True."""
+        winner = _make_submod(name="winner", priority=500,
+                              animations=["mt_idle.hkx"])
+        loser = _make_submod(name="loser", priority=100,
+                             animations=["mt_idle.hkx"])
+        # winner is first → rank 0 for winner, rank 1 for loser
+        conflict_map = {"mt_idle.hkx": [winner, loser]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(winner)
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 1
+        assert sections[0].is_winning is True
+
+    def test_is_winning_false_when_losing(self, qtbot):
+        """Sections where the selected submod is NOT rank #1 have is_winning=False."""
+        winner = _make_submod(name="winner", priority=500,
+                              animations=["mt_idle.hkx"])
+        loser = _make_submod(name="loser", priority=100,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [winner, loser]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        # Select the loser — it is NOT rank #1 in this stack
+        panel.update_selection(loser)
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 1
+        assert sections[0].is_winning is False
+
+    def test_collapse_winning_collapses_winning_sections(self, qtbot):
+        """Enabling Hide Winning collapses sections where submod is #1."""
+        winner = _make_submod(
+            name="winner", priority=500,
+            animations=["mt_idle.hkx", "mt_run.hkx"],
+        )
+        loser = _make_submod(
+            name="loser", priority=100,
+            animations=["mt_idle.hkx"],
+        )
+        # winner beats loser in mt_idle; winner is sole competitor in mt_run
+        conflict_map = {
+            "mt_idle.hkx": [winner, loser],
+            "mt_run.hkx": [winner],
+        }
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(winner)
+
+        # All sections start expanded
+        sections = _iter_sections(panel)
+        assert all(s._expanded for s in sections)
+
+        panel._on_collapse_winning(True)
+
+        sections = _iter_sections(panel)
+        for s in sections:
+            if s.is_winning:
+                assert not s._expanded, (
+                    f"Section {s.anim_name} should be collapsed (winning)"
+                )
+
+    def test_collapse_winning_keeps_losing_sections_expanded(self, qtbot):
+        """Enabling Hide Winning does NOT collapse losing/tied sections."""
+        winner = _make_submod(
+            name="winner", priority=500, animations=["mt_idle.hkx"]
+        )
+        loser = _make_submod(
+            name="loser", priority=100, animations=["mt_idle.hkx"]
+        )
+        conflict_map = {"mt_idle.hkx": [winner, loser]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        # Select the loser — the section is NOT winning for loser
+        panel.update_selection(loser)
+
+        panel._on_collapse_winning(True)
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 1
+        assert sections[0]._expanded  # losing section stays expanded
+
+    def test_unchecking_expands_all_sections(self, qtbot):
+        """Unchecking Hide Winning restores all sections to expanded."""
+        winner = _make_submod(
+            name="winner", priority=500,
+            animations=["mt_idle.hkx", "mt_run.hkx"],
+        )
+        loser = _make_submod(
+            name="loser", priority=100, animations=["mt_idle.hkx"]
+        )
+        conflict_map = {
+            "mt_idle.hkx": [winner, loser],
+            "mt_run.hkx": [winner],
+        }
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(winner)
+
+        # Collapse first, then uncollapse
+        panel._on_collapse_winning(True)
+        panel._on_collapse_winning(False)
+
+        sections = _iter_sections(panel)
+        assert all(s._expanded for s in sections)

--- a/tests/unit/test_stacks_panel.py
+++ b/tests/unit/test_stacks_panel.py
@@ -1,9 +1,10 @@
 """Unit tests for StacksPanel toolbar enhancements.
 
-Covers the three new controls added in issues #46, #47, and #48:
+Covers the new controls added in issues #46, #47, #48, and #74:
   #46 — Shift… button and _on_shift dialog
   #47 — Animation filter QLineEdit
   #48 — Hide Winning checkable toggle
+  #74 — Collapse same-mod competitor rows into a summary row
 """
 from __future__ import annotations
 
@@ -11,7 +12,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 from oar_priority_manager.core.models import OverrideSource, SubMod
-from oar_priority_manager.ui.stacks_panel import StacksPanel, _StackSection
+from oar_priority_manager.ui.stacks_panel import (
+    StacksPanel,
+    _ModGroupRow,
+    _StackSection,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -22,6 +27,7 @@ def _make_submod(
     priority: int = 100,
     animations: list[str] | None = None,
     has_warnings: bool = False,
+    mo2_mod: str = "Test Mod",
 ) -> SubMod:
     """Build a minimal SubMod for testing.
 
@@ -31,12 +37,13 @@ def _make_submod(
         animations: List of animation filenames; defaults to
             ``["mt_idle.hkx"]``.
         has_warnings: When ``True``, adds a dummy warning string.
+        mo2_mod: MO2 mod name used for same-mod grouping tests.
 
     Returns:
         A fully constructed SubMod.
     """
     return SubMod(
-        mo2_mod="Test Mod",
+        mo2_mod=mo2_mod,
         replacer="rep",
         name=name,
         description="",
@@ -412,3 +419,261 @@ class TestCollapseWinning:
 
         sections = _iter_sections(panel)
         assert all(s._expanded for s in sections)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for issue #74 tests
+# ---------------------------------------------------------------------------
+
+def _iter_section_children(section: _StackSection) -> list:
+    """Return all direct child widgets of a _StackSection's content area.
+
+    Args:
+        section: The _StackSection to inspect.
+
+    Returns:
+        A list of direct child QWidget objects in the content layout.
+    """
+    layout = section._content_layout
+    children = []
+    for i in range(layout.count()):
+        item = layout.itemAt(i)
+        if item and item.widget():
+            children.append(item.widget())
+    return children
+
+
+# ---------------------------------------------------------------------------
+# Issue #74 — Collapse same-mod competitor rows
+# ---------------------------------------------------------------------------
+
+class TestCollapseCompetitors:
+    """Tests for same-mod sibling collapsing in stacks panel (issue #74)."""
+
+    def test_same_mod_siblings_create_group_row(self, qtbot):
+        """Same-mod competitors produce a _ModGroupRow summary in the section."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 1
+        children = _iter_section_children(sections[0])
+
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1, "Expected exactly one _ModGroupRow for same-mod siblings"
+
+    def test_group_row_label_shows_mod_name_and_count(self, qtbot):
+        """The summary row label reflects the mod name and sibling count."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sib2 = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                            animations=["mt_idle.hkx"])
+        sib3 = _make_submod(name="sub3", mo2_mod="SneakMod", priority=300,
+                            animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sib2, sib3]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        label = group_rows[0]._btn.text()
+        # Label should mention the mod name and sibling count (2 siblings)
+        assert "SneakMod" in label
+        assert "2" in label
+
+    def test_cross_mod_competitors_are_individual_rows(self, qtbot):
+        """Cross-mod competitors do NOT get grouped into a _ModGroupRow."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        other = _make_submod(name="other", mo2_mod="CombatMod", priority=300,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, other]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 0, "Cross-mod competitor should NOT create a group row"
+
+    def test_you_row_is_direct_section_child_not_in_group(self, qtbot):
+        """'You' row is a direct child of the section — not inside _ModGroupRow."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+
+        # The group row exists but holds only the sibling — not the "you" row
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        # selected submod's row must NOT be inside the group's child rows
+        assert len(group_rows[0]._child_rows) == 1
+
+    def test_clicking_group_row_toggles_sibling_visibility(self, qtbot):
+        """Clicking the _ModGroupRow summary button toggles the collapsed state and container."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        group = group_rows[0]
+
+        # Groups start collapsed — container is explicitly hidden
+        assert group.is_collapsed
+        assert group._child_container.isHidden()
+
+        # Click to expand — collapsed state flips, container no longer hidden
+        group._btn.click()
+        assert not group.is_collapsed
+        assert not group._child_container.isHidden()
+
+        # Click again to collapse — container hidden again
+        group._btn.click()
+        assert group.is_collapsed
+        assert group._child_container.isHidden()
+
+    def test_no_group_when_selected_is_only_submod_from_its_mod(self, qtbot):
+        """No _ModGroupRow is created when no same-mod siblings exist."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        other = _make_submod(name="other", mo2_mod="CombatMod", priority=300,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, other]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 0
+
+    def test_group_state_persists_across_refresh(self, qtbot):
+        """Expanding a group and calling _refresh_display preserves expanded state."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        # Expand the group (it starts collapsed)
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        group_rows[0]._btn.click()  # expand
+
+        # Trigger a refresh
+        panel._refresh_display()
+
+        # Group should still be expanded after refresh
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        assert not group_rows[0].is_collapsed
+
+    def test_sibling_group_contains_correct_child_count(self, qtbot):
+        """The group's _child_rows has exactly the same-mod sibling count."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sib2 = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                            animations=["mt_idle.hkx"])
+        sib3 = _make_submod(name="sub3", mo2_mod="SneakMod", priority=300,
+                            animations=["mt_idle.hkx"])
+        cross = _make_submod(name="cross", mo2_mod="CombatMod", priority=200,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sib2, sib3, cross]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        # 2 siblings (sib2, sib3) — "you" (selected) is NOT in the group
+        assert len(group_rows[0]._child_rows) == 2
+
+    def test_rank_and_priority_labels_preserved_for_grouped_rows(self, qtbot):
+        """Grouped sibling rows still carry rank badge and priority value labels."""
+        from PySide6.QtWidgets import QLabel
+
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+
+        sibling_row = group_rows[0]._child_rows[0]
+        # Row should have QLabel children (rank badge + priority value + name)
+        labels = sibling_row.findChildren(QLabel)
+        assert len(labels) >= 2, "Grouped rows should still have rank badge and priority labels"
+
+    def test_group_starts_collapsed_by_default(self, qtbot):
+        """A freshly built mod group starts in the collapsed state."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        assert group_rows[0].is_collapsed
+        assert group_rows[0]._child_container.isHidden()
+
+    def test_mixed_same_and_cross_mod(self, qtbot):
+        """Mixed scenario: same-mod siblings collapsed, cross-mod rows individual."""
+        from PySide6.QtWidgets import QPushButton
+
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        cross = _make_submod(name="cross", mo2_mod="CombatMod", priority=300,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling, cross]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        direct_buttons = [c for c in children if isinstance(c, QPushButton)]
+
+        # Exactly one group (same-mod sibling), one cross-mod individual button,
+        # plus the "you" button
+        assert len(group_rows) == 1, "Same-mod sibling must be in one group"
+        assert len(direct_buttons) == 2, "Cross-mod + 'you' should be direct buttons"

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -62,3 +62,80 @@ class TestComputeTagsEmpty:
     def test_empty_submod_returns_empty_set(self):
         sm = _make_submod()
         assert compute_tags(sm) == set()
+
+
+class TestLayer1Keywords:
+    """Layer 1: folder/mod name keyword matching."""
+
+    def test_nsfw_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Dynamic Feminine Female Modesty Animations OAR")
+        tags = compute_tags(sm)
+        assert TagCategory.NSFW in tags
+
+    def test_nsfw_from_submod_name(self):
+        sm = _make_submod(name="nude_both_free")
+        tags = compute_tags(sm)
+        assert TagCategory.NSFW in tags
+
+    def test_nsfw_sexlab_keyword(self):
+        sm = _make_submod(mo2_mod="SexLab Animation Pack")
+        tags = compute_tags(sm)
+        assert TagCategory.NSFW in tags
+
+    def test_gender_female_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Dynamic Female Weather Idles")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+
+    def test_gender_male_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Random Male Wall Leaning Animations")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+
+    def test_gender_no_substring_match(self):
+        """'female' inside 'maleficent' should NOT match."""
+        sm = _make_submod(mo2_mod="Maleficent Anim Pack")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER not in tags
+
+    def test_npc_from_mod_name(self):
+        sm = _make_submod(mo2_mod="NPC Animation Remix")
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_npc_children_keyword(self):
+        sm = _make_submod(mo2_mod="Lively Children Animations")
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_sneak_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Dynamic Relaxed sneak OAR")
+        tags = compute_tags(sm)
+        assert TagCategory.SNEAK in tags
+
+    def test_combat_from_mod_name(self):
+        sm = _make_submod(mo2_mod="Combat Animation Overhaul")
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_combat_dodge_keyword(self):
+        sm = _make_submod(mo2_mod="Nolvus Awakening Dodge Framework")
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_movement_from_mod_name(self):
+        sm = _make_submod(mo2_mod="EVG Animated Traversal")
+        tags = compute_tags(sm)
+        assert TagCategory.MOVEMENT in tags
+
+    def test_multiple_keywords_yield_multiple_tags(self):
+        sm = _make_submod(mo2_mod="Female NPC Sneak Pack")
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+        assert TagCategory.NPC in tags
+        assert TagCategory.SNEAK in tags
+
+    def test_no_match_returns_empty(self):
+        sm = _make_submod(mo2_mod="Some Random Mod")
+        tags = compute_tags(sm)
+        assert len(tags) == 0

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -139,3 +139,80 @@ class TestLayer1Keywords:
         sm = _make_submod(mo2_mod="Some Random Mod")
         tags = compute_tags(sm)
         assert len(tags) == 0
+
+
+class TestLayer2Animations:
+    """Layer 2: animation filename pattern voting with 30% threshold."""
+
+    def test_combat_animations(self):
+        anims = [f"1hm_attack{i}.hkx" for i in range(10)]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_movement_animations(self):
+        anims = ["mt_runforward.hkx", "mt_runbackward.hkx", "mt_walk.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.MOVEMENT in tags
+
+    def test_sneak_animations(self):
+        anims = ["mt_sneak_idle.hkx", "sneak_forward.hkx", "sneak_back.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.SNEAK in tags
+
+    def test_idle_animations(self):
+        anims = ["mt_idle.hkx", "1hm_idle.hkx", "idle_front.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.IDLE in tags
+
+    def test_furniture_animations(self):
+        anims = ["chair_sit.hkx", "sit_idle.hkx", "bed_enter.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.FURNITURE in tags
+
+    def test_equipment_animations(self):
+        anims = ["1hm_equip.hkx", "1hm_unequip.hkx", "bow_draw.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.EQUIPMENT in tags
+
+    def test_magic_animations(self):
+        anims = ["mlh_cast.hkx", "mrh_cast.hkx", "mt_cast_idle.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.MAGIC in tags
+
+    def test_voting_threshold_below_30_percent(self):
+        """1 idle out of 10 combat = 10% idle, should NOT tag Idle."""
+        anims = [f"1hm_attack{i}.hkx" for i in range(9)] + ["mt_idle.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+        assert TagCategory.IDLE not in tags
+
+    def test_voting_threshold_at_30_percent(self):
+        """3 idle out of 10 = 30%, should tag Idle."""
+        anims = [f"1hm_attack{i}.hkx" for i in range(7)] + [
+            "mt_idle.hkx",
+            "idle_front.hkx",
+            "1hm_idle.hkx",
+        ]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+        assert TagCategory.IDLE in tags
+
+    def test_empty_animations_no_tags(self):
+        sm = _make_submod(animations=[])
+        tags = compute_tags(sm)
+        assert len(tags) == 0
+
+    def test_unrecognized_animations_no_tags(self):
+        anims = ["custom_anim1.hkx", "custom_anim2.hkx"]
+        sm = _make_submod(animations=anims)
+        tags = compute_tags(sm)
+        assert len(tags) == 0

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -4,9 +4,10 @@ See design spec docs/superpowers/specs/2026-04-14-category-tags-design.md.
 """
 from __future__ import annotations
 
-from oar_priority_manager.core.tag_engine import TagCategory, apply_overrides, compute_tags
-from oar_priority_manager.core.models import SubMod, OverrideSource
 from pathlib import Path
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.core.tag_engine import TagCategory, apply_overrides, compute_tags
 
 
 def _make_submod(

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -4,7 +4,7 @@ See design spec docs/superpowers/specs/2026-04-14-category-tags-design.md.
 """
 from __future__ import annotations
 
-from oar_priority_manager.core.tag_engine import TagCategory, compute_tags
+from oar_priority_manager.core.tag_engine import TagCategory, apply_overrides, compute_tags
 from oar_priority_manager.core.models import SubMod, OverrideSource
 from pathlib import Path
 
@@ -373,3 +373,49 @@ class TestComputeTagsMultiLayer:
         assert TagCategory.GENDER in tags   # Layer 1 (female)
         assert TagCategory.COMBAT in tags   # Layer 1 (combat) + Layer 2 (attack anims)
         assert TagCategory.SNEAK in tags    # Layer 3 (IsSneaking)
+
+
+class TestApplyOverrides:
+    def test_override_replaces_auto_tags(self):
+        sm = _make_submod(
+            mo2_mod="Test Mod",
+            replacer="Rep",
+            name="sub1",
+            animations=["1hm_attack1.hkx", "1hm_attack2.hkx", "1hm_attack3.hkx"],
+        )
+        sm.tags = compute_tags(sm)
+        assert TagCategory.COMBAT in sm.tags
+
+        overrides = {"Test Mod/Rep/sub1": ["nsfw", "gender"]}
+        apply_overrides([sm], overrides)
+        assert sm.tags == {TagCategory.NSFW, TagCategory.GENDER}
+
+    def test_no_override_keeps_auto_tags(self):
+        sm = _make_submod(
+            animations=["1hm_attack1.hkx", "1hm_attack2.hkx", "1hm_attack3.hkx"],
+        )
+        sm.tags = compute_tags(sm)
+        original = sm.tags.copy()
+
+        apply_overrides([sm], {})
+        assert sm.tags == original
+
+    def test_override_key_format(self):
+        sm = _make_submod(
+            mo2_mod="My Mod",
+            replacer="MyRep",
+            name="MySub",
+        )
+        sm.tags = compute_tags(sm)
+
+        overrides = {"My Mod/MyRep/MySub": ["sneak"]}
+        apply_overrides([sm], overrides)
+        assert sm.tags == {TagCategory.SNEAK}
+
+    def test_unknown_tag_name_in_override_ignored(self):
+        sm = _make_submod(mo2_mod="Test", replacer="R", name="S")
+        sm.tags = compute_tags(sm)
+
+        overrides = {"Test/R/S": ["combat", "nonexistent_tag"]}
+        apply_overrides([sm], overrides)
+        assert sm.tags == {TagCategory.COMBAT}

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -216,3 +216,125 @@ class TestLayer2Animations:
         sm = _make_submod(animations=anims)
         tags = compute_tags(sm)
         assert len(tags) == 0
+
+
+class TestLayer3Conditions:
+    """Layer 3: condition type refinement with precondition filter."""
+
+    def test_distinctive_issneaking_always_tags(self):
+        """IsSneaking is distinctive — tags Sneak even with 8+ condition types."""
+        sm = _make_submod(
+            condition_types_present={
+                "IsSneaking", "IsEquippedType", "IsWornInSlotHasKeyword",
+                "HasMagicEffect", "IsActorBase", "IsClass", "HasPerk",
+                "CompareValues", "HasKeyword",
+            },
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.SNEAK in tags
+
+    def test_distinctive_isfemale_always_tags(self):
+        sm = _make_submod(
+            condition_types_present={"IsFemale", "IsEquippedType", "IsWornInSlotHasKeyword",
+                                      "HasMagicEffect", "IsClass", "HasPerk",
+                                      "CompareValues", "HasKeyword", "IsActorBase"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags
+
+    def test_distinctive_ischild_always_tags_npc(self):
+        sm = _make_submod(
+            condition_types_present={"IsChild", "IsEquippedType", "IsWornInSlotHasKeyword",
+                                      "HasMagicEffect", "IsClass", "HasPerk",
+                                      "CompareValues", "HasKeyword", "IsActorBase"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_nondistinctive_with_few_conditions_tags(self):
+        """IsEquippedType with <=3 total conditions should tag Equipment."""
+        sm = _make_submod(
+            condition_types_present={"IsEquippedType", "IsWeaponDrawn"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.EQUIPMENT in tags
+
+    def test_nondistinctive_with_many_conditions_skipped(self):
+        """IsEquippedType with 8+ total conditions is a precondition — skip."""
+        sm = _make_submod(
+            condition_types_present={
+                "IsEquippedType", "IsWornInSlotHasKeyword", "HasMagicEffect",
+                "IsActorBase", "IsClass", "HasPerk", "CompareValues",
+                "HasKeyword",
+            },
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.EQUIPMENT not in tags
+
+    def test_combat_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"IsInCombat", "IsCombatState"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_magic_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"HasMagicEffect", "HasSpell"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.MAGIC in tags
+
+    def test_npc_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"IsActorBase", "IsRace"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags
+
+    def test_furniture_conditions_few(self):
+        sm = _make_submod(
+            condition_types_present={"SitSleepState", "CurrentFurniture"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.FURNITURE in tags
+
+    def test_movement_distinctive_isonmount(self):
+        sm = _make_submod(
+            condition_types_present={
+                "IsOnMount", "IsEquippedType", "IsWornInSlotHasKeyword",
+                "HasMagicEffect", "IsActorBase", "IsClass", "HasPerk",
+                "CompareValues", "HasKeyword",
+            },
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.MOVEMENT in tags
+
+    def test_layer3_skips_already_tagged(self):
+        """If Layer 1 already tagged Combat, Layer 3 should not re-add it."""
+        sm = _make_submod(
+            mo2_mod="Combat Animation Overhaul",
+            condition_types_present={"IsInCombat"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.COMBAT in tags
+
+    def test_ignored_conditions(self):
+        """IED_*, SDS_*, PRESET, AND, OR should not produce tags."""
+        sm = _make_submod(
+            condition_types_present={
+                "IED_GearNodeEquippedPlacementHint", "SDS_IsShieldOnBackEnabled",
+                "PRESET",
+            },
+        )
+        tags = compute_tags(sm)
+        assert len(tags) == 0
+
+    def test_negated_isfemale_skipped(self):
+        """IsFemale that is negated should NOT tag Gender (it's a filter, not purpose)."""
+        sm = _make_submod(
+            condition_types_present={"IsFemale"},
+            condition_types_negated={"IsFemale"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER not in tags

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -1,0 +1,64 @@
+"""Tests for core/tag_engine.py — category tag auto-detection.
+
+See design spec docs/superpowers/specs/2026-04-14-category-tags-design.md.
+"""
+from __future__ import annotations
+
+from oar_priority_manager.core.tag_engine import TagCategory, compute_tags
+from oar_priority_manager.core.models import SubMod, OverrideSource
+from pathlib import Path
+
+
+def _make_submod(
+    mo2_mod: str = "Test Mod",
+    replacer: str = "TestReplacer",
+    name: str = "test_sub",
+    animations: list[str] | None = None,
+    condition_types_present: set[str] | None = None,
+    condition_types_negated: set[str] | None = None,
+) -> SubMod:
+    """Factory for SubMod instances with sensible defaults."""
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=100,
+        source_priority=100,
+        disabled=False,
+        config_path=Path(f"/fake/{mo2_mod}/{replacer}/{name}/config.json"),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={},
+        animations=animations or [],
+        condition_types_present=condition_types_present or set(),
+        condition_types_negated=condition_types_negated or set(),
+    )
+
+
+class TestTagCategory:
+    def test_enum_has_10_members(self):
+        assert len(TagCategory) == 10
+
+    def test_each_member_has_color_metadata(self):
+        for tag in TagCategory:
+            assert tag.color_bg.startswith("#"), f"{tag.name} missing color_bg"
+            assert tag.color_fg.startswith("#"), f"{tag.name} missing color_fg"
+            assert tag.color_border.startswith("#"), f"{tag.name} missing color_border"
+
+    def test_each_member_has_label(self):
+        for tag in TagCategory:
+            assert isinstance(tag.label, str) and len(tag.label) > 0
+
+    def test_sort_order_is_unique(self):
+        orders = [tag.sort_order for tag in TagCategory]
+        assert len(orders) == len(set(orders))
+
+    def test_nsfw_sorts_first(self):
+        assert TagCategory.NSFW.sort_order == 0
+
+
+class TestComputeTagsEmpty:
+    def test_empty_submod_returns_empty_set(self):
+        sm = _make_submod()
+        assert compute_tags(sm) == set()

--- a/tests/unit/test_tag_engine.py
+++ b/tests/unit/test_tag_engine.py
@@ -338,3 +338,38 @@ class TestLayer3Conditions:
         )
         tags = compute_tags(sm)
         assert TagCategory.GENDER not in tags
+
+
+class TestComputeTagsMultiLayer:
+    """Integration: tags accumulate across layers."""
+
+    def test_keyword_plus_animation_tags(self):
+        """Layer 1 keyword + Layer 2 animation should combine."""
+        sm = _make_submod(
+            mo2_mod="Dynamic Female Weather Idles",
+            animations=["mt_idle.hkx", "idle_front.hkx", "idle_rain.hkx"],
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags  # Layer 1
+        assert TagCategory.IDLE in tags    # Layer 2
+
+    def test_keyword_plus_condition_tags(self):
+        """Layer 1 + Layer 3 should combine."""
+        sm = _make_submod(
+            mo2_mod="NPC Animation Remix",
+            condition_types_present={"IsSneaking"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.NPC in tags    # Layer 1
+        assert TagCategory.SNEAK in tags  # Layer 3
+
+    def test_all_three_layers_combine(self):
+        sm = _make_submod(
+            mo2_mod="Female Combat Pack",
+            animations=["1hm_attack1.hkx", "1hm_attack2.hkx", "1hm_attack3.hkx"],
+            condition_types_present={"IsSneaking"},
+        )
+        tags = compute_tags(sm)
+        assert TagCategory.GENDER in tags   # Layer 1 (female)
+        assert TagCategory.COMBAT in tags   # Layer 1 (combat) + Layer 2 (attack anims)
+        assert TagCategory.SNEAK in tags    # Layer 3 (IsSneaking)

--- a/tests/unit/test_tree_model.py
+++ b/tests/unit/test_tree_model.py
@@ -129,3 +129,51 @@ class TestSearchIndex:
         index = SearchIndex(root, {})
         results = index.search("heavy")
         assert len(results) > 0
+
+
+class TestSearchIndexTags:
+    def test_search_by_tag_name(self):
+        """Searching 'combat' should match submods tagged Combat."""
+        from oar_priority_manager.core.tag_engine import TagCategory
+
+        sm = SubMod(
+            mo2_mod="Test Mod",
+            replacer="Rep",
+            name="test_sub",
+            description="",
+            priority=100,
+            source_priority=100,
+            disabled=False,
+            config_path=Path("/fake/config.json"),
+            override_source=OverrideSource.SOURCE,
+            override_is_ours=False,
+            raw_dict={},
+            tags={TagCategory.COMBAT},
+        )
+        root = build_tree([sm])
+        index = SearchIndex(root, {})
+        results = index.search("combat")
+        assert len(results) >= 1
+        assert any(r.node.submod is sm for r in results)
+
+    def test_search_tag_case_insensitive(self):
+        from oar_priority_manager.core.tag_engine import TagCategory
+
+        sm = SubMod(
+            mo2_mod="Test Mod",
+            replacer="Rep",
+            name="test_sub",
+            description="",
+            priority=100,
+            source_priority=100,
+            disabled=False,
+            config_path=Path("/fake/config.json"),
+            override_source=OverrideSource.SOURCE,
+            override_is_ours=False,
+            raw_dict={},
+            tags={TagCategory.NSFW},
+        )
+        root = build_tree([sm])
+        index = SearchIndex(root, {})
+        results = index.search("nsfw")
+        assert len(results) >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.15"
 
 [[package]]
 name = "colorama"
@@ -171,7 +171,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "pyside6-essentials", specifier = ">=6.6,<6.9" },
+    { name = "pyside6-essentials", specifier = ">=6.6,<7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-qt", marker = "extra == 'dev'", specifier = ">=4.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },


### PR DESCRIPTION
## Summary

Implements the full Alpha 2 feature set — 37 commits, 28 files changed, ~7,700 lines covering conditions rendering, stacks panel UX, category tags, competitor collapsing, and tree navigation improvements.

This PR is the primary `alpha2-ui` branch merging into `main`. Sub-branches for category tags (PR #78) and collapse competitors (PR #80) were merged into this branch during development.

### Conditions panel rewrite (#43, #44)
- Formatted tree view with collapsible AND/OR groups and JSON toggle
- Condition preset extraction from replacer configs attached to TreeNode
- Preset expansion integration tests and `render_conditions()` renderer
- `conditions_stats` helper for footer display

### Real OAR data handling (#75)
- Collapsible AND/OR condition groups with proper real OAR data format handling

### Alpha 2 UI batch (#45, #46, #47, #48)
- Sort toggle, hide filter, confirm dialogs, warnings batch

### Stacks panel UX (#60, #61)
- Right-click "Go to in tree" context menu on competitor rows
- Target badge in stacks toolbar showing which submod actions apply to

### Category tags (#73, via PR #78)
- 10 tag categories (NSFW, Combat, Equipment, Furniture, Gender, Idle, Magic, Movement, NPC, Sneak)
- 3-layer auto-detection pipeline: folder/mod name keywords → animation filename voting (30% threshold) → condition type refinement
- Manual tag overrides via right-click "Edit Tags..." context menu, persisted in AppConfig
- Tag pills displayed via custom `QStyledItemDelegate`
- Tag names searchable via search bar; pills shown in details panel
- 52 tag engine unit tests + 6 integration tests

### Collapse same-mod competitors (#74, via PR #80)
- Same-mod competitor rows grouped into collapsible summary rows (e.g. "▸ SneakMod (3 siblings)")
- Cross-mod competitors remain as individual rows
- "You" row always visible, never hidden inside collapsed group
- Expand/collapse state persists across display refreshes
- 11 new tests in `TestCollapseCompetitors`

### Tests
- `test_conditions_panel.py` — 256 lines
- `test_conditions_renderer.py` — 389 lines
- `test_scanner.py` — 95 lines
- `test_stacks_panel.py` — 679 lines
- `test_tag_engine.py` — 422 lines
- `test_tag_integration.py` — 131 lines
- 293+ total tests passing

## Test plan
- [ ] Run full pytest suite — all tests pass
- [ ] Launch app with real OAR data — conditions panel renders formatted tree
- [ ] Right-click competitor row — "Go to in tree" context menu appears and navigates
- [ ] Verify stacks toolbar shows target badge for selected submod
- [ ] Verify category tag pills render on mods/submods in tree panel
- [ ] Right-click mod → "Edit Tags..." opens tag editor dialog
- [ ] Verify same-mod competitors collapse into summary row
- [ ] Verify cross-mod competitors remain as individual rows

closes #60
closes #61

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*