### PR TITLE
fix(actions): guard move_to_top against None target (#100)

### DIFF
--- a/src/oar_priority_manager/core/priority_resolver.py
+++ b/src/oar_priority_manager/core/priority_resolver.py
@@ -43,11 +43,32 @@ def build_stacks(conflict_map: dict[str, list[SubMod]]) -> list[PriorityStack]:
 
 
 def _get_scope_submods(
-    target: SubMod,
+    target: SubMod | None,
     conflict_map: dict[str, list[SubMod]],
     scope: str,
 ) -> list[SubMod]:
-    """Get all unique submods in the scope (submod/replacer/mod)."""
+    """Get all unique submods in the scope (submod/replacer/mod).
+
+    Args:
+        target: The submod selected by the user, or ``None`` when the UI
+            dispatches an action before a selection exists.  A ``None``
+            target returns an empty list so callers see a no-op result
+            rather than an ``AttributeError``.
+        conflict_map: Animation filename -> list of competing submods.
+        scope: One of ``"submod"``, ``"replacer"``, or ``"mod"``.
+
+    Returns:
+        Unique submods within the requested scope, in encounter order.
+        Returns ``[]`` when ``target`` is ``None``.
+
+    Note:
+        The ``None`` guard exists because the UI may dispatch actions
+        (e.g., via keyboard shortcuts) before any row is selected in the
+        tree.  Callers that pass a guaranteed non-None value are unaffected.
+    """
+    if target is None:
+        return []
+
     seen: set[int] = set()
     result: list[SubMod] = []
 
@@ -96,19 +117,22 @@ def _get_external_max(
 
 
 def move_to_top(
-    target: SubMod,
+    target: SubMod | None,
     conflict_map: dict[str, list[SubMod]],
     scope: str = "submod",
 ) -> dict[SubMod, int]:
     """Compute new priorities to make target (and scope) #1 in all stacks.
 
     Args:
-        target: The submod the user selected.
+        target: The submod the user selected, or ``None`` when no row is
+            selected.  A ``None`` target produces an empty result dict
+            (the ``_get_scope_submods`` None guard fires first).
         conflict_map: Animation filename -> list of competing submods.
         scope: "submod", "replacer", or "mod".
 
     Returns:
-        Dict of SubMod -> new_priority. Empty if already winning everywhere.
+        Dict of SubMod -> new_priority. Empty if already winning everywhere
+        or if ``target`` is ``None``.
 
     Raises:
         PriorityOverflowError: If computed priority exceeds INT32_MAX.

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -491,8 +491,23 @@ class MainWindow(QMainWindow):
         )
         return reply == QMessageBox.StandardButton.Ok
 
-    def _on_action(self, action: str, submod: SubMod, value: object) -> None:
-        """Handle priority mutation actions from the stacks panel (spec §6.3 step 5)."""
+    def _on_action(self, action: str, submod: SubMod | None, value: object) -> None:
+        """Handle priority mutation actions from the stacks panel (spec §6.3 step 5).
+
+        Args:
+            action: One of ``"move_to_top"``, ``"move_to_top_replacer"``,
+                ``"move_to_top_mod"``, ``"set_exact"``, or ``"shift"``.
+            submod: The target submod the action applies to, or ``None``
+                when no row is currently selected (e.g., a keyboard shortcut
+                fires before the tree selection has settled).  A ``None``
+                submod is a silent no-op — belt-and-suspenders guard on top
+                of the button ``setEnabled`` gating in ``StacksPanel``.
+            value: Action-specific parameter (int for ``set_exact``/``shift``,
+                ``None`` for move-to-top variants).
+        """
+        if submod is None:
+            return
+
         from oar_priority_manager.core.override_manager import write_override
         from oar_priority_manager.core.priority_resolver import (
             PriorityOverflowError,

--- a/tests/unit/test_main_window_none_guard.py
+++ b/tests/unit/test_main_window_none_guard.py
@@ -1,0 +1,202 @@
+"""Tests for MainWindow None-submod guards (issue #100).
+
+Covers:
+- ``MainWindow._on_action`` — early-return when ``submod`` is ``None``.
+- ``StacksPanel.update_selection(None)`` — action buttons are disabled
+  when no submod is selected.
+- ``StacksPanel.update_selection(submod)`` — action buttons are re-enabled
+  when a valid submod is provided.
+
+The ``_on_action`` tests use the MagicMock-as-self pattern from
+``test_main_window_scan_issues.py`` to avoid pulling in a live MO2
+instance.  The ``StacksPanel`` tests instantiate the real widget under
+``QT_QPA_PLATFORM=offscreen``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from oar_priority_manager.core.models import OverrideSource, SubMod
+from oar_priority_manager.ui.main_window import MainWindow  # noqa: E402
+from oar_priority_manager.ui.stacks_panel import StacksPanel  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_submod(
+    name: str = "sub",
+    priority: int = 100,
+    mo2_mod: str = "TestMod",
+    replacer: str = "rep",
+    animations: list[str] | None = None,
+) -> SubMod:
+    """Build a minimal SubMod for None-guard tests.
+
+    Args:
+        name: Submod name.
+        priority: Priority integer.
+        mo2_mod: MO2 mod name.
+        replacer: Replacer name.
+        animations: Animation filenames.
+
+    Returns:
+        A fully constructed SubMod instance with no warnings.
+    """
+    return SubMod(
+        mo2_mod=mo2_mod,
+        replacer=replacer,
+        name=name,
+        description="",
+        priority=priority,
+        source_priority=priority,
+        disabled=False,
+        config_path=Path(
+            f"C:/mods/{mo2_mod}/meshes/actors/character/animations"
+            f"/OpenAnimationReplacer/{replacer}/{name}/config.json"
+        ),
+        override_source=OverrideSource.SOURCE,
+        override_is_ours=False,
+        raw_dict={"name": name, "priority": priority},
+        animations=animations or ["mt_idle.hkx"],
+        conditions={},
+        warnings=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _on_action None-submod guard
+# ---------------------------------------------------------------------------
+
+
+class TestOnActionNoneSubmod:
+    """``_on_action`` must return immediately when ``submod`` is ``None``.
+
+    The early return prevents ``_confirm_action`` from reaching
+    ``move_to_top(None, …)`` and raising
+    ``AttributeError: 'NoneType' object has no attribute 'animations'``.
+    """
+
+    def _make_win(self) -> MagicMock:
+        """Build a minimal mock MainWindow substitute.
+
+        Returns:
+            MagicMock configured with the attributes ``_on_action`` reads.
+        """
+        mock_self = MagicMock()
+        return mock_self
+
+    def test_move_to_top_none_submod_does_not_raise(self) -> None:
+        """``_on_action('move_to_top', None, None)`` must not raise."""
+        mock_self = self._make_win()
+        # Should return without calling _confirm_action or write_override
+        MainWindow._on_action(mock_self, "move_to_top", None, None)
+        mock_self._confirm_action.assert_not_called()
+
+    def test_move_to_top_replacer_none_submod_does_not_raise(self) -> None:
+        """``_on_action('move_to_top_replacer', None, None)`` must not raise."""
+        mock_self = self._make_win()
+        MainWindow._on_action(mock_self, "move_to_top_replacer", None, None)
+        mock_self._confirm_action.assert_not_called()
+
+    def test_move_to_top_mod_none_submod_does_not_raise(self) -> None:
+        """``_on_action('move_to_top_mod', None, None)`` must not raise."""
+        mock_self = self._make_win()
+        MainWindow._on_action(mock_self, "move_to_top_mod", None, None)
+        mock_self._confirm_action.assert_not_called()
+
+    def test_no_state_mutation_when_submod_is_none(self) -> None:
+        """No write_override calls must occur when ``submod`` is ``None``.
+
+        ``write_override`` is imported inside ``_on_action``'s body, so we
+        patch it at its definition site in ``override_manager``.
+        """
+        mock_self = self._make_win()
+        with patch(
+            "oar_priority_manager.core.override_manager.write_override"
+        ) as mock_write:
+            # The None guard should return before write_override is ever reached.
+            MainWindow._on_action(mock_self, "move_to_top", None, None)
+            mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# StacksPanel button gating on selection state
+# ---------------------------------------------------------------------------
+
+
+class TestStacksPanelButtonGating:
+    """Action buttons must be disabled with no selection, enabled otherwise.
+
+    Uses a real ``StacksPanel`` under ``QT_QPA_PLATFORM=offscreen`` so
+    the ``QWidget.isEnabled()`` contract is exercised without a live MO2
+    instance.
+    """
+
+    @pytest.fixture()
+    def panel(self, qapp) -> StacksPanel:  # type: ignore[no-untyped-def]
+        """Instantiate a real StacksPanel with an empty conflict map.
+
+        Args:
+            qapp: pytest-qt fixture that ensures a ``QApplication`` exists.
+
+        Returns:
+            A ``StacksPanel`` ready for button-state assertions.
+        """
+        return StacksPanel(conflict_map={})
+
+    def _action_buttons(self, panel: StacksPanel) -> list:
+        """Return the action buttons that must track selection state.
+
+        Args:
+            panel: The StacksPanel under test.
+
+        Returns:
+            List of QPushButton instances for move-to-top variants.
+        """
+        return [
+            panel._move_to_top_btn,
+            panel._move_rep_btn,
+            panel._move_mod_btn,
+        ]
+
+    def test_buttons_disabled_with_no_selection(
+        self, panel: StacksPanel
+    ) -> None:
+        """Action buttons are disabled when ``update_selection(None)`` is called."""
+        panel.update_selection(None)
+        for btn in self._action_buttons(panel):
+            assert not btn.isEnabled(), (
+                f"{btn.text()!r} should be disabled with no selection"
+            )
+
+    def test_buttons_enabled_after_valid_selection(
+        self, panel: StacksPanel
+    ) -> None:
+        """Action buttons are enabled when a valid submod (no warnings) is selected."""
+        sm = _make_submod()
+        panel.update_selection(sm)
+        for btn in self._action_buttons(panel):
+            assert btn.isEnabled(), (
+                f"{btn.text()!r} should be enabled after selecting a submod"
+            )
+
+    def test_buttons_re_disabled_after_selection_cleared(
+        self, panel: StacksPanel
+    ) -> None:
+        """Selecting then clearing re-disables all action buttons."""
+        sm = _make_submod()
+        panel.update_selection(sm)
+        panel.update_selection(None)
+        for btn in self._action_buttons(panel):
+            assert not btn.isEnabled(), (
+                f"{btn.text()!r} should be disabled after selection cleared"
+            )

--- a/tests/unit/test_priority_resolver.py
+++ b/tests/unit/test_priority_resolver.py
@@ -14,6 +14,7 @@ from oar_priority_manager.core.priority_resolver import (
     INT32_MAX,
     INT32_MIN,
     PriorityOverflowError,
+    _get_scope_submods,
     build_stacks,
     move_to_top,
     set_exact,
@@ -188,3 +189,36 @@ class TestShift:
         sub_b = _sm("b", INT32_MAX, animations=["idle.hkx"])
         with pytest.raises(PriorityOverflowError):
             shift([sub_a, sub_b], floor_priority=1)
+
+
+class TestGetScopeSubmodsNoneGuard:
+    """Tests for the None-target guard in ``_get_scope_submods``.
+
+    The UI may call ``move_to_top`` before a submod is selected (e.g.,
+    keyboard shortcut fires before the tree selection has settled).  The
+    defensive guard ensures the function returns an empty list rather than
+    raising ``AttributeError: 'NoneType' object has no attribute
+    'animations'``.
+    """
+
+    def test_none_target_returns_empty_list(self) -> None:
+        """``_get_scope_submods(None, …)`` must return ``[]``, never raise."""
+        result = _get_scope_submods(None, {}, "submod")  # type: ignore[arg-type]
+        assert result == []
+
+    def test_none_target_non_empty_conflict_map_returns_empty(self) -> None:
+        """Guard holds even when the conflict map has entries."""
+        sm = _sm("other", 100, animations=["idle.hkx"])
+        conflict_map = {"idle.hkx": [sm]}
+        result = _get_scope_submods(None, conflict_map, "mod")  # type: ignore[arg-type]
+        assert result == []
+
+    def test_move_to_top_none_target_returns_empty_dict(self) -> None:
+        """``move_to_top(None, …)`` must return ``{}`` without raising.
+
+        The public API propagates the empty-list result from
+        ``_get_scope_submods`` and short-circuits to ``{}`` (already
+        handled by the ``if not scope_submods: return {}`` branch).
+        """
+        result = move_to_top(None, {}, scope="submod")  # type: ignore[arg-type]
+        assert result == {}


### PR DESCRIPTION
## Summary

Fixes the `AttributeError: 'NoneType' object has no attribute 'animations'` raised when a "move to top" action is triggered with no submod selected (or when the loaded MO2 instance has zero submods). Qt swallowed the exception so the app didn't crash to desktop, but the action silently failed and the traceback ended up in the log.

## Root cause

`_get_scope_submods` in `core/priority_resolver.py` was typed `target: SubMod` (non-Optional) and dereferenced `target.animations` without checking. The argument contract was on callers, but `_on_action` / `_confirm_action` reached this path with `submod=None` whenever the UI dispatched an action before a selection settled — most commonly via the empty-instance state and keyboard shortcuts firing before button enabled-state had updated.

## Fix — both layers (per issue #100)

### Layer 1: defensive guard in `priority_resolver.py`

- Type signatures for `_get_scope_submods` and `move_to_top` updated to `SubMod | None` so the contract advertises what the runtime now permits.
- Early `if target is None: return []` at the top of `_get_scope_submods`. The `move_to_top` caller already short-circuits on the resulting empty result, and `_confirm_action`'s downstream `if not preview: return True` ensures the UI sees a clean no-op.
- Docstrings explain *why* the guard exists (UI dispatch race), so future maintainers don't strip it as "dead code."

### Layer 2: upstream gating in `main_window.py`

- `_on_action` now early-returns when `submod is None`, with a docstring crediting the existing `StacksPanel.update_selection` button-gating as the primary defense and labeling this as belt-and-suspenders.
- `update_selection(None)` in `StacksPanel` already disables the action buttons via `setEnabled(submod is not None)` — that pre-existing logic is now covered by regression tests rather than rebuilt.
- Type signature updated to `submod: SubMod | None` for honesty.

## Tests

- `tests/unit/test_priority_resolver.py` — adds `TestGetScopeSubmodsNoneGuard` (3 tests) covering the `None` guard return, type contract, and downstream interaction with `move_to_top`.
- `tests/unit/test_main_window_none_guard.py` — new file: `TestOnActionNoneSubmod` (4 tests) for the early-return path, plus `TestStacksPanelButtonGating` (3 tests) documenting the existing `setEnabled`-on-selection contract as regression coverage.
- **+10 tests, all passing.** Test count: 520 baseline → 530 post-change.

## Verification (CI mirror)

Run from the worktree's venv:

```
ruff check src/ tests/                                    # ✅ All checks passed!
QT_QPA_PLATFORM=offscreen pytest -v --tb=short            # ✅ 520 passed, 9 skipped, 1 pre-existing fail*
```

*The single failing test (`test_config.py::TestInstanceDetection::test_no_detection_raises`) **fails identically on `main`** at `0bb9906` with none of these changes applied — confirmed pre-existing, unrelated to this fix. A follow-up issue should be filed separately.

## Acceptance criteria (from #100)

- [x] Triggering any `move_to_top*` action with `submod=None` no longer raises `AttributeError`
- [x] Action buttons / menu items reflect the selection state (disabled when no valid target — pre-existing in `StacksPanel.update_selection`, now covered by regression tests)
- [x] Regression test added covering the no-selection / empty-instance path
- [x] `ruff check src/ tests/` passes; full pytest suite passes (modulo pre-existing unrelated failure)
- [x] Fix is independent of any qt-material work (closed branch)

Closes #100

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_