### PR TITLE
fix(tests): isolate detect_instance_root tests from global appdata cache (#103)

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -42,7 +42,19 @@ class TestInstanceDetection:
         result = detect_instance_root(cwd=nested)
         assert result == tmp_path
 
-    def test_no_detection_raises(self, tmp_path: Path):
+    def test_no_detection_raises(self, tmp_path: Path, monkeypatch):
+        """Step 4 (appdata cache) must be patched so the test is machine-independent.
+
+        Without the patch, a developer machine that has launched the app at
+        least once will have a valid last-instance.json in %APPDATA%, causing
+        step 4 to return a real path and preventing DetectionError from ever
+        being raised.  The monkeypatch forces load_last_instance to return
+        None, ensuring the full fallback chain exhausts at step 5.
+        """
+        monkeypatch.setattr(
+            "oar_priority_manager.app.config.load_last_instance",
+            lambda: None,
+        )
         with pytest.raises(DetectionError):
             detect_instance_root(cwd=tmp_path)
 


### PR DESCRIPTION
## Summary

Fixes the environment-dependent failure of `tests/unit/test_config.py::TestInstanceDetection::test_no_detection_raises` on machines where the app has been launched at least once. The test was correctly reaching `detect_instance_root(cwd=empty_tmp_path)` but never reaching step 5 of its fallback chain because step 4 (the global `%APPDATA%/oar-priority-manager/last-instance.json` cache) returned a populated path on any non-fresh machine.

The fix is **test-only** — production code unchanged. The `detect_instance_root` 5-step fallback is behaving as documented; the test was simply not isolating step 4's global state.

## Fix

Applied option A from the issue — `monkeypatch` the `load_last_instance` reference in the test to return `None`, ensuring step 4 always returns no cached path and step 5 is reached:

```python
def test_no_detection_raises(self, tmp_path: Path, monkeypatch):
    monkeypatch.setattr(
        "oar_priority_manager.app.config.load_last_instance",
        lambda: None,
    )
    with pytest.raises(DetectionError):
        detect_instance_root(cwd=tmp_path)
```

## Audit of sibling tests (per AC #2)

The other tests in `TestInstanceDetection` were audited for the same isolation gap. None needed patching — they all short-circuit before step 4:

| Test | Short-circuits at | Step 4 reachable? |
|---|---|---|
| `test_mods_path_cli_arg` | Step 1 (valid `mods_path`) | No |
| `test_mods_path_nonexistent_raises` | Step 1 (raises immediately) | No |
| `test_cwd_with_mo_ini` | Step 2 (`ModOrganizer.ini` + `mods/` in cwd) | No |
| `test_walk_up_finds_instance` | Step 3 (walk-up finds markers in parent) | No |
| `test_no_detection_raises` | Never — empty `tmp_path` exhausts steps 2+3 | **Yes — patched** |

A class-level autouse fixture (option C) was considered and rejected — only one test in the class needs the isolation, and the explicit per-test `monkeypatch` makes the dependency on global appdata state visible to readers.

## Verification

```
ruff check src/ tests/                                    # ✅ All checks passed!
QT_QPA_PLATFORM=offscreen pytest -v --tb=short            # ✅ 524 passed, 6 skipped
```

Test count summary on the worktree's machine (where `last-instance.json` exists):

| State | Passed | Skipped | Failed |
|---|---|---|---|
| Baseline (`main`, pre-fix) | 523 | 6 | 1 |
| Post-fix | **524** | 6 | **0** |

The previously-failing test now passes; full suite is clean.

## Acceptance criteria (from #103)

- [x] `test_no_detection_raises` passes regardless of whether `%APPDATA%/oar-priority-manager/last-instance.json` exists
- [x] Sibling `TestInstanceDetection` tests audited for the same isolation gap (none affected)
- [x] No production-code changes
- [x] Full pytest suite passes including the fixed test

Closes #103

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_