### PR TITLE
feat: wire condition filter engine to search bar (#50)

### DIFF
--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -21,13 +21,17 @@ from PySide6.QtWidgets import (
 
 from oar_priority_manager.app.config import AppConfig
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
-from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.filter_engine import (
+    extract_condition_types,
+    match_filter,
+    parse_filter_query,
+)
 from oar_priority_manager.core.models import PriorityStack, SubMod
 from oar_priority_manager.core.priority_resolver import build_stacks
 from oar_priority_manager.core.scanner import scan_mods
 from oar_priority_manager.ui.conditions_panel import ConditionsPanel
 from oar_priority_manager.ui.details_panel import DetailsPanel
-from oar_priority_manager.ui.search_bar import SearchBar
+from oar_priority_manager.ui.search_bar import SearchBar, SearchMode, detect_search_mode
 from oar_priority_manager.ui.stacks_panel import StacksPanel
 from oar_priority_manager.ui.tree_model import SearchIndex
 from oar_priority_manager.ui.tree_panel import TreePanel
@@ -171,15 +175,84 @@ class MainWindow(QMainWindow):
         self._hide_mode = hide_mode
 
     def _on_search(self, query: str) -> None:
-        """Filter tree based on search query (spec §7.2)."""
+        """Filter tree based on search query (spec §7.2).
+
+        When the query activates condition filter mode (contains AND/OR/NOT
+        keywords or a ``condition:`` prefix), routes through
+        :func:`~oar_priority_manager.core.filter_engine.parse_filter_query`
+        and :func:`~oar_priority_manager.core.filter_engine.match_filter`
+        to filter by structural condition presence.  Otherwise falls back
+        to the normal ``SearchIndex`` substring search.
+
+        Args:
+            query: The raw text currently in the search bar.
+        """
         if not query.strip():
             self._tree_panel.filter_tree(None)
             return
 
-        # Build search index on each search (fast enough for typical mod counts)
+        mode = detect_search_mode(query)
+
+        if mode == SearchMode.CONDITION:
+            self._apply_condition_filter(query)
+        else:
+            self._apply_text_filter(query)
+
+    def _apply_text_filter(self, query: str) -> None:
+        """Run a normal substring search and filter the tree.
+
+        Args:
+            query: Raw search text (already confirmed non-empty).
+        """
+        # Build search index on each search (fast enough for typical
+        # mod counts).
         index = SearchIndex(self._tree_panel.tree_root, self._conflict_map)
         results = index.search(query)
         matching = {id(r.node) for r in results}
+        self._tree_panel.filter_tree(matching, hide_mode=self._hide_mode)
+
+    def _apply_condition_filter(self, query: str) -> None:
+        """Filter tree nodes using the condition-presence filter engine.
+
+        Strips the optional ``condition:`` prefix before parsing so both
+        ``condition:IsFemale`` and ``IsFemale`` are handled identically once
+        condition mode is active.
+
+        Only SUBMOD-level ``TreeNode`` objects whose associated ``SubMod``
+        passes :func:`match_filter` are included in the matching set.
+        Ancestor nodes are revealed automatically by
+        :meth:`~oar_priority_manager.ui.tree_panel.TreePanel.filter_tree`.
+
+        Args:
+            query: Raw search text containing condition filter keywords.
+        """
+        from oar_priority_manager.ui.tree_model import NodeType
+
+        # Strip the optional prefix so "condition:IsFemale" parses as
+        # "IsFemale".
+        stripped = query.strip()
+        if stripped.lower().startswith("condition:"):
+            stripped = stripped[len("condition:"):]
+
+        filter_query = parse_filter_query(stripped)
+
+        matching: set[int] = set()
+        root = self._tree_panel.tree_root
+        for mod_node in root.children:
+            for rep_node in mod_node.children:
+                for sub_node in rep_node.children:
+                    if sub_node.node_type != NodeType.SUBMOD:
+                        continue
+                    sm = sub_node.submod
+                    if sm is None:
+                        continue
+                    if match_filter(
+                        sm.condition_types_present,
+                        sm.condition_types_negated,
+                        filter_query,
+                    ):
+                        matching.add(id(sub_node))
+
         self._tree_panel.filter_tree(matching, hide_mode=self._hide_mode)
 
     def _confirm_action(self, action: str, submod: SubMod, value: object) -> bool:

--- a/src/oar_priority_manager/ui/search_bar.py
+++ b/src/oar_priority_manager/ui/search_bar.py
@@ -1,31 +1,136 @@
 """Unified search bar — name search + condition filter mode.
 
 See spec §7.2. Tier 2: condition filter mode (AND/OR/NOT), autocomplete.
+
+When the user types AND/OR/NOT keywords (as whole words, case-insensitive)
+or a ``condition:`` prefix, the bar switches automatically to condition
+filter mode.  The ``condition_mode_changed`` signal notifies the main
+window, which routes the query through ``parse_filter_query`` /
+``match_filter`` instead of the regular ``SearchIndex``.
 """
 
 from __future__ import annotations
 
+import re
+from enum import Enum, auto
+
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QWidget
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Whole-word regex that matches any of the boolean keywords
+_KEYWORD_RE = re.compile(
+    r"\b(AND|OR|NOT)\b",
+    re.IGNORECASE,
+)
+
+_CONDITION_PREFIX = "condition:"
+
+# Tooltip shown on the search input when condition mode is active
+_CONDITION_MODE_TOOLTIP = (
+    "Condition filter active — matches submods that have these "
+    "condition types in their config.\n"
+    "Use NOT <Type> to exclude a condition type.\n"
+    "Example: IsFemale NOT HasPerk"
+)
+
+# Stylesheet snippets applied to the QLineEdit
+_STYLE_NORMAL = ""
+_STYLE_CONDITION = (
+    "QLineEdit {"
+    "  border: 2px solid #5b9bd5;"
+    "  background: #1a2030;"
+    "}"
+)
+
+
+class SearchMode(Enum):
+    """Tracks whether the search bar is in text or condition filter mode.
+
+    Attributes:
+        TEXT: Normal substring search using ``SearchIndex``.
+        CONDITION: Condition-filter mode using ``parse_filter_query`` and
+            ``match_filter`` from ``filter_engine``.
+    """
+
+    TEXT = auto()
+    CONDITION = auto()
+
+
+def detect_search_mode(text: str) -> SearchMode:
+    """Determine whether *text* should activate condition filter mode.
+
+    Condition mode is triggered when the text:
+
+    * contains any of ``AND``, ``OR``, ``NOT`` as whole words
+      (case-insensitive), **or**
+    * starts with the prefix ``condition:`` (case-insensitive).
+
+    This function is intentionally a module-level pure function so that
+    it can be tested independently of the Qt widget.
+
+    Args:
+        text: The raw string currently in the search bar.
+
+    Returns:
+        :attr:`SearchMode.CONDITION` when a condition-mode trigger is
+        detected; :attr:`SearchMode.TEXT` otherwise.
+    """
+    stripped = text.strip()
+    if stripped.lower().startswith(_CONDITION_PREFIX):
+        return SearchMode.CONDITION
+    if _KEYWORD_RE.search(stripped):
+        return SearchMode.CONDITION
+    return SearchMode.TEXT
+
 
 class SearchBar(QWidget):
-    """Top-bar search input with Advanced button, Hide toggle, and Refresh button."""
+    """Top-bar search input with condition-filter mode detection.
+
+    Emits :attr:`search_changed` on every keystroke.  The main window
+    reads :attr:`current_mode` to decide which search backend to use.
+
+    Signals:
+        search_changed: Emitted whenever the input text changes; carries
+            the current text string.
+        refresh_requested: Emitted when the Refresh button is clicked.
+        advanced_requested: Emitted when the Advanced button is clicked.
+        filter_mode_changed: Emitted when the Hide/Dim toggle changes.
+            Carries ``True`` when hide mode is active, ``False`` for dim.
+        condition_mode_changed: Emitted when the search mode transitions
+            between TEXT and CONDITION.  Carries the new
+            :class:`SearchMode` value.
+    """
 
     search_changed = Signal(str)
     refresh_requested = Signal()
     advanced_requested = Signal()
-    # Emitted when the hide/dim mode changes. True = hide mode, False = dim mode.
+    # Emitted when the hide/dim mode changes. True = hide mode, False = dim.
     filter_mode_changed = Signal(bool)
+    # Emitted when the mode switches between TEXT and CONDITION.
+    condition_mode_changed = Signal(object)  # carries SearchMode
 
     def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialise the search bar widget.
+
+        Args:
+            parent: Optional parent widget.
+        """
         super().__init__(parent)
+        self._mode: SearchMode = SearchMode.TEXT
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
 
         self._input = QLineEdit()
-        self._input.setPlaceholderText("Search mods, submods, animations...")
-        self._input.textChanged.connect(self.search_changed.emit)
+        self._input.setPlaceholderText(
+            "Search mods, submods, animations…  "
+            "(use AND/OR/NOT or condition: for condition filter)"
+        )
+        self._input.textChanged.connect(self._on_text_changed)
         layout.addWidget(self._input, stretch=1)
 
         # Hide/Dim toggle: unchecked = dim (default), checked = hide
@@ -47,6 +152,27 @@ class SearchBar(QWidget):
         self._refresh_btn.clicked.connect(self.refresh_requested.emit)
         layout.addWidget(self._refresh_btn)
 
+    # ------------------------------------------------------------------
+    # Internal slots
+    # ------------------------------------------------------------------
+
+    def _on_text_changed(self, text: str) -> None:
+        """Handle keystroke in the search input.
+
+        Detects mode switches, updates the visual indicator and tooltip,
+        and forwards the text via :attr:`search_changed`.
+
+        Args:
+            text: Current content of the QLineEdit.
+        """
+        new_mode = detect_search_mode(text)
+        if new_mode != self._mode:
+            self._mode = new_mode
+            self._apply_mode_style()
+            self.condition_mode_changed.emit(new_mode)
+
+        self.search_changed.emit(text)
+
     def _on_filter_mode_changed(self) -> None:
         """Handle the Hide toggle being clicked.
 
@@ -58,6 +184,24 @@ class SearchBar(QWidget):
         self.filter_mode_changed.emit(hide_mode)
         # Re-emit the current query so the filter re-applies in the new mode.
         self.search_changed.emit(self._input.text())
+
+    def _apply_mode_style(self) -> None:
+        """Update QLineEdit style and tooltip to reflect the current mode."""
+        if self._mode == SearchMode.CONDITION:
+            self._input.setStyleSheet(_STYLE_CONDITION)
+            self._input.setToolTip(_CONDITION_MODE_TOOLTIP)
+        else:
+            self._input.setStyleSheet(_STYLE_NORMAL)
+            self._input.setToolTip("")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def current_mode(self) -> SearchMode:
+        """Return the current :class:`SearchMode`."""
+        return self._mode
 
     @property
     def hide_mode(self) -> bool:

--- a/tests/unit/test_condition_filter_search.py
+++ b/tests/unit/test_condition_filter_search.py
@@ -1,0 +1,584 @@
+"""Tests for condition-filter search bar wiring (issue #50).
+
+Covers:
+- ``detect_search_mode`` — pure mode-detection logic
+- ``SearchBar`` widget — visual mode switching, signal emission
+- ``MainWindow._apply_condition_filter`` — integration with filter engine
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.ui.search_bar import (
+    SearchMode,
+    detect_search_mode,
+)
+from oar_priority_manager.ui.tree_model import NodeType, TreeNode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_submod(
+    name: str = "sub",
+    priority: int = 100,
+    condition_types_present: set[str] | None = None,
+    condition_types_negated: set[str] | None = None,
+    mo2_mod: str = "TestMod",
+    replacer: str = "rep",
+) -> SubMod:
+    """Build a minimal SubMod for condition-filter tests.
+
+    Args:
+        name: Submod name.
+        priority: Priority integer.
+        condition_types_present: Pre-populated condition type set.
+        condition_types_negated: Pre-populated negated type set.
+        mo2_mod: MO2 mod name.
+        replacer: Replacer name.
+
+    Returns:
+        A fully constructed SubMod instance.
+    """
+    sm = SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=False,
+        config_path=Path(
+            f"C:/mods/{mo2_mod}/meshes/actors/character/animations"
+            f"/OpenAnimationReplacer/{replacer}/{name}/config.json"
+        ),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": name, "priority": priority},
+        animations=["mt_idle.hkx"],
+    )
+    sm.condition_types_present = condition_types_present or set()
+    sm.condition_types_negated = condition_types_negated or set()
+    return sm
+
+
+def _make_tree(submods: list[SubMod]) -> TreeNode:
+    """Build a minimal three-level TreeNode tree from a flat SubMod list.
+
+    Args:
+        submods: List of SubMod instances to organise into the tree.
+
+    Returns:
+        The ROOT TreeNode whose children are MOD nodes.
+    """
+    from oar_priority_manager.ui.tree_model import build_tree
+    return build_tree(submods)
+
+
+# ---------------------------------------------------------------------------
+# detect_search_mode — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSearchMode:
+    """Tests for the ``detect_search_mode`` pure function."""
+
+    def test_empty_string_is_text_mode(self) -> None:
+        assert detect_search_mode("") == SearchMode.TEXT
+
+    def test_plain_name_is_text_mode(self) -> None:
+        assert detect_search_mode("IsFemale") == SearchMode.TEXT
+
+    def test_plain_multi_word_no_keywords_is_text_mode(self) -> None:
+        assert detect_search_mode("my cool mod") == SearchMode.TEXT
+
+    # condition: prefix triggers condition mode
+    def test_condition_prefix_lowercase_triggers(self) -> None:
+        assert detect_search_mode("condition:IsFemale") == SearchMode.CONDITION
+
+    def test_condition_prefix_mixed_case_triggers(self) -> None:
+        assert detect_search_mode("Condition:IsFemale") == SearchMode.CONDITION
+
+    def test_condition_prefix_uppercase_triggers(self) -> None:
+        assert detect_search_mode("CONDITION:IsFemale") == SearchMode.CONDITION
+
+    def test_condition_prefix_with_leading_whitespace(self) -> None:
+        assert detect_search_mode("  condition:IsFemale") == SearchMode.CONDITION
+
+    def test_condition_prefix_alone_triggers(self) -> None:
+        # Even with nothing after the colon
+        assert detect_search_mode("condition:") == SearchMode.CONDITION
+
+    # NOT keyword
+    def test_not_keyword_uppercase_triggers(self) -> None:
+        assert detect_search_mode("NOT HasPerk") == SearchMode.CONDITION
+
+    def test_not_keyword_mixed_case_triggers(self) -> None:
+        assert detect_search_mode("Not HasPerk") == SearchMode.CONDITION
+
+    def test_not_keyword_lowercase_triggers(self) -> None:
+        assert detect_search_mode("not HasPerk") == SearchMode.CONDITION
+
+    def test_not_as_substring_does_not_trigger(self) -> None:
+        # "notable" should not trigger because NOT is not a whole word here
+        assert detect_search_mode("notable") == SearchMode.TEXT
+
+    # OR keyword
+    def test_or_keyword_triggers(self) -> None:
+        assert detect_search_mode("IsFemale OR IsInCombat") == SearchMode.CONDITION
+
+    def test_or_lowercase_triggers(self) -> None:
+        assert detect_search_mode("IsFemale or IsInCombat") == SearchMode.CONDITION
+
+    def test_or_as_substring_does_not_trigger(self) -> None:
+        # "organizer" contains "or" but it's not a whole word match at boundary
+        assert detect_search_mode("organizer") == SearchMode.TEXT
+
+    # AND keyword
+    def test_and_keyword_triggers(self) -> None:
+        assert detect_search_mode("IsFemale AND HasPerk") == SearchMode.CONDITION
+
+    def test_and_lowercase_triggers(self) -> None:
+        assert detect_search_mode("IsFemale and HasPerk") == SearchMode.CONDITION
+
+    def test_and_as_substring_does_not_trigger(self) -> None:
+        # "android" contains "and" but not as a whole word
+        assert detect_search_mode("android mod") == SearchMode.TEXT
+
+    # Combined
+    def test_combined_not_and_name_triggers(self) -> None:
+        assert detect_search_mode("IsFemale NOT HasPerk") == SearchMode.CONDITION
+
+    def test_whitespace_only_is_text_mode(self) -> None:
+        assert detect_search_mode("   ") == SearchMode.TEXT
+
+
+# ---------------------------------------------------------------------------
+# SearchBar widget — mode switching
+# ---------------------------------------------------------------------------
+
+
+class TestSearchBarModeSwitch:
+    """Tests for the SearchBar widget's automatic mode-switch behaviour."""
+
+    @pytest.fixture
+    def search_bar(self, qtbot):
+        """Provide a SearchBar widget ready for testing.
+
+        Args:
+            qtbot: pytest-qt bot fixture for widget management.
+        """
+        from oar_priority_manager.ui.search_bar import SearchBar
+        bar = SearchBar()
+        qtbot.addWidget(bar)
+        return bar
+
+    def test_initial_mode_is_text(self, search_bar) -> None:
+        assert search_bar.current_mode == SearchMode.TEXT
+
+    def test_typing_plain_text_stays_text_mode(
+        self, search_bar, qtbot
+    ) -> None:
+        qtbot.keyClicks(search_bar._input, "hello")
+        assert search_bar.current_mode == SearchMode.TEXT
+
+    def test_typing_not_keyword_switches_to_condition(
+        self, search_bar, qtbot
+    ) -> None:
+        search_bar._input.setText("NOT HasPerk")
+        assert search_bar.current_mode == SearchMode.CONDITION
+
+    def test_typing_or_keyword_switches_to_condition(
+        self, search_bar, qtbot
+    ) -> None:
+        search_bar._input.setText("IsFemale OR IsInCombat")
+        assert search_bar.current_mode == SearchMode.CONDITION
+
+    def test_typing_and_keyword_switches_to_condition(
+        self, search_bar, qtbot
+    ) -> None:
+        search_bar._input.setText("IsFemale AND HasPerk")
+        assert search_bar.current_mode == SearchMode.CONDITION
+
+    def test_condition_prefix_switches_to_condition(
+        self, search_bar, qtbot
+    ) -> None:
+        search_bar._input.setText("condition:IsFemale")
+        assert search_bar.current_mode == SearchMode.CONDITION
+
+    def test_clearing_keywords_reverts_to_text_mode(
+        self, search_bar, qtbot
+    ) -> None:
+        # Activate condition mode first
+        search_bar._input.setText("NOT HasPerk")
+        assert search_bar.current_mode == SearchMode.CONDITION
+        # Clear input — should revert to text mode
+        search_bar._input.clear()
+        assert search_bar.current_mode == SearchMode.TEXT
+
+    def test_removing_keywords_reverts_to_text_mode(
+        self, search_bar, qtbot
+    ) -> None:
+        search_bar._input.setText("IsFemale NOT HasPerk")
+        assert search_bar.current_mode == SearchMode.CONDITION
+        # Replace with plain text — no keywords remain
+        search_bar._input.setText("IsFemale HasPerk")
+        assert search_bar.current_mode == SearchMode.TEXT
+
+    def test_condition_mode_changed_signal_emitted(
+        self, search_bar, qtbot
+    ) -> None:
+        received = []
+        search_bar.condition_mode_changed.connect(received.append)
+        search_bar._input.setText("NOT HasPerk")
+        assert len(received) == 1
+        assert received[0] == SearchMode.CONDITION
+
+    def test_condition_mode_changed_emitted_on_revert(
+        self, search_bar, qtbot
+    ) -> None:
+        received = []
+        search_bar._input.setText("NOT HasPerk")
+        search_bar.condition_mode_changed.connect(received.append)
+        # Now revert
+        search_bar._input.setText("HasPerk")
+        assert len(received) == 1
+        assert received[0] == SearchMode.TEXT
+
+    def test_no_duplicate_mode_signals(self, search_bar, qtbot) -> None:
+        """Mode signal should fire only on transitions, not every keystroke."""
+        received = []
+        search_bar._input.setText("NOT HasPerk")
+        search_bar.condition_mode_changed.connect(received.append)
+        # Type more inside condition mode — no extra transition
+        search_bar._input.setText("NOT HasPerk IsFemale")
+        assert len(received) == 0
+
+    def test_search_changed_always_emitted(self, search_bar, qtbot) -> None:
+        """search_changed fires for every text change regardless of mode."""
+        received = []
+        search_bar.search_changed.connect(received.append)
+        search_bar._input.setText("hello")
+        search_bar._input.setText("NOT HasPerk")
+        assert len(received) == 2
+
+    def test_condition_mode_applies_blue_style(
+        self, search_bar, qtbot
+    ) -> None:
+        search_bar._input.setText("NOT HasPerk")
+        # The stylesheet should contain the blue border colour
+        style = search_bar._input.styleSheet()
+        assert "#5b9bd5" in style
+
+    def test_text_mode_clears_style(self, search_bar, qtbot) -> None:
+        search_bar._input.setText("NOT HasPerk")
+        search_bar._input.setText("normal text")
+        assert search_bar._input.styleSheet() == ""
+
+    def test_condition_mode_sets_tooltip(self, search_bar, qtbot) -> None:
+        search_bar._input.setText("NOT HasPerk")
+        assert "Condition filter active" in search_bar._input.toolTip()
+
+    def test_text_mode_clears_tooltip(self, search_bar, qtbot) -> None:
+        search_bar._input.setText("NOT HasPerk")
+        search_bar._input.setText("normal")
+        assert search_bar._input.toolTip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Condition filter integration — _apply_condition_filter
+# ---------------------------------------------------------------------------
+
+
+class TestApplyConditionFilter:
+    """Tests for the main window's condition-filter routing logic.
+
+    We test the filter matching logic directly by constructing a minimal
+    tree and calling ``_apply_condition_filter`` with a mocked
+    ``_tree_panel``.  This avoids creating a full ``MainWindow`` (which
+    requires a real MO2 instance on disk) while still covering the
+    routing code paths.
+    """
+
+    # ------------------------------------------------------------------
+    # Fixtures
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    def female_submod(self) -> SubMod:
+        """SubMod with IsFemale condition present."""
+        return _make_submod(
+            name="female_anim",
+            condition_types_present={"IsFemale"},
+        )
+
+    @pytest.fixture
+    def perk_submod(self) -> SubMod:
+        """SubMod with HasPerk condition present."""
+        return _make_submod(
+            name="perk_anim",
+            condition_types_present={"HasPerk"},
+        )
+
+    @pytest.fixture
+    def female_perk_submod(self) -> SubMod:
+        """SubMod with both IsFemale and HasPerk conditions."""
+        return _make_submod(
+            name="female_perk_anim",
+            condition_types_present={"IsFemale", "HasPerk"},
+        )
+
+    @pytest.fixture
+    def empty_submod(self) -> SubMod:
+        """SubMod with no conditions."""
+        return _make_submod(
+            name="bare_anim",
+            condition_types_present=set(),
+        )
+
+    def _run_filter(
+        self,
+        submods: list[SubMod],
+        query: str,
+    ) -> set[str]:
+        """Helper: run ``_apply_condition_filter`` and return matched submod names.
+
+        Builds a real tree from *submods*, wires a mock tree panel, calls
+        the filter method, and returns the set of submod ``display_name``
+        values whose ``TreeNode`` ids ended up in the ``matching`` set
+        passed to ``filter_tree``.
+
+        Args:
+            submods: SubMods to include in the tree.
+            query: Condition filter query string.
+
+        Returns:
+            Set of display_name strings for matched SUBMOD nodes.
+        """
+        from oar_priority_manager.ui.main_window import MainWindow
+        from oar_priority_manager.ui.tree_model import NodeType, build_tree
+
+        root = build_tree(submods)
+
+        # Build id → node map from the tree
+        node_by_id: dict[int, TreeNode] = {}
+
+        def _collect(node: TreeNode) -> None:
+            node_by_id[id(node)] = node
+            for child in node.children:
+                _collect(child)
+
+        _collect(root)
+
+        # Capture what _apply_condition_filter passes to filter_tree
+        captured: dict = {}
+
+        mock_panel = MagicMock()
+        mock_panel.tree_root = root
+        mock_panel.filter_tree.side_effect = (
+            lambda matching, hide_mode=False: captured.update(
+                {"matching": matching}
+            )
+        )
+
+        # Use a MagicMock as self and call the unbound method — avoids
+        # PySide6 metaclass restrictions on object.__new__(QMainWindow).
+        win = MagicMock()
+        win._tree_panel = mock_panel
+        win._hide_mode = False
+
+        MainWindow._apply_condition_filter(win, query)
+
+        matched_ids = captured.get("matching", set())
+        return {
+            node_by_id[nid].display_name
+            for nid in matched_ids
+            if nid in node_by_id
+            and node_by_id[nid].node_type == NodeType.SUBMOD
+        }
+
+    # ------------------------------------------------------------------
+    # Happy-path tests
+    # ------------------------------------------------------------------
+
+    def test_required_condition_matches_submod(
+        self,
+        female_submod: SubMod,
+        perk_submod: SubMod,
+    ) -> None:
+        matched = self._run_filter(
+            [female_submod, perk_submod], "IsFemale"
+        )
+        assert "female_anim" in matched
+        assert "perk_anim" not in matched
+
+    def test_not_excludes_submod(
+        self,
+        female_submod: SubMod,
+        perk_submod: SubMod,
+    ) -> None:
+        matched = self._run_filter(
+            [female_submod, perk_submod], "NOT IsFemale"
+        )
+        assert "female_anim" not in matched
+        assert "perk_anim" in matched
+
+    def test_multiple_required_conditions(
+        self,
+        female_submod: SubMod,
+        female_perk_submod: SubMod,
+    ) -> None:
+        # Only the submod with BOTH conditions should match.
+        matched = self._run_filter(
+            [female_submod, female_perk_submod], "IsFemale HasPerk"
+        )
+        assert "female_perk_anim" in matched
+        assert "female_anim" not in matched
+
+    def test_condition_prefix_stripped_before_parsing(
+        self,
+        female_submod: SubMod,
+        perk_submod: SubMod,
+    ) -> None:
+        matched = self._run_filter(
+            [female_submod, perk_submod], "condition:IsFemale"
+        )
+        assert "female_anim" in matched
+        assert "perk_anim" not in matched
+
+    def test_condition_prefix_case_insensitive(
+        self,
+        female_submod: SubMod,
+        perk_submod: SubMod,
+    ) -> None:
+        matched = self._run_filter(
+            [female_submod, perk_submod], "CONDITION:IsFemale"
+        )
+        assert "female_anim" in matched
+
+    # ------------------------------------------------------------------
+    # Edge-case tests
+    # ------------------------------------------------------------------
+
+    def test_empty_query_matches_all_submods(
+        self,
+        female_submod: SubMod,
+        perk_submod: SubMod,
+        empty_submod: SubMod,
+    ) -> None:
+        """An empty filter query (only an empty condition: prefix) matches all."""
+        matched = self._run_filter(
+            [female_submod, perk_submod, empty_submod], "condition:"
+        )
+        assert "female_anim" in matched
+        assert "perk_anim" in matched
+        assert "bare_anim" in matched
+
+    def test_submod_with_no_conditions_fails_required(
+        self,
+        empty_submod: SubMod,
+    ) -> None:
+        matched = self._run_filter([empty_submod], "IsFemale")
+        assert "bare_anim" not in matched
+
+    def test_submod_with_no_conditions_passes_not(
+        self,
+        empty_submod: SubMod,
+    ) -> None:
+        """A submod with no conditions passes a NOT filter (absent = not excluded)."""
+        matched = self._run_filter([empty_submod], "NOT IsFemale")
+        assert "bare_anim" in matched
+
+    def test_required_and_excluded_combined(
+        self,
+        female_submod: SubMod,
+        female_perk_submod: SubMod,
+    ) -> None:
+        """IsFemale NOT HasPerk matches female only, not female+perk."""
+        matched = self._run_filter(
+            [female_submod, female_perk_submod], "IsFemale NOT HasPerk"
+        )
+        assert "female_anim" in matched
+        assert "female_perk_anim" not in matched
+
+    def test_no_match_returns_empty_set(
+        self,
+        perk_submod: SubMod,
+    ) -> None:
+        matched = self._run_filter([perk_submod], "IsFemale")
+        assert len(matched) == 0
+
+    def test_none_submod_node_skipped(self) -> None:
+        """Tree nodes without an attached SubMod must not cause errors."""
+        # Build a tree normally then inject a node with submod=None
+        sm = _make_submod("test_sub", condition_types_present={"IsFemale"})
+        root = _make_tree([sm])
+        # Inject a SUBMOD node with no submod
+        orphan = TreeNode(
+            display_name="orphan",
+            node_type=NodeType.SUBMOD,
+            submod=None,
+        )
+        # Attach it to the first replacer
+        root.children[0].children[0].children.append(orphan)
+
+        from oar_priority_manager.ui.main_window import MainWindow
+
+        mock_panel = MagicMock()
+        mock_panel.tree_root = root
+        captured: dict = {}
+        mock_panel.filter_tree.side_effect = (
+            lambda matching, hide_mode=False: captured.update(
+                {"matching": matching}
+            )
+        )
+
+        win = MagicMock()
+        win._tree_panel = mock_panel
+        win._hide_mode = False
+
+        # Should not raise even with the None-submod node present
+        MainWindow._apply_condition_filter(win, "IsFemale")
+        assert isinstance(captured["matching"], set)
+
+    # ------------------------------------------------------------------
+    # Revert-to-text-mode tests
+    # ------------------------------------------------------------------
+
+    def test_clearing_input_calls_filter_tree_with_none(
+        self, qtbot
+    ) -> None:
+        """When the search bar is cleared, the main window clears the filter."""
+        from oar_priority_manager.ui.search_bar import SearchBar
+
+        bar = SearchBar()
+        qtbot.addWidget(bar)
+
+        captured = {}
+        bar.search_changed.connect(lambda t: captured.update({"text": t}))
+
+        bar._input.setText("NOT HasPerk")
+        bar._input.clear()
+
+        assert captured["text"] == ""
+
+    def test_mode_reverts_after_clearing_keyword(self, qtbot) -> None:
+        """Removing the last keyword reverts the bar to TEXT mode."""
+        from oar_priority_manager.ui.search_bar import SearchBar
+
+        bar = SearchBar()
+        qtbot.addWidget(bar)
+
+        bar._input.setText("NOT HasPerk")
+        assert bar.current_mode == SearchMode.CONDITION
+
+        bar._input.setText("HasPerk")
+        assert bar.current_mode == SearchMode.TEXT

--- a/tests/unit/test_condition_filter_search.py
+++ b/tests/unit/test_condition_filter_search.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

- Wires the existing `parse_filter_query()` and `match_filter()` backend from `filter_engine.py` to the search bar UI
- Automatically detects condition filter mode when the user types `AND`/`OR`/`NOT` keywords (whole words, case-insensitive) or a `condition:` prefix
- Visual indicator: blue border on the search input when condition mode is active
- Help tooltip explains structural-presence semantics when condition mode activates
- Seamlessly reverts to normal text search when condition keywords are removed

## Files changed

| File | Change |
|---|---|
| `ui/search_bar.py` | Add `SearchMode` enum, `detect_search_mode()` pure function, mode detection on every keystroke, visual styling, `condition_mode_changed` signal |
| `ui/main_window.py` | Route search queries through `_apply_condition_filter()` when in condition mode — walks tree nodes and calls `match_filter()` per submod |
| `tests/unit/test_condition_filter_search.py` | 49 tests across 3 test classes: mode detection (20), widget behaviour (16), filter integration (13) |

## Test plan

- [x] 342 tests passing (49 new + 293 existing)
- [ ] Launch app — type `NOT HasPerk` in search bar → border turns blue, tooltip appears, tree filters by condition presence
- [ ] Type `condition:IsFemale` → same behaviour
- [ ] Clear search → reverts to normal mode (border clears, tooltip gone)
- [ ] Type normal text → regular text search, no blue border

fixes #50

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*