### PR TITLE
feat: collapse same-mod competitors in stacks panel (#74)

### DIFF
--- a/src/oar_priority_manager/ui/stacks_panel.py
+++ b/src/oar_priority_manager/ui/stacks_panel.py
@@ -14,6 +14,7 @@ Issues addressed:
   #61 — Target badge label showing which submod action buttons apply to
   #68 — Action buttons moved to toolbar row
   #69 — Relative/Absolute replaced with segmented toggle control
+  #74 — Collapse same-mod competitor rows into a single summary row
 """
 
 from __future__ import annotations
@@ -180,6 +181,102 @@ def _make_competitor_row(
 
 
 # ---------------------------------------------------------------------------
+# Helper widget: collapsible same-mod sibling group (issue #74)
+# ---------------------------------------------------------------------------
+
+class _ModGroupRow(QWidget):
+    """A clickable summary row that collapses/expands same-mod sibling rows.
+
+    Rendered as a sub-header inside a ``_StackSection`` when more than one
+    submod from the same MO2 mod appears in the competitor list.  Individual
+    sibling rows are stored as children and toggled on click.
+
+    Args:
+        mod_name: The MO2 mod name used as the group label.
+        sibling_count: Number of sibling submods in the group (excluding the
+            "you" row, which is always visible outside the group).
+        collapsed: Initial collapsed state.  Defaults to ``True`` so groups
+            start collapsed and the panel stays compact.
+        parent: Optional parent widget.
+    """
+
+    def __init__(
+        self,
+        mod_name: str,
+        sibling_count: int,
+        collapsed: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._collapsed = collapsed
+        self._mod_name = mod_name
+        self._sibling_count = sibling_count
+        self._child_rows: list[QWidget] = []
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Summary button — acts as the toggle handle
+        self._btn = QPushButton()
+        self._btn.setFlat(True)
+        self._btn.setStyleSheet(
+            "QPushButton { text-align: left; padding: 2px 8px;"
+            "  color: #8ab; font-style: italic; }"
+            "QPushButton:hover { background: rgba(255,255,255,0.05); }"
+        )
+        self._btn.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._btn.clicked.connect(self._toggle)
+        layout.addWidget(self._btn)
+
+        # Container for child rows
+        self._child_container = QWidget()
+        self._child_layout = QVBoxLayout(self._child_container)
+        self._child_layout.setContentsMargins(0, 0, 0, 0)
+        self._child_layout.setSpacing(1)
+        layout.addWidget(self._child_container)
+
+        self._update_label()
+        self._child_container.setVisible(not self._collapsed)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def add_child_row(self, row_widget: QWidget) -> None:
+        """Append a sibling competitor row to this group's child container.
+
+        Args:
+            row_widget: The competitor row widget to add.
+        """
+        self._child_rows.append(row_widget)
+        self._child_layout.addWidget(row_widget)
+
+    @property
+    def is_collapsed(self) -> bool:
+        """Whether the group is currently collapsed."""
+        return self._collapsed
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _toggle(self) -> None:
+        self._collapsed = not self._collapsed
+        self._child_container.setVisible(not self._collapsed)
+        self._update_label()
+
+    def _update_label(self) -> None:
+        arrow = "▸" if self._collapsed else "▾"
+        noun = "sibling" if self._sibling_count == 1 else "siblings"
+        self._btn.setText(
+            f"{arrow} {self._mod_name} ({self._sibling_count} {noun})"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Main panel
 # ---------------------------------------------------------------------------
 
@@ -203,6 +300,8 @@ class StacksPanel(QWidget):
         self._current_submod: SubMod | None = None
         self._relative_mode = True
         self._collapsed: dict[str, bool] = {}  # anim -> collapsed state (issue #35)
+        # Keyed by f"{anim}:{mo2_mod}" — persists expand/collapse across refreshes
+        self._mod_group_collapsed: dict[str, bool] = {}  # issue #74
         self._setup_ui()
 
     # ------------------------------------------------------------------
@@ -577,7 +676,42 @@ class StacksPanel(QWidget):
         section._header_btn.clicked.disconnect()
         section._header_btn.clicked.connect(_patched_toggle)
 
-        # Competitor rows
+        # ---- Competitor rows with same-mod grouping (issue #74) ----
+        # Competitors from the same MO2 mod as the selected submod are grouped
+        # into a collapsible _ModGroupRow.  Cross-mod competitors remain as
+        # individual rows.  The "you" row is always rendered outside the group.
+        selected_mod = selected.mo2_mod
+
+        # Count how many competitors share the selected submod's MO2 mod
+        # (excluding the selected submod itself) to decide whether to group.
+        same_mod_siblings = [
+            c for c in competitors if c.mo2_mod == selected_mod and c is not selected
+        ]
+        use_group = len(same_mod_siblings) > 0
+
+        # Build the _ModGroupRow once if needed so sibling rows can be added to it.
+        group_row: _ModGroupRow | None = None
+        group_inserted = False  # track whether the group widget is in the section yet
+
+        if use_group:
+            state_key = f"{anim}:{selected_mod}"
+            initial_collapsed = self._mod_group_collapsed.get(state_key, True)
+            group_row = _ModGroupRow(
+                mod_name=selected_mod,
+                sibling_count=len(same_mod_siblings),
+                collapsed=initial_collapsed,
+            )
+
+            # Persist state changes back to _mod_group_collapsed
+            def _on_group_toggle(
+                *,
+                gr: _ModGroupRow = group_row,
+                key: str = state_key,
+            ) -> None:
+                self._mod_group_collapsed[key] = gr.is_collapsed
+
+            group_row._btn.clicked.connect(_on_group_toggle)
+
         for i, comp in enumerate(competitors):
             is_you = comp is selected
             rank_num = i + 1
@@ -615,7 +749,24 @@ class StacksPanel(QWidget):
                 )
             )
 
-            section.add_row(row)
+            # Route row into the correct container (issue #74):
+            #   - "you" row: always goes directly into the section (always visible)
+            #   - Same-mod sibling: routed into the group's child container
+            #   - Cross-mod competitor: goes directly into the section
+            if is_you:
+                # The "you" row is always visible — never hidden inside the group
+                section.add_row(row)
+            elif use_group and comp.mo2_mod == selected_mod:
+                # Same-mod sibling: insert group header before first sibling row,
+                # then add this row as a child of the group.
+                assert group_row is not None  # guaranteed by use_group
+                if not group_inserted:
+                    section.add_row(group_row)
+                    group_inserted = True
+                group_row.add_child_row(row)
+            else:
+                # Cross-mod competitor: individual row, no grouping
+                section.add_row(row)
 
         return section
 

--- a/tests/unit/test_stacks_panel.py
+++ b/tests/unit/test_stacks_panel.py
@@ -1,9 +1,10 @@
 """Unit tests for StacksPanel toolbar enhancements.
 
-Covers the three new controls added in issues #46, #47, and #48:
+Covers the new controls added in issues #46, #47, #48, and #74:
   #46 — Shift… button and _on_shift dialog
   #47 — Animation filter QLineEdit
   #48 — Hide Winning checkable toggle
+  #74 — Collapse same-mod competitor rows into a summary row
 """
 from __future__ import annotations
 
@@ -11,7 +12,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 from oar_priority_manager.core.models import OverrideSource, SubMod
-from oar_priority_manager.ui.stacks_panel import StacksPanel, _StackSection
+from oar_priority_manager.ui.stacks_panel import (
+    StacksPanel,
+    _ModGroupRow,
+    _StackSection,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -22,6 +27,7 @@ def _make_submod(
     priority: int = 100,
     animations: list[str] | None = None,
     has_warnings: bool = False,
+    mo2_mod: str = "Test Mod",
 ) -> SubMod:
     """Build a minimal SubMod for testing.
 
@@ -31,12 +37,13 @@ def _make_submod(
         animations: List of animation filenames; defaults to
             ``["mt_idle.hkx"]``.
         has_warnings: When ``True``, adds a dummy warning string.
+        mo2_mod: MO2 mod name used for same-mod grouping tests.
 
     Returns:
         A fully constructed SubMod.
     """
     return SubMod(
-        mo2_mod="Test Mod",
+        mo2_mod=mo2_mod,
         replacer="rep",
         name=name,
         description="",
@@ -412,3 +419,261 @@ class TestCollapseWinning:
 
         sections = _iter_sections(panel)
         assert all(s._expanded for s in sections)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for issue #74 tests
+# ---------------------------------------------------------------------------
+
+def _iter_section_children(section: _StackSection) -> list:
+    """Return all direct child widgets of a _StackSection's content area.
+
+    Args:
+        section: The _StackSection to inspect.
+
+    Returns:
+        A list of direct child QWidget objects in the content layout.
+    """
+    layout = section._content_layout
+    children = []
+    for i in range(layout.count()):
+        item = layout.itemAt(i)
+        if item and item.widget():
+            children.append(item.widget())
+    return children
+
+
+# ---------------------------------------------------------------------------
+# Issue #74 — Collapse same-mod competitor rows
+# ---------------------------------------------------------------------------
+
+class TestCollapseCompetitors:
+    """Tests for same-mod sibling collapsing in stacks panel (issue #74)."""
+
+    def test_same_mod_siblings_create_group_row(self, qtbot):
+        """Same-mod competitors produce a _ModGroupRow summary in the section."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        assert len(sections) == 1
+        children = _iter_section_children(sections[0])
+
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1, "Expected exactly one _ModGroupRow for same-mod siblings"
+
+    def test_group_row_label_shows_mod_name_and_count(self, qtbot):
+        """The summary row label reflects the mod name and sibling count."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sib2 = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                            animations=["mt_idle.hkx"])
+        sib3 = _make_submod(name="sub3", mo2_mod="SneakMod", priority=300,
+                            animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sib2, sib3]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        label = group_rows[0]._btn.text()
+        # Label should mention the mod name and sibling count (2 siblings)
+        assert "SneakMod" in label
+        assert "2" in label
+
+    def test_cross_mod_competitors_are_individual_rows(self, qtbot):
+        """Cross-mod competitors do NOT get grouped into a _ModGroupRow."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        other = _make_submod(name="other", mo2_mod="CombatMod", priority=300,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, other]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 0, "Cross-mod competitor should NOT create a group row"
+
+    def test_you_row_is_direct_section_child_not_in_group(self, qtbot):
+        """'You' row is a direct child of the section — not inside _ModGroupRow."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+
+        # The group row exists but holds only the sibling — not the "you" row
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        # selected submod's row must NOT be inside the group's child rows
+        assert len(group_rows[0]._child_rows) == 1
+
+    def test_clicking_group_row_toggles_sibling_visibility(self, qtbot):
+        """Clicking the _ModGroupRow summary button toggles the collapsed state and container."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        group = group_rows[0]
+
+        # Groups start collapsed — container is explicitly hidden
+        assert group.is_collapsed
+        assert group._child_container.isHidden()
+
+        # Click to expand — collapsed state flips, container no longer hidden
+        group._btn.click()
+        assert not group.is_collapsed
+        assert not group._child_container.isHidden()
+
+        # Click again to collapse — container hidden again
+        group._btn.click()
+        assert group.is_collapsed
+        assert group._child_container.isHidden()
+
+    def test_no_group_when_selected_is_only_submod_from_its_mod(self, qtbot):
+        """No _ModGroupRow is created when no same-mod siblings exist."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        other = _make_submod(name="other", mo2_mod="CombatMod", priority=300,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, other]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 0
+
+    def test_group_state_persists_across_refresh(self, qtbot):
+        """Expanding a group and calling _refresh_display preserves expanded state."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        # Expand the group (it starts collapsed)
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        group_rows[0]._btn.click()  # expand
+
+        # Trigger a refresh
+        panel._refresh_display()
+
+        # Group should still be expanded after refresh
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        assert not group_rows[0].is_collapsed
+
+    def test_sibling_group_contains_correct_child_count(self, qtbot):
+        """The group's _child_rows has exactly the same-mod sibling count."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sib2 = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                            animations=["mt_idle.hkx"])
+        sib3 = _make_submod(name="sub3", mo2_mod="SneakMod", priority=300,
+                            animations=["mt_idle.hkx"])
+        cross = _make_submod(name="cross", mo2_mod="CombatMod", priority=200,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sib2, sib3, cross]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        # 2 siblings (sib2, sib3) — "you" (selected) is NOT in the group
+        assert len(group_rows[0]._child_rows) == 2
+
+    def test_rank_and_priority_labels_preserved_for_grouped_rows(self, qtbot):
+        """Grouped sibling rows still carry rank badge and priority value labels."""
+        from PySide6.QtWidgets import QLabel
+
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+
+        sibling_row = group_rows[0]._child_rows[0]
+        # Row should have QLabel children (rank badge + priority value + name)
+        labels = sibling_row.findChildren(QLabel)
+        assert len(labels) >= 2, "Grouped rows should still have rank badge and priority labels"
+
+    def test_group_starts_collapsed_by_default(self, qtbot):
+        """A freshly built mod group starts in the collapsed state."""
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        assert len(group_rows) == 1
+        assert group_rows[0].is_collapsed
+        assert group_rows[0]._child_container.isHidden()
+
+    def test_mixed_same_and_cross_mod(self, qtbot):
+        """Mixed scenario: same-mod siblings collapsed, cross-mod rows individual."""
+        from PySide6.QtWidgets import QPushButton
+
+        selected = _make_submod(name="sub1", mo2_mod="SneakMod", priority=500,
+                                animations=["mt_idle.hkx"])
+        sibling = _make_submod(name="sub2", mo2_mod="SneakMod", priority=400,
+                               animations=["mt_idle.hkx"])
+        cross = _make_submod(name="cross", mo2_mod="CombatMod", priority=300,
+                             animations=["mt_idle.hkx"])
+        conflict_map = {"mt_idle.hkx": [selected, sibling, cross]}
+        panel = _make_panel(qtbot, conflict_map=conflict_map)
+        panel.update_selection(selected)
+
+        sections = _iter_sections(panel)
+        children = _iter_section_children(sections[0])
+
+        group_rows = [c for c in children if isinstance(c, _ModGroupRow)]
+        direct_buttons = [c for c in children if isinstance(c, QPushButton)]
+
+        # Exactly one group (same-mod sibling), one cross-mod individual button,
+        # plus the "you" button
+        assert len(group_rows) == 1, "Same-mod sibling must be in one group"
+        assert len(direct_buttons) == 2, "Cross-mod + 'you' should be direct buttons"


### PR DESCRIPTION
## Summary
- Same-mod competitor rows in the stacks panel are now grouped into a collapsible summary row (e.g. "▸ SneakMod (3 siblings)")
- Cross-mod competitors remain as individual rows — only same-mod siblings collapse
- The "you" row (selected submod) is always visible, never hidden inside a collapsed group
- Expand/collapse state persists across display refreshes

## Technical Details
- New `_ModGroupRow` widget handles the collapsible group UI
- Grouping logic added to `_build_stack_section()` — groups by `comp.mo2_mod` matching the selected submod
- State stored in `_mod_group_collapsed` dict (keyed by `anim:mo2_mod`)
- 11 new tests in `TestCollapseCompetitors`, 293 total passing

## Test plan
- [ ] Verify same-mod siblings collapse into summary row
- [ ] Verify cross-mod competitors remain as individual rows
- [ ] Verify "you" row always visible when group is collapsed
- [ ] Verify clicking summary row toggles sibling visibility
- [ ] Verify rank badges and priority values preserved
- [ ] Verify context menu still works on expanded sibling rows

Closes #74

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*