### PR TITLE
feat: add directory picker dialog on detection failure (#53)

### DIFF
--- a/src/oar_priority_manager/app/config.py
+++ b/src/oar_priority_manager/app/config.py
@@ -6,10 +6,84 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Last-instance persistence (spec §8.3.1 — manual picker fallback)
+# ---------------------------------------------------------------------------
+
+#: Subdirectory under %APPDATA% where the last-instance file is stored.
+_APPDATA_SUBDIR = "oar-priority-manager"
+
+#: File that stores the manually-chosen mods path across launches.
+_LAST_INSTANCE_FILENAME = "last-instance.json"
+
+
+def _appdata_dir() -> Path:
+    """Return the %APPDATA%/oar-priority-manager directory.
+
+    Returns:
+        Path to the application data directory.
+    """
+    appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+    return Path(appdata) / _APPDATA_SUBDIR
+
+
+def load_last_instance() -> Path | None:
+    """Load the manually-chosen mods path from the last-instance cache.
+
+    Reads ``%APPDATA%/oar-priority-manager/last-instance.json``.  Returns
+    ``None`` on any failure (missing file, bad JSON, path no longer valid).
+
+    Returns:
+        The cached mods directory as a resolved :class:`Path`, or ``None`` if
+        the cache is absent, unreadable, or points to a directory that no
+        longer exists.
+    """
+    cache_path = _appdata_dir() / _LAST_INSTANCE_FILENAME
+    if not cache_path.is_file():
+        return None
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        mods_path = Path(data["mods_path"])
+        if mods_path.is_dir():
+            return mods_path
+        logger.warning(
+            "Cached mods path no longer exists: %s", mods_path
+        )
+        return None
+    except (json.JSONDecodeError, KeyError, OSError) as exc:
+        logger.warning("Could not read last-instance cache: %s", exc)
+        return None
+
+
+def save_last_instance(mods_path: Path) -> None:
+    """Persist the manually-chosen mods path for use on subsequent launches.
+
+    Writes ``%APPDATA%/oar-priority-manager/last-instance.json`` with the
+    given path and the current UTC timestamp.
+
+    Args:
+        mods_path: Absolute path to the MO2 ``mods/`` directory chosen by
+            the user via the directory picker dialog.
+    """
+    cache_dir = _appdata_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / _LAST_INSTANCE_FILENAME
+    payload = {
+        "mods_path": str(mods_path),
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+    }
+    cache_path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    logger.debug("Saved last-instance cache: %s", cache_path)
 
 
 class DetectionError(Exception):
@@ -39,7 +113,10 @@ def detect_instance_root(
       1. ``mods_path`` CLI arg — parent directory is the instance root.
       2. ``cwd`` contains both ``ModOrganizer.ini`` and ``mods/``.
       3. Walk up from ``cwd`` looking for ``ModOrganizer.ini`` + ``mods/``.
-      4. Raise :class:`DetectionError` — no instance found.
+      4. Cached last-instance path from ``%APPDATA%/oar-priority-manager/``
+         ``last-instance.json`` — parent directory is the instance root.
+      5. Raise :class:`DetectionError` — no instance found (caller should
+         show the directory-picker dialog as a last resort).
 
     Args:
         mods_path: Explicit path to the MO2 ``mods/`` directory, typically
@@ -73,6 +150,12 @@ def detect_instance_root(
             ):
                 return current
             current = current.parent
+
+    # Step 4 — check the last-instance cache written by the directory picker.
+    cached = load_last_instance()
+    if cached is not None:
+        logger.info("Using cached mods path from last-instance: %s", cached)
+        return cached.parent
 
     raise DetectionError(
         "Could not detect MO2 instance. Please configure the executable with "

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -74,14 +75,26 @@ def main(argv: list[str] | None = None) -> int:
         format="%(name)s %(levelname)s: %(message)s",
     )
 
+    # Force the native Windows platform plugin.  pytest-qt sets
+    # QT_QPA_PLATFORM=offscreen for headless tests — if that leaks into
+    # a real launch (same terminal, IDE env, etc.) the app renders to an
+    # invisible buffer and no window ever appears.
+    os.environ.pop("QT_QPA_PLATFORM", None)
+    app = QApplication(sys.argv[:1] + ["-platform", "windows"])
+    app.setApplicationName("OAR Priority Manager")
+
     try:
         instance_root = detect_instance_root(
             mods_path=args.mods_path,
             cwd=Path.cwd(),
         )
-    except DetectionError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
-        return 1
+    except DetectionError:
+        # All auto-detection steps failed — fall back to the manual picker.
+        logger.info("Auto-detection failed; showing directory picker dialog.")
+        from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+        mods_path = pick_mods_directory(app)
+        instance_root = mods_path.parent
 
     logger.info("MO2 instance root: %s", instance_root)
 
@@ -91,15 +104,6 @@ def main(argv: list[str] | None = None) -> int:
     submods, conflict_map, stacks = run_scan(instance_root)
     apply_overrides(submods, app_config.tag_overrides)
     logger.info("Loaded %d submods, %d animation stacks", len(submods), len(stacks))
-
-    # Force the native Windows platform plugin.  pytest-qt sets
-    # QT_QPA_PLATFORM=offscreen for headless tests — if that leaks into
-    # a real launch (same terminal, IDE env, etc.) the app renders to an
-    # invisible buffer and no window ever appears.
-    import os
-    os.environ.pop("QT_QPA_PLATFORM", None)
-    app = QApplication(sys.argv[:1] + ["-platform", "windows"])
-    app.setApplicationName("OAR Priority Manager")
 
     # Diagnostic: which Qt platform plugin is loaded?
     logger.info("Qt platform: %s", app.platformName())

--- a/src/oar_priority_manager/ui/instance_picker.py
+++ b/src/oar_priority_manager/ui/instance_picker.py
@@ -1,0 +1,156 @@
+"""Manual MO2 mods-folder picker dialog (spec §8.3.1, last-resort fallback).
+
+Shown when all automatic MO2 instance detection steps are exhausted.  The
+user browses to their MO2 mods folder; the chosen path is cached in
+``%APPDATA%/oar-priority-manager/last-instance.json`` so subsequent launches
+skip the dialog.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QMessageBox,
+)
+
+from oar_priority_manager.app.config import save_last_instance
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+#: Minimum number of subdirectories a folder must contain to be considered a
+#: plausible MO2 mods directory.
+_MIN_SUBDIR_COUNT = 1
+
+
+def _looks_like_mods_dir(path: Path) -> bool:
+    """Return True if *path* looks like a plausible MO2 mods directory.
+
+    The check is intentionally permissive — we only require that the folder
+    has at least one subdirectory (i.e. it is not empty).  A stricter check
+    (e.g. looking for OAR content) would reject valid but pristine installs.
+
+    Args:
+        path: Directory chosen by the user.
+
+    Returns:
+        ``True`` when the directory contains at least one sub-directory,
+        ``False`` otherwise.
+    """
+    try:
+        subdirs = [p for p in path.iterdir() if p.is_dir()]
+        return len(subdirs) >= _MIN_SUBDIR_COUNT
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def pick_mods_directory(app: QApplication | None = None) -> Path:
+    """Show a directory-picker dialog and return the chosen mods path.
+
+    This function is the last-resort fallback in the MO2 instance detection
+    chain.  It:
+
+    1. Prompts the user with an informational message explaining why the
+       dialog is appearing.
+    2. Opens a :class:`~PySide6.QtWidgets.QFileDialog` so the user can
+       browse to their MO2 ``mods/`` folder.
+    3. Validates the selection (warns but does not block if validation fails).
+    4. Saves the chosen path via :func:`~oar_priority_manager.app.config.\
+save_last_instance` so the next launch can skip the dialog.
+    5. Returns the chosen :class:`Path`.
+
+    If the user cancels the dialog, the function prints a message to stderr
+    and calls :func:`sys.exit` with exit code 1.
+
+    Args:
+        app: An existing :class:`~PySide6.QtWidgets.QApplication` instance.
+            When ``None``, the function retrieves the running instance via
+            :meth:`~PySide6.QtWidgets.QApplication.instance`.  A
+            ``QApplication`` *must* already exist before calling this
+            function.
+
+    Returns:
+        The directory chosen by the user as a resolved :class:`Path`.
+
+    Raises:
+        RuntimeError: If no ``QApplication`` is running when the function is
+            called.
+    """
+    _app = app or QApplication.instance()
+    if _app is None:
+        raise RuntimeError(
+            "pick_mods_directory() requires a running QApplication."
+        )
+
+    # Explain why we're asking before showing the file dialog.
+    info = QMessageBox()
+    info.setWindowTitle("MO2 Instance Not Found")
+    info.setIcon(QMessageBox.Icon.Information)
+    info.setText(
+        "OAR Priority Manager could not automatically locate your MO2 "
+        "instance.\n\n"
+        "Please browse to your MO2 <b>mods/</b> folder in the next dialog. "
+        "Your choice will be remembered for future launches."
+    )
+    info.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
+    info.setDefaultButton(QMessageBox.StandardButton.Ok)
+    result = info.exec()
+
+    if result != QMessageBox.StandardButton.Ok:
+        print(
+            "Instance selection cancelled by user.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    chosen = QFileDialog.getExistingDirectory(
+        None,
+        "Select MO2 Mods Folder",
+        "",
+        QFileDialog.Option.ShowDirsOnly | QFileDialog.Option.DontResolveSymlinks,
+    )
+
+    if not chosen:
+        print(
+            "No directory selected. Exiting.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    mods_path = Path(chosen)
+
+    if not _looks_like_mods_dir(mods_path):
+        warn = QMessageBox()
+        warn.setWindowTitle("Directory May Not Be a Mods Folder")
+        warn.setIcon(QMessageBox.Icon.Warning)
+        warn.setText(
+            f"The selected directory appears to be empty or does not contain "
+            f"any mod sub-folders:\n\n{mods_path}\n\n"
+            "You can still proceed, but scanning may return no results."
+        )
+        warn.setStandardButtons(
+            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
+        )
+        warn.setDefaultButton(QMessageBox.StandardButton.Ok)
+        if warn.exec() != QMessageBox.StandardButton.Ok:
+            print(
+                "User declined to proceed with empty mods folder. Exiting.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    save_last_instance(mods_path)
+    logger.info("User selected mods path: %s", mods_path)
+    return mods_path

--- a/tests/unit/test_directory_picker.py
+++ b/tests/unit/test_directory_picker.py
@@ -1,0 +1,487 @@
+"""Tests for the manual directory picker dialog and last-instance persistence.
+
+Covers:
+  - load_last_instance / save_last_instance round-trip
+  - load_last_instance returns None for missing, corrupt, or stale entries
+  - detect_instance_root uses the last-instance cache as a fallback step
+  - pick_mods_directory happy path (dialog accepted, path saved)
+  - pick_mods_directory cancel — sys.exit(1) is called
+  - pick_mods_directory with empty mods folder — validation warning shown,
+    user can proceed or cancel
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtWidgets import QMessageBox
+
+from oar_priority_manager.app.config import (
+    DetectionError,
+    detect_instance_root,
+    load_last_instance,
+    save_last_instance,
+)
+
+#: Real enum values — kept on mock classes so comparisons in the SUT work.
+_OK = QMessageBox.StandardButton.Ok
+_CANCEL = QMessageBox.StandardButton.Cancel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_cache(cache_path: Path, mods_path: str) -> None:
+    """Write a minimal last-instance.json at *cache_path*."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps({"mods_path": mods_path, "timestamp": "2026-04-15T00:00:00+00:00"}),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_last_instance / save_last_instance
+# ---------------------------------------------------------------------------
+
+
+class TestLastInstancePersistence:
+    """Round-trip and failure-mode tests for the cache helpers."""
+
+    def test_save_creates_file(self, tmp_path: Path, monkeypatch) -> None:
+        """save_last_instance writes a JSON file in the appdata directory."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+
+        save_last_instance(mods)
+
+        cache = tmp_path / "oar-priority-manager" / "last-instance.json"
+        assert cache.is_file()
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path, monkeypatch) -> None:
+        """Saved path is returned verbatim by load_last_instance."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+
+        save_last_instance(mods)
+        result = load_last_instance()
+
+        assert result == mods
+
+    def test_save_stores_mods_path_string(self, tmp_path: Path, monkeypatch) -> None:
+        """The JSON file contains a ``mods_path`` key."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+
+        save_last_instance(mods)
+
+        cache = tmp_path / "oar-priority-manager" / "last-instance.json"
+        data = json.loads(cache.read_text(encoding="utf-8"))
+        assert "mods_path" in data
+        assert data["mods_path"] == str(mods)
+
+    def test_save_stores_timestamp(self, tmp_path: Path, monkeypatch) -> None:
+        """The JSON file contains a ``timestamp`` key."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+
+        save_last_instance(mods)
+
+        cache = tmp_path / "oar-priority-manager" / "last-instance.json"
+        data = json.loads(cache.read_text(encoding="utf-8"))
+        assert "timestamp" in data
+
+    def test_load_missing_file_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        """load_last_instance returns None when the cache file is absent."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        result = load_last_instance()
+        assert result is None
+
+    def test_load_corrupt_json_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        """load_last_instance returns None when the file contains invalid JSON."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        cache = tmp_path / "oar-priority-manager" / "last-instance.json"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text("not valid json!!!", encoding="utf-8")
+
+        result = load_last_instance()
+        assert result is None
+
+    def test_load_missing_key_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        """load_last_instance returns None when ``mods_path`` key is absent."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        cache = tmp_path / "oar-priority-manager" / "last-instance.json"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(json.dumps({"timestamp": "2026-04-15"}), encoding="utf-8")
+
+        result = load_last_instance()
+        assert result is None
+
+    def test_load_stale_path_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        """load_last_instance returns None when the cached directory no longer exists."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        ghost_path = tmp_path / "gone" / "mods"  # never created
+        cache = tmp_path / "oar-priority-manager" / "last-instance.json"
+        _write_cache(cache, str(ghost_path))
+
+        result = load_last_instance()
+        assert result is None
+
+    def test_overwrite_updates_cached_path(self, tmp_path: Path, monkeypatch) -> None:
+        """Calling save_last_instance twice keeps the most recent path."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        old_mods = tmp_path / "old_mods"
+        new_mods = tmp_path / "new_mods"
+        old_mods.mkdir()
+        new_mods.mkdir()
+
+        save_last_instance(old_mods)
+        save_last_instance(new_mods)
+        result = load_last_instance()
+
+        assert result == new_mods
+
+
+# ---------------------------------------------------------------------------
+# detect_instance_root — last-instance fallback step
+# ---------------------------------------------------------------------------
+
+
+class TestDetectInstanceRootFallback:
+    """The last-instance cache is checked before DetectionError is raised."""
+
+    def test_cache_used_when_auto_detection_fails(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When no MO2 instance is found, the cached mods path is used."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+        # Simulate a previous successful picker session.
+        save_last_instance(mods)
+
+        # cwd has no ModOrganizer.ini — auto-detection will fail.
+        empty_cwd = tmp_path / "some" / "other" / "dir"
+        empty_cwd.mkdir(parents=True)
+
+        result = detect_instance_root(cwd=empty_cwd)
+        # The instance root is the parent of the mods/ directory.
+        assert result == tmp_path
+
+    def test_raises_when_cache_also_missing(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """DetectionError is raised when both auto-detection and cache fail."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        # No cache file, no ModOrganizer.ini.
+        result_dir = tmp_path / "empty"
+        result_dir.mkdir()
+
+        with pytest.raises(DetectionError):
+            detect_instance_root(cwd=result_dir)
+
+    def test_cli_arg_takes_priority_over_cache(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Explicit --mods-path overrides any cached path."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        cached_mods = tmp_path / "cached_mods"
+        cached_mods.mkdir()
+        save_last_instance(cached_mods)
+
+        real_mods = tmp_path / "real_mods"
+        real_mods.mkdir()
+
+        result = detect_instance_root(mods_path=str(real_mods))
+        assert result == tmp_path
+        assert result == real_mods.parent
+
+    def test_mo_ini_takes_priority_over_cache(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A found ModOrganizer.ini is used before consulting the cache."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        # Instance in a sub-path.
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "ModOrganizer.ini").touch()
+        (instance / "mods").mkdir()
+
+        # Cache points somewhere else.
+        other_mods = tmp_path / "other_mods"
+        other_mods.mkdir()
+        save_last_instance(other_mods)
+
+        result = detect_instance_root(cwd=instance)
+        assert result == instance
+
+
+# ---------------------------------------------------------------------------
+# pick_mods_directory — dialog behaviour (mocked Qt)
+# ---------------------------------------------------------------------------
+
+
+class TestPickModsDirectory:
+    """Verifies dialog flow via monkeypatched Qt calls."""
+
+    def _make_app(self):
+        """Return a mock QApplication instance."""
+        app = MagicMock()
+        return app
+
+    def test_happy_path_returns_chosen_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Chosen directory is returned and persisted to the cache."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+        # Populate with a subdirectory so validation passes.
+        (mods / "SomeMod").mkdir()
+
+        with (
+            patch(
+                "oar_priority_manager.ui.instance_picker.QMessageBox"
+            ) as mock_mb_cls,
+            patch(
+                "oar_priority_manager.ui.instance_picker.QFileDialog"
+                ".getExistingDirectory",
+                return_value=str(mods),
+            ),
+        ):
+            # Preserve real enum values so comparisons in the SUT work.
+            mock_mb_cls.StandardButton = QMessageBox.StandardButton
+            mock_mb_cls.Icon = QMessageBox.Icon
+            mock_mb_instance = MagicMock()
+            mock_mb_instance.exec.return_value = _OK
+            mock_mb_cls.return_value = mock_mb_instance
+
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            result = pick_mods_directory(self._make_app())
+
+        assert result == mods
+
+    def test_happy_path_saves_to_cache(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """After a successful pick, the path is written to last-instance.json."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+        (mods / "SomeMod").mkdir()
+
+        with (
+            patch(
+                "oar_priority_manager.ui.instance_picker.QMessageBox"
+            ) as mock_mb_cls,
+            patch(
+                "oar_priority_manager.ui.instance_picker.QFileDialog"
+                ".getExistingDirectory",
+                return_value=str(mods),
+            ),
+        ):
+            mock_mb_cls.StandardButton = QMessageBox.StandardButton
+            mock_mb_cls.Icon = QMessageBox.Icon
+            mock_mb_instance = MagicMock()
+            mock_mb_instance.exec.return_value = _OK
+            mock_mb_cls.return_value = mock_mb_instance
+
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            pick_mods_directory(self._make_app())
+
+        cached = load_last_instance()
+        assert cached == mods
+
+    def test_info_dialog_cancel_exits(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Cancelling the intro QMessageBox calls sys.exit(1)."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+
+        with (
+            patch(
+                "oar_priority_manager.ui.instance_picker.QMessageBox"
+            ) as mock_mb_cls,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            mock_mb_cls.StandardButton = QMessageBox.StandardButton
+            mock_mb_cls.Icon = QMessageBox.Icon
+            mock_mb_instance = MagicMock()
+            mock_mb_instance.exec.return_value = _CANCEL
+            mock_mb_cls.return_value = mock_mb_instance
+
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            pick_mods_directory(self._make_app())
+
+        assert exc_info.value.code == 1
+
+    def test_file_dialog_cancel_exits(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Returning an empty string from getExistingDirectory calls sys.exit(1)."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+
+        with (
+            patch(
+                "oar_priority_manager.ui.instance_picker.QMessageBox"
+            ) as mock_mb_cls,
+            patch(
+                "oar_priority_manager.ui.instance_picker.QFileDialog"
+                ".getExistingDirectory",
+                return_value="",
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            mock_mb_cls.StandardButton = QMessageBox.StandardButton
+            mock_mb_cls.Icon = QMessageBox.Icon
+            mock_mb_instance = MagicMock()
+            mock_mb_instance.exec.return_value = _OK
+            mock_mb_cls.return_value = mock_mb_instance
+
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            pick_mods_directory(self._make_app())
+
+        assert exc_info.value.code == 1
+
+    def test_empty_mods_folder_shows_warning_then_proceeds(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """An empty mods folder triggers a warning; user can still proceed."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+        # No subdirectories — validation will flag this.
+
+        call_count = [0]
+
+        class _FakeMBClass:
+            """Stand-in for QMessageBox that preserves real enum attrs."""
+
+            StandardButton = QMessageBox.StandardButton
+            Icon = QMessageBox.Icon
+            Option = QMessageBox.Option
+
+            def __init__(self, *args, **kwargs):
+                call_count[0] += 1
+
+            def setWindowTitle(self, *a):
+                pass
+
+            def setIcon(self, *a):
+                pass
+
+            def setText(self, *a):
+                pass
+
+            def setStandardButtons(self, *a):
+                pass
+
+            def setDefaultButton(self, *a):
+                pass
+
+            def exec(self):
+                # Both info and warning dialogs return Ok.
+                return _OK
+
+        with (
+            patch(
+                "oar_priority_manager.ui.instance_picker.QMessageBox",
+                _FakeMBClass,
+            ),
+            patch(
+                "oar_priority_manager.ui.instance_picker.QFileDialog"
+                ".getExistingDirectory",
+                return_value=str(mods),
+            ),
+        ):
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            result = pick_mods_directory(self._make_app())
+
+        # Both the info dialog and the warning dialog were shown.
+        assert call_count[0] == 2
+        assert result == mods
+
+    def test_empty_mods_folder_warning_cancel_exits(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Cancelling the empty-folder warning calls sys.exit(1)."""
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        mods = tmp_path / "mods"
+        mods.mkdir()
+
+        call_count = [0]
+
+        class _FakeMBClassCancel:
+            """Stand-in: info → Ok, warning → Cancel."""
+
+            StandardButton = QMessageBox.StandardButton
+            Icon = QMessageBox.Icon
+            Option = QMessageBox.Option
+
+            def __init__(self, *args, **kwargs):
+                call_count[0] += 1
+
+            def setWindowTitle(self, *a):
+                pass
+
+            def setIcon(self, *a):
+                pass
+
+            def setText(self, *a):
+                pass
+
+            def setStandardButtons(self, *a):
+                pass
+
+            def setDefaultButton(self, *a):
+                pass
+
+            def exec(self):
+                if call_count[0] == 1:
+                    return _OK
+                return _CANCEL
+
+        with (
+            patch(
+                "oar_priority_manager.ui.instance_picker.QMessageBox",
+                _FakeMBClassCancel,
+            ),
+            patch(
+                "oar_priority_manager.ui.instance_picker.QFileDialog"
+                ".getExistingDirectory",
+                return_value=str(mods),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            pick_mods_directory(self._make_app())
+
+        assert exc_info.value.code == 1
+
+    def test_no_qapplication_raises_runtime_error(
+        self, monkeypatch
+    ) -> None:
+        """RuntimeError is raised when no QApplication exists."""
+        with patch(
+            "oar_priority_manager.ui.instance_picker.QApplication"
+            ".instance",
+            return_value=None,
+        ):
+            from oar_priority_manager.ui.instance_picker import pick_mods_directory
+
+            with pytest.raises(RuntimeError, match="QApplication"):
+                pick_mods_directory(None)


### PR DESCRIPTION
## Summary

- When all MO2 auto-detection steps fail, shows a modal directory picker dialog instead of exiting with an error
- User browses to their MO2 `mods/` folder; choice is saved to `%APPDATA%/oar-priority-manager/last-instance.json`
- On subsequent launches, the cached path is checked as a fallback step in the detection chain (step 4, before giving up)
- Validates the selected directory (warns if empty, but allows the user to proceed)
- QApplication is now created before detection so the dialog can render when needed

## Files changed

| File | Change |
|---|---|
| `app/config.py` | Add `load_last_instance()`, `save_last_instance()`, step 4 cache fallback in `detect_instance_root()` |
| `app/main.py` | Move QApplication creation before detection; catch `DetectionError` and show picker |
| `ui/instance_picker.py` | **New** — `pick_mods_directory()` with info dialog, `QFileDialog`, validation warning |
| `tests/unit/test_directory_picker.py` | **New** — 20 tests: cache round-trip, fallback priority, dialog flows (mocked Qt) |

## Test plan

- [x] 362 tests passing (20 new + 342 existing)
- [x] Ruff lint clean
- [ ] Launch app without `--mods-path` and outside any MO2 instance — dialog should appear
- [ ] Select a valid mods folder — app launches normally
- [ ] Re-launch — should use cached path, no dialog
- [ ] Select an empty folder — warning appears, user can proceed or cancel
- [ ] Cancel the dialog — app exits with code 1

fixes #53

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*