### PR TITLE
feat(scan): off-thread scan pipeline + splash progress dialog (#95, #96)

### DIFF
--- a/docs/scan-worker.md
+++ b/docs/scan-worker.md
@@ -101,6 +101,74 @@ concurrent scans.
 
 ---
 
+---
+
+## Progress Dialog (`ScanProgressDialog`)
+
+`ScanProgressDialog` (`ui/scan_progress_dialog.py`) is the visual counterpart
+to `ScanWorker`.  It reads the worker's signals and renders a splash-style
+modal dialog with an overall progress bar, a per-stage label, a per-item
+submod name, and a Cancel button.
+
+### Stage weighting
+
+The overall progress bar maps the five pipeline stages to contiguous ranges:
+
+| Stage               | Start % | Weight % |
+|---------------------|---------|---------|
+| `detect`            | 0       | 5       |
+| `scan_mods`         | 5       | 55      |
+| `scan_animations`   | 60      | 30      |
+| `build_conflict_map`| 90      | 5       |
+| `build_stacks`      | 95      | 5       |
+
+Overall = start + (weight × current / total).  When `total = 0` (indeterminate
+stage boundary), only the start offset is shown.
+
+### Modality
+
+The dialog uses different modality depending on the context:
+
+| Context | Mode string | Modality | Parent |
+|---------|-------------|----------|--------|
+| Initial startup | `"startup"` | `ApplicationModal` (frameless) | `None` |
+| User-triggered refresh | `"refresh"` | `WindowModal` (title-bar chrome) | `MainWindow` |
+
+`WindowModal` is used for refresh because it blocks the main window (the only
+window that matters during a re-scan) while leaving other applications usable.
+`ApplicationModal` is used for startup because there is no parent window yet.
+
+### Cancel behaviour
+
+Clicking **Cancel**:
+1. Disables the button and updates the stage label to "Cancelling…".
+2. Emits `cancellation_requested`.
+3. The caller wires this to `thread.requestInterruption()`.
+
+The dialog does not close on cancel-click — it waits for the worker to emit
+`cancelled`, which calls `on_cancelled()` → `reject()`.  This keeps the user
+informed that cancellation is in progress.
+
+**Startup cancel**: `_run_scan_blocking` detects `cancelled` and calls
+`sys.exit(0)` — the user explicitly chose not to scan, so a clean exit is
+the right response.
+
+**Refresh cancel**: `_on_refresh` detects the empty `result_holder` after
+`dialog.exec()` returns and returns without updating the panels.  The
+existing data remains displayed.
+
+### Signal connections summary
+
+```
+worker.progress_updated  →  dialog.on_progress
+worker.finished          →  dialog.on_finished  (auto-dismiss after 1 s)
+worker.failed            →  dialog.on_failed    (immediate close)
+worker.cancelled         →  dialog.on_cancelled (immediate close)
+dialog.cancellation_requested  →  thread.requestInterruption
+```
+
+---
+
 ## Why Not Subclass QThread
 
 The Qt documentation and several Qt style guides recommend the **QObject +

--- a/docs/scan-worker.md
+++ b/docs/scan-worker.md
@@ -1,0 +1,118 @@
+# Scan Worker — Architecture Note
+
+## Why
+
+The full scan pipeline (`scan_mods` → `scan_animations` → `build_conflict_map` →
+`build_stacks`) blocks the GUI thread for several seconds on large MO2 instances
+(e.g. Nolvus-class with ~4 500 submods).  Two consequences:
+
+1. **GUI freeze at startup** — the main window does not appear until the scan
+   completes, which looks like the application has hung.
+2. **Splash prerequisite** — a future live scan-progress window (#96) needs an
+   async scan to drive its progress bar.  A synchronous call site makes that
+   impossible without major restructuring.
+
+`ScanWorker` moves the pipeline off the GUI thread so the event loop stays alive.
+
+---
+
+## Worker Contract
+
+`ScanWorker` is a `QObject` that lives on a `QThread`.  It exposes four signals:
+
+| Signal | Payload | When emitted |
+|---|---|---|
+| `progress_updated(stage, current, total, label)` | `str, int, int, str` | At each of the 5 stage boundaries and after each submod during `scan_mods` |
+| `finished(result)` | `tuple` — `(submods, conflict_map, stacks)` | Scan completed successfully |
+| `failed(exception)` | `Exception` | Any uncaught exception in the pipeline |
+| `cancelled()` | _(none)_ | Scan stopped via `QThread.requestInterruption()` |
+
+`finished` and `failed` are mutually exclusive.  Neither fires if `cancelled` fires.
+
+Stage names are the `_STAGES` module-level tuple in `scan_worker.py`:
+
+```python
+_STAGES = ("detect", "scan_mods", "scan_animations", "build_conflict_map", "build_stacks")
+```
+
+Consumer code (splash screen, status bar) should use these string constants.
+
+---
+
+## Threading Model
+
+```
+GUI thread                     Worker thread
+──────────────────────         ──────────────────────────────
+QThread(parent=window)
+worker = ScanWorker(root)
+worker.moveToThread(thread)    # worker now lives on thread
+thread.started → worker.run    # slot executes on thread
+thread.start()
+                               worker.run()
+                                 _run_pipeline()
+                                   scan_mods(…, on_progress)
+                                     on_progress(cur, total)  ← checks isInterruptionRequested()
+                                   scan_animations(…)
+                                   build_conflict_map(…)
+                                   build_stacks(…)
+                               worker.finished.emit(result)   ← Qt queued connection back to GUI
+GUI on_finished(result)
+  update self._submods …
+  thread.quit() / wait()
+```
+
+**Cancellation** is implemented without locks:
+
+1. Caller calls `QThread.requestInterruption()` (thread-safe Qt primitive).
+2. The `on_progress` callback (runs on the worker thread) checks
+   `QThread.currentThread().isInterruptionRequested()` after each submod.
+3. If set, it raises `_Cancelled` (a private `Exception` subclass).
+4. `_run_pipeline` also checks at the top of each stage so cancellation
+   propagates even when a stage produces zero submods.
+5. `worker.run()` catches `_Cancelled` and emits `cancelled()`.
+
+There is no shared mutable state between the threads beyond Qt's signal queue.
+
+### Startup (blocking pattern)
+
+`main()` must not show the window before the first scan has data.
+`_run_scan_blocking()` pumps a `QEventLoop` while the worker thread runs:
+
+```python
+loop = QEventLoop()
+worker.finished.connect(lambda r: (result_holder.append(r), loop.quit()))
+worker.failed.connect(lambda e: (error_holder.append(e), loop.quit()))
+thread.start()
+loop.exec()          # keeps GUI event loop alive; exits when finished/failed fires
+thread.quit(); thread.wait()
+```
+
+This is simpler and more correct than `QThread.wait()` (which would deadlock
+if any cross-thread signal tried to call back to the GUI thread while we were
+blocked inside `wait()`).
+
+### Refresh (async pattern)
+
+`MainWindow._on_refresh()` starts the worker and returns immediately.  The GUI
+stays interactive; `on_finished` re-populates the panels when the scan completes.
+A guard (`self._scan_thread is not None and thread.isRunning()`) prevents
+concurrent scans.
+
+---
+
+## Why Not Subclass QThread
+
+The Qt documentation and several Qt style guides recommend the **QObject +
+moveToThread** pattern over subclassing `QThread` for non-trivial workers:
+
+- **Composability** — `ScanWorker`'s signals are ordinary `QObject` signals;
+  any slot or `qtbot.waitSignal()` call can connect to them without knowing
+  anything about the thread.
+- **pytest-qt testability** — `qtbot.waitSignal(worker.finished)` works
+  directly on the worker object regardless of which thread it is moved to.
+  If `ScanWorker` subclassed `QThread`, `finished` would be the *thread's*
+  `finished` (fired when the thread exits), not the scan's, making it
+  impossible to distinguish "scan done" from "thread stopped".
+- **Separation of concerns** — the worker's `run()` slot contains domain
+  logic, not thread lifecycle code.  The caller controls thread start/stop/wait.

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -78,15 +78,21 @@ def run_scan(instance_root: Path) -> tuple:
 
 
 def _run_scan_blocking(instance_root: Path) -> tuple:
-    """Run the scan pipeline via ScanWorker, blocking until complete.
+    """Run the scan pipeline via ScanWorker with a startup progress dialog.
 
-    Uses a QEventLoop that exits when the worker emits finished or failed.
-    This pattern keeps the GUI thread's event loop alive during the wait
-    (important for splash screens, etc.) while still blocking main() from
-    proceeding until the first scan has data.
+    Constructs an ``ApplicationModal`` ``ScanProgressDialog`` and a
+    ``QEventLoop``.  The dialog is shown before the event loop starts so
+    the user sees scan progress from the very first frame.  The loop exits
+    when the worker emits ``finished``, ``failed``, or ``cancelled``.
+
+    On successful completion the dialog auto-dismisses after ~1 second
+    (driven by ``ScanProgressDialog.on_finished``).
+
+    On cancellation the user chose to abort startup, so the application
+    exits cleanly via ``sys.exit(0)``.
 
     If the worker fails, the exception captured by the ``failed`` signal is
-    re-raised so main() can handle it like any other startup error.
+    re-raised so ``main()`` can handle it like any other startup error.
 
     Args:
         instance_root: Path to the MO2 instance root.
@@ -98,31 +104,58 @@ def _run_scan_blocking(instance_root: Path) -> tuple:
         Exception: Re-raises whatever exception the worker captured if the
             scan pipeline raises unexpectedly.
     """
+    from oar_priority_manager.ui.scan_progress_dialog import ScanProgressDialog
+
     worker = ScanWorker(instance_root=instance_root)
     thread = QThread()
     worker.moveToThread(thread)
     thread.started.connect(worker.run)
 
+    dialog = ScanProgressDialog(mode="startup")
+
     loop = QEventLoop()
     result_holder: list[tuple] = []
     error_holder: list[Exception] = []
+    cancelled_holder: list[bool] = []
 
     def on_finished(result: tuple) -> None:
         result_holder.append(result)
-        loop.quit()
+        # dialog.on_finished auto-dismisses after 1 s via QTimer; the
+        # loop exits once the dialog's finished signal fires (accept/reject).
+        dialog.finished.connect(loop.quit)
 
     def on_failed(exc: Exception) -> None:
         error_holder.append(exc)
         loop.quit()
 
+    def on_cancelled() -> None:
+        cancelled_holder.append(True)
+        loop.quit()
+
+    # Wire worker signals → dialog slots
+    worker.progress_updated.connect(dialog.on_progress)
+    worker.finished.connect(dialog.on_finished)
+    worker.failed.connect(dialog.on_failed)
+    worker.cancelled.connect(dialog.on_cancelled)
+
+    # Wire worker signals → loop control
     worker.finished.connect(on_finished)
     worker.failed.connect(on_failed)
+    worker.cancelled.connect(on_cancelled)
 
+    # Wire cancel button → thread interruption
+    dialog.cancellation_requested.connect(thread.requestInterruption)
+
+    dialog.show()
     thread.start()
-    loop.exec()  # blocks until on_finished or on_failed calls loop.quit()
+    loop.exec()  # blocks until on_finished/on_failed/on_cancelled
 
     thread.quit()
     thread.wait()
+
+    if cancelled_holder:
+        logger.info("Startup scan cancelled by user — exiting.")
+        sys.exit(0)
 
     if error_holder:
         raise error_holder[0]

--- a/src/oar_priority_manager/app/main.py
+++ b/src/oar_priority_manager/app/main.py
@@ -11,6 +11,7 @@ import os
 import sys
 from pathlib import Path
 
+from PySide6.QtCore import QEventLoop, QThread
 from PySide6.QtWidgets import QApplication
 
 from oar_priority_manager.app.config import (
@@ -22,6 +23,7 @@ from oar_priority_manager.app.config import (
 from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
 from oar_priority_manager.core.filter_engine import extract_condition_types
 from oar_priority_manager.core.priority_resolver import build_stacks
+from oar_priority_manager.core.scan_worker import ScanWorker
 from oar_priority_manager.core.scanner import scan_mods
 from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
 
@@ -47,7 +49,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def run_scan(instance_root: Path) -> tuple:
     """Execute the full scan pipeline (spec §6.3 steps 2-3).
 
-    Returns (submods, conflict_map, stacks).
+    This synchronous function exists as the canonical scan implementation and
+    is called internally by ScanWorker.  It remains public so callers that
+    need a blocking scan (e.g. tests) can invoke it directly.
+
+    Args:
+        instance_root: Path to the MO2 instance root containing mods/ and
+            overwrite/ subdirectories.
+
+    Returns:
+        A 3-tuple ``(submods, conflict_map, stacks)``.
     """
     mods_dir = instance_root / "mods"
     overwrite_dir = instance_root / "overwrite"
@@ -64,6 +75,59 @@ def run_scan(instance_root: Path) -> tuple:
         sm.tags = compute_tags(sm)
 
     return submods, conflict_map, stacks
+
+
+def _run_scan_blocking(instance_root: Path) -> tuple:
+    """Run the scan pipeline via ScanWorker, blocking until complete.
+
+    Uses a QEventLoop that exits when the worker emits finished or failed.
+    This pattern keeps the GUI thread's event loop alive during the wait
+    (important for splash screens, etc.) while still blocking main() from
+    proceeding until the first scan has data.
+
+    If the worker fails, the exception captured by the ``failed`` signal is
+    re-raised so main() can handle it like any other startup error.
+
+    Args:
+        instance_root: Path to the MO2 instance root.
+
+    Returns:
+        A 3-tuple ``(submods, conflict_map, stacks)``.
+
+    Raises:
+        Exception: Re-raises whatever exception the worker captured if the
+            scan pipeline raises unexpectedly.
+    """
+    worker = ScanWorker(instance_root=instance_root)
+    thread = QThread()
+    worker.moveToThread(thread)
+    thread.started.connect(worker.run)
+
+    loop = QEventLoop()
+    result_holder: list[tuple] = []
+    error_holder: list[Exception] = []
+
+    def on_finished(result: tuple) -> None:
+        result_holder.append(result)
+        loop.quit()
+
+    def on_failed(exc: Exception) -> None:
+        error_holder.append(exc)
+        loop.quit()
+
+    worker.finished.connect(on_finished)
+    worker.failed.connect(on_failed)
+
+    thread.start()
+    loop.exec()  # blocks until on_finished or on_failed calls loop.quit()
+
+    thread.quit()
+    thread.wait()
+
+    if error_holder:
+        raise error_holder[0]
+
+    return result_holder[0]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -101,7 +165,10 @@ def main(argv: list[str] | None = None) -> int:
     config_path = instance_root / CONFIG_SUBDIR / CONFIG_FILENAME
     app_config = load_config(config_path)
 
-    submods, conflict_map, stacks = run_scan(instance_root)
+    # Run the scan off the GUI thread.  _run_scan_blocking pumps the event
+    # loop while waiting so the window manager stays responsive during the
+    # initial scan on large instances.
+    submods, conflict_map, stacks = _run_scan_blocking(instance_root)
     apply_overrides(submods, app_config.tag_overrides)
     logger.info("Loaded %d submods, %d animation stacks", len(submods), len(stacks))
 

--- a/src/oar_priority_manager/core/scan_worker.py
+++ b/src/oar_priority_manager/core/scan_worker.py
@@ -135,19 +135,22 @@ class ScanWorker(QObject):
         """Build the on_progress callable passed to scan_mods.
 
         The returned callable:
-        1. Emits ``progress_updated`` with stage ``"scan_mods"``.
+        1. Emits ``progress_updated`` with stage ``"scan_mods"`` and the
+           real submod name supplied by ``scan_mods``.
         2. Checks for a pending interruption after each submod; raises
            ``_Cancelled`` to unwind the pipeline when one is found.
 
         Returns:
-            A callable accepting ``(current: int, total: int)`` that
-            also receives the submod name via closure over the submods
-            list.  Because ``scan_mods`` only provides ``(current, total)``
-            the label is synthesised as ``f"submod {current}/{total}"``.
+            A callable accepting ``(current: int, total: int,
+            submod_name: str)`` that forwards the real submod display
+            name as the ``label`` field of ``progress_updated``.
         """
-        def on_progress(current: int, total: int) -> None:
-            label = f"submod {current}/{total}"
-            self.progress_updated.emit("scan_mods", current, total, label)
+        def on_progress(
+            current: int, total: int, submod_name: str
+        ) -> None:
+            self.progress_updated.emit(
+                "scan_mods", current, total, submod_name
+            )
             self._check_interruption()
 
         return on_progress

--- a/src/oar_priority_manager/core/scan_worker.py
+++ b/src/oar_priority_manager/core/scan_worker.py
@@ -1,0 +1,245 @@
+"""QThread-backed worker that runs the full scan pipeline off the GUI thread.
+
+Architecture note: uses the QObject + moveToThread pattern rather than
+subclassing QThread.  This keeps the worker composable (its signals are
+ordinary QObject signals) and plays nicely with pytest-qt's qtbot helpers,
+which assert signals directly against the worker object.
+
+See docs/scan-worker.md for the full threading model and design rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtCore import QObject, QThread, Signal
+
+from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.filter_engine import extract_condition_types
+from oar_priority_manager.core.priority_resolver import build_stacks
+from oar_priority_manager.core.scanner import scan_mods
+from oar_priority_manager.core.tag_engine import compute_tags
+
+logger = logging.getLogger(__name__)
+
+# Canonical stage names emitted with progress_updated.  The splash / progress
+# UI consumes these string constants — keep them stable across releases.
+_STAGES = (
+    "detect",
+    "scan_mods",
+    "scan_animations",
+    "build_conflict_map",
+    "build_stacks",
+)
+
+# Type alias for the scan result 3-tuple returned by run_scan.
+ScanResult = tuple[list, dict, list]
+
+
+class _Cancelled(Exception):
+    """Raised internally to unwind the scan pipeline on cancellation.
+
+    Subclasses Exception so it is caught by the broad ``except Exception``
+    guard in :py:meth:`ScanWorker.run`.  KeyboardInterrupt / SystemExit are
+    NOT subclasses of Exception and therefore propagate normally.
+    """
+
+
+class ScanWorker(QObject):
+    """Runs the OAR scan pipeline on a background QThread.
+
+    Usage pattern::
+
+        worker = ScanWorker(instance_root=path)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(on_done)
+        worker.failed.connect(on_error)
+        thread.start()
+
+    To cancel a running scan call ``thread.requestInterruption()``.
+    The worker checks for the interruption flag between submods (via the
+    ``on_progress`` callback wired to :py:func:`scan_mods`) and between
+    pipeline stages.  On cancellation ``cancelled`` is emitted and the
+    thread returns cleanly with no partial result.
+
+    Attributes:
+        instance_root: Path to the MO2 instance root (contains mods/ and
+            overwrite/ subdirectories).
+    """
+
+    # --- Signals -----------------------------------------------------------
+
+    progress_updated: Signal = Signal(str, int, int, str)
+    """Emitted at each pipeline stage boundary and per submod during scan_mods.
+
+    Args:
+        stage: One of the _STAGES constants (e.g. ``"scan_mods"``).
+        current: Items processed so far in this stage.
+        total: Total items expected in this stage (0 if unknown).
+        label: Human-readable label for the current item (submod name or "").
+    """
+
+    finished: Signal = Signal(object)
+    """Emitted on successful completion with the ScanResult 3-tuple.
+
+    Args:
+        result: ``(submods, conflict_map, stacks)`` — same shape as
+            :py:func:`oar_priority_manager.app.main.run_scan`.
+    """
+
+    failed: Signal = Signal(object)
+    """Emitted when an unexpected exception terminates the scan.
+
+    Args:
+        exception: The caught Exception instance.
+    """
+
+    cancelled: Signal = Signal()
+    """Emitted when the scan is interrupted via QThread.requestInterruption()."""
+
+    # -----------------------------------------------------------------------
+
+    def __init__(
+        self, instance_root: Path, parent: QObject | None = None
+    ) -> None:
+        """Initialize the worker.
+
+        Args:
+            instance_root: Path to the MO2 instance root.
+            parent: Optional QObject parent.
+        """
+        super().__init__(parent)
+        self.instance_root = instance_root
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _check_interruption(self) -> None:
+        """Raise _Cancelled if the current thread has been interrupted.
+
+        Args: (none)
+
+        Raises:
+            _Cancelled: If QThread.currentThread().isInterruptionRequested()
+                returns True.
+        """
+        if QThread.currentThread().isInterruptionRequested():
+            raise _Cancelled()
+
+    def _make_progress_callback(self) -> Any:
+        """Build the on_progress callable passed to scan_mods.
+
+        The returned callable:
+        1. Emits ``progress_updated`` with stage ``"scan_mods"``.
+        2. Checks for a pending interruption after each submod; raises
+           ``_Cancelled`` to unwind the pipeline when one is found.
+
+        Returns:
+            A callable accepting ``(current: int, total: int)`` that
+            also receives the submod name via closure over the submods
+            list.  Because ``scan_mods`` only provides ``(current, total)``
+            the label is synthesised as ``f"submod {current}/{total}"``.
+        """
+        def on_progress(current: int, total: int) -> None:
+            label = f"submod {current}/{total}"
+            self.progress_updated.emit("scan_mods", current, total, label)
+            self._check_interruption()
+
+        return on_progress
+
+    # ------------------------------------------------------------------
+    # Main run slot
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        """Execute the full scan pipeline.
+
+        This method is designed to be connected to ``QThread.started`` and
+        runs entirely on the background thread.  It must not be called
+        directly on the GUI thread.
+
+        On completion  emits :py:attr:`finished`.
+        On error       emits :py:attr:`failed`.
+        On cancel      emits :py:attr:`cancelled`.
+
+        Raises:
+            (nothing — all exceptions are caught internally and forwarded
+            via the ``failed`` signal, except _Cancelled which routes to
+            ``cancelled``.)
+        """
+        try:
+            result = self._run_pipeline()
+        except _Cancelled:
+            logger.debug("ScanWorker: scan cancelled by interruption request")
+            self.cancelled.emit()
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("ScanWorker: scan failed with exception")
+            self.failed.emit(exc)
+            return
+
+        self.finished.emit(result)
+
+    def _run_pipeline(self) -> ScanResult:
+        """Run all scan pipeline stages, emitting progress at each boundary.
+
+        Checks for interruption at the top of each stage so cancellation
+        has at most one-stage latency even when the scan_mods callback is
+        not called (e.g. zero submods).
+
+        Returns:
+            A ``(submods, conflict_map, stacks)`` 3-tuple.
+
+        Raises:
+            _Cancelled: If QThread.currentThread().isInterruptionRequested()
+                at any stage boundary or between submods.
+            Exception: Any unhandled exception from the underlying scan
+                functions propagates to the caller.
+        """
+        mods_dir = self.instance_root / "mods"
+        overwrite_dir = self.instance_root / "overwrite"
+
+        # Stage: detect
+        self._check_interruption()
+        self.progress_updated.emit("detect", 0, 0, "")
+
+        # Stage: scan_mods
+        self._check_interruption()
+        self.progress_updated.emit("scan_mods", 0, 0, "")
+        on_progress = self._make_progress_callback()
+        submods = scan_mods(mods_dir, overwrite_dir, on_progress=on_progress)
+
+        # Stage: scan_animations
+        self._check_interruption()
+        self.progress_updated.emit("scan_animations", 0, 0, "")
+        scan_animations(submods)
+
+        # Stage: build_conflict_map
+        self._check_interruption()
+        self.progress_updated.emit("build_conflict_map", 0, 0, "")
+        conflict_map = build_conflict_map(submods)
+
+        # Stage: build_stacks
+        self._check_interruption()
+        self.progress_updated.emit("build_stacks", 0, 0, "")
+        stacks = build_stacks(conflict_map)
+
+        # Post-processing: condition types and tags (no separate stage needed)
+        self._check_interruption()
+        for sm in submods:
+            present, negated = extract_condition_types(sm.conditions)
+            sm.condition_types_present = present
+            sm.condition_types_negated = negated
+            sm.tags = compute_tags(sm)
+
+        logger.info(
+            "ScanWorker: pipeline complete — %d submods, %d stacks",
+            len(submods),
+            len(stacks),
+        )
+        return submods, conflict_map, stacks

--- a/src/oar_priority_manager/core/scanner.py
+++ b/src/oar_priority_manager/core/scanner.py
@@ -158,7 +158,7 @@ def _build_submod(
 def scan_mods(
     mods_dir: Path,
     overwrite_dir: Path,
-    on_progress: Callable[[int, int], None] | None = None,
+    on_progress: Callable[[int, int, str], None] | None = None,
 ) -> list[SubMod]:
     """Scan the MO2 instance and build SubMod records for every OAR submod.
 
@@ -166,8 +166,10 @@ def scan_mods(
         mods_dir: Path to the MO2 mods/ directory.
         overwrite_dir: Path to the MO2 overwrite/ directory.
         on_progress: Optional callback invoked after each submod is built.
-            Called with (current, total) where current is the number of submods
-            built so far and total is the total number to build.
+            Called with ``(current, total, submod_name)`` where ``current``
+            is the number of submods built so far, ``total`` is the total
+            number to build, and ``submod_name`` is the display name of the
+            submod directory currently being processed.
 
     Returns:
         List of SubMod records. Submods with parse errors have non-empty warnings.
@@ -202,7 +204,7 @@ def scan_mods(
         )
         submods.append(sm)
         if on_progress is not None:
-            on_progress(len(submods), total)
+            on_progress(len(submods), total, sm.name)
 
     logger.info("Scanned %d submods from %s", len(submods), mods_dir)
     return submods

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -627,61 +627,102 @@ class MainWindow(QMainWindow):
         self._on_refresh()
 
     def _on_refresh(self) -> None:
-        """Re-scan the VFS asynchronously and rebuild all models (spec §6.3 step 6).
+        """Re-scan the VFS with a modal progress dialog (spec §6.3 step 6).
 
-        Launches a ScanWorker on a background QThread so the GUI stays
-        responsive while scanning.  The UI re-renders when finished fires.
-        If a scan is already in progress the new request is ignored.
+        Shows a ``WindowModal`` :class:`~oar_priority_manager.ui\
+.scan_progress_dialog.ScanProgressDialog` before starting the worker so
+        the user cannot interact with the main window during the scan.
+        The dialog blocks via ``exec()`` until the scan completes, fails,
+        or is cancelled — eliminating the race condition where a delegate
+        paint or filter iteration could hold a stale ``self._submods``
+        reference while the worker's ``finished`` slot mutates it.
+
+        On successful completion, ``on_finished`` re-populates the panels
+        after the dialog closes.  On failure, a ``QMessageBox`` is shown.
+        Cancellation is a no-op (the user dismissed the dialog deliberately).
+
+        A guard prevents concurrent scans: if ``self._scan_thread`` is
+        already running, the new request is silently ignored.
         """
         if self._scan_thread is not None and self._scan_thread.isRunning():
             return
+
+        from oar_priority_manager.ui.scan_progress_dialog import (
+            ScanProgressDialog,
+        )
 
         worker = ScanWorker(instance_root=self._instance_root)
         self._scan_worker = worker  # keep strong ref; PySide6 slots are weak
         thread = QThread(self)
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
+        self._scan_thread = thread
+
+        dialog = ScanProgressDialog(mode="refresh", parent=self)
+
+        result_holder: list[tuple] = []
+        error_holder: list[Exception] = []
 
         def on_finished(result: tuple) -> None:
-            submods, conflict_map, stacks = result
-            from oar_priority_manager.core.tag_engine import apply_overrides
-
-            apply_overrides(submods, self._config.tag_overrides)
-            self._submods = submods
-            self._conflict_map = conflict_map
-            self._stacks = stacks
-            self._tree_panel.refresh(self._submods)
-            # Full data reload — all cached stack widgets are stale (issue #66).
-            self._stacks_panel.clear_cache()
-            self._stacks_panel.refresh(self._conflict_map)
-            self._refresh_warning_count()
-            if (
-                self._scan_issues_pane is not None
-                and self._scan_issues_pane.isVisible()
-            ):
-                self._scan_issues_pane.set_entries(
-                    collect_warning_entries(self._submods)
-                )
-            thread.quit()
-            self._scan_thread = None
-            self._scan_worker = None
+            result_holder.append(result)
 
         def on_failed(exc: Exception) -> None:
-            thread.quit()
-            self._scan_thread = None
-            self._scan_worker = None
+            error_holder.append(exc)
+
+        # Wire worker signals → dialog slots (progress display + auto-dismiss)
+        worker.progress_updated.connect(dialog.on_progress)
+        worker.finished.connect(dialog.on_finished)
+        worker.failed.connect(dialog.on_failed)
+        worker.cancelled.connect(dialog.on_cancelled)
+
+        # Wire worker signals → local holders for post-dialog processing
+        worker.finished.connect(on_finished)
+        worker.failed.connect(on_failed)
+
+        # Wire cancel button → thread interruption
+        dialog.cancellation_requested.connect(thread.requestInterruption)
+
+        thread.start()
+        dialog.exec()  # blocks (WindowModal) until dialog is dismissed
+
+        thread.quit()
+        thread.wait()
+        self._scan_thread = None
+        self._scan_worker = None
+
+        if error_holder:
+            exc = error_holder[0]
             logger.error("Refresh scan failed: %s", exc, exc_info=exc)
             QMessageBox.warning(
                 self,
                 "Scan Failed",
                 f"Background scan failed:\n{exc}",
             )
+            return
 
-        worker.finished.connect(on_finished)
-        worker.failed.connect(on_failed)
+        if not result_holder:
+            # Cancelled — nothing to update.
+            return
 
-        self._scan_thread = thread
-        thread.start()
+        submods, conflict_map, stacks = result_holder[0]
+        from oar_priority_manager.core.tag_engine import apply_overrides
+
+        apply_overrides(submods, self._config.tag_overrides)
+        self._submods = submods
+        self._conflict_map = conflict_map
+        self._stacks = stacks
+        self._tree_panel.refresh(self._submods)
+        # Full data reload — all cached stack widgets are stale (issue #66).
+        self._stacks_panel.clear_cache()
+        self._stacks_panel.refresh(self._conflict_map)
+        self._refresh_warning_count()
+        if (
+            self._scan_issues_pane is not None
+            and self._scan_issues_pane.isVisible()
+        ):
+            self._scan_issues_pane.set_entries(
+                collect_warning_entries(self._submods)
+            )
 
     def _apply_config(self) -> None:
         """Apply persisted config values to UI widgets (spec §8.3)."""

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QThread
 from PySide6.QtGui import QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -20,18 +20,17 @@ from PySide6.QtWidgets import (
 )
 
 from oar_priority_manager.app.config import AppConfig
-from oar_priority_manager.core.anim_scanner import build_conflict_map, scan_animations
+from oar_priority_manager.core.anim_scanner import build_conflict_map
 from oar_priority_manager.core.filter_engine import (
     AdvancedFilterQuery,
     collect_known_condition_types,
-    extract_condition_types,
     match_advanced_filter,
     match_filter,
     parse_filter_query,
 )
 from oar_priority_manager.core.models import PriorityStack, SubMod
 from oar_priority_manager.core.priority_resolver import build_stacks
-from oar_priority_manager.core.scanner import scan_mods
+from oar_priority_manager.core.scan_worker import ScanWorker
 from oar_priority_manager.core.warning_report import collect_warning_entries
 from oar_priority_manager.ui.conditions_panel import ConditionsPanel
 from oar_priority_manager.ui.details_panel import DetailsPanel
@@ -73,6 +72,8 @@ class MainWindow(QMainWindow):
         # Scan Issues log pane (non-modal; lazily created on first open).
         self._scan_issues_pane: ScanIssuesPane | None = None
         self._warning_count: int = 0
+        # Background scan thread; None when no scan is in progress.
+        self._scan_thread: QThread | None = None
 
         self._setup_ui()
         self._connect_signals()
@@ -619,35 +620,53 @@ class MainWindow(QMainWindow):
         self._on_refresh()
 
     def _on_refresh(self) -> None:
-        """Re-scan the VFS and rebuild all models (spec §6.3 step 6)."""
-        mods_dir = self._instance_root / "mods"
-        overwrite_dir = self._instance_root / "overwrite"
+        """Re-scan the VFS asynchronously and rebuild all models (spec §6.3 step 6).
 
-        self._submods = scan_mods(mods_dir, overwrite_dir)
-        scan_animations(self._submods)
-        self._conflict_map = build_conflict_map(self._submods)
-        self._stacks = build_stacks(self._conflict_map)
+        Launches a ScanWorker on a background QThread so the GUI stays
+        responsive while scanning.  The UI re-renders when finished fires.
+        If a scan is already in progress the new request is ignored.
+        """
+        if self._scan_thread is not None and self._scan_thread.isRunning():
+            return
 
-        for sm in self._submods:
-            present, negated = extract_condition_types(sm.conditions)
-            sm.condition_types_present = present
-            sm.condition_types_negated = negated
+        worker = ScanWorker(instance_root=self._instance_root)
+        thread = QThread(self)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
 
-        from oar_priority_manager.core.tag_engine import apply_overrides, compute_tags
-        for sm in self._submods:
-            sm.tags = compute_tags(sm)
-        apply_overrides(self._submods, self._config.tag_overrides)
+        def on_finished(result: tuple) -> None:
+            submods, conflict_map, stacks = result
+            from oar_priority_manager.core.tag_engine import apply_overrides
 
-        self._tree_panel.refresh(self._submods)
-        # Full data reload — all cached stack widgets are stale (issue #66).
-        self._stacks_panel.clear_cache()
-        self._stacks_panel.refresh(self._conflict_map)
+            apply_overrides(submods, self._config.tag_overrides)
+            self._submods = submods
+            self._conflict_map = conflict_map
+            self._stacks = stacks
+            self._tree_panel.refresh(self._submods)
+            # Full data reload — all cached stack widgets are stale (issue #66).
+            self._stacks_panel.clear_cache()
+            self._stacks_panel.refresh(self._conflict_map)
+            self._refresh_warning_count()
+            if (
+                self._scan_issues_pane is not None
+                and self._scan_issues_pane.isVisible()
+            ):
+                self._scan_issues_pane.set_entries(
+                    collect_warning_entries(self._submods)
+                )
+            thread.quit()
+            self._scan_thread = None
 
-        self._refresh_warning_count()
-        if self._scan_issues_pane is not None and self._scan_issues_pane.isVisible():
-            self._scan_issues_pane.set_entries(
-                collect_warning_entries(self._submods)
-            )
+        def on_failed(exc: Exception) -> None:
+            thread.quit()
+            self._scan_thread = None
+            raise exc
+
+        worker.finished.connect(on_finished)
+        worker.failed.connect(on_failed)
+
+        self._scan_thread = thread
+        thread.start()
 
     def _apply_config(self) -> None:
         """Apply persisted config values to UI widgets (spec §8.3)."""

--- a/src/oar_priority_manager/ui/main_window.py
+++ b/src/oar_priority_manager/ui/main_window.py
@@ -5,6 +5,7 @@ See spec §7.1 (layout), §6.3 (data flow).
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from PySide6.QtCore import Qt, QThread
@@ -41,6 +42,8 @@ from oar_priority_manager.ui.stacks_panel import StacksPanel
 from oar_priority_manager.ui.tree_model import SearchIndex
 from oar_priority_manager.ui.tree_panel import TreePanel
 
+logger = logging.getLogger(__name__)
+
 
 class MainWindow(QMainWindow):
     """Three-pane main window: (Tree+Details) | Stacks | Conditions."""
@@ -72,8 +75,12 @@ class MainWindow(QMainWindow):
         # Scan Issues log pane (non-modal; lazily created on first open).
         self._scan_issues_pane: ScanIssuesPane | None = None
         self._warning_count: int = 0
-        # Background scan thread; None when no scan is in progress.
+        # Background scan thread and worker; both None when no scan is in
+        # progress.  The worker must be held on self — signal connections
+        # in PySide6 are weak references, so a parentless local variable
+        # would be GC'd after _on_refresh returns, silencing the slot.
         self._scan_thread: QThread | None = None
+        self._scan_worker: ScanWorker | None = None
 
         self._setup_ui()
         self._connect_signals()
@@ -630,6 +637,7 @@ class MainWindow(QMainWindow):
             return
 
         worker = ScanWorker(instance_root=self._instance_root)
+        self._scan_worker = worker  # keep strong ref; PySide6 slots are weak
         thread = QThread(self)
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
@@ -656,11 +664,18 @@ class MainWindow(QMainWindow):
                 )
             thread.quit()
             self._scan_thread = None
+            self._scan_worker = None
 
         def on_failed(exc: Exception) -> None:
             thread.quit()
             self._scan_thread = None
-            raise exc
+            self._scan_worker = None
+            logger.error("Refresh scan failed: %s", exc, exc_info=exc)
+            QMessageBox.warning(
+                self,
+                "Scan Failed",
+                f"Background scan failed:\n{exc}",
+            )
 
         worker.finished.connect(on_finished)
         worker.failed.connect(on_failed)

--- a/src/oar_priority_manager/ui/scan_progress_dialog.py
+++ b/src/oar_priority_manager/ui/scan_progress_dialog.py
@@ -1,0 +1,298 @@
+"""Splash-style modal progress dialog for the OAR scan pipeline.
+
+Displays overall scan progress with per-stage weighting, a per-item label
+showing the current submod name, and a cancel button.  Used in two modes:
+
+- ``"startup"`` — ``ApplicationModal``, no parent; shown during initial
+  startup scan before the main window exists.
+- ``"refresh"`` — ``WindowModal`` with a ``MainWindow`` parent; shown during
+  a user-triggered re-scan.  Blocks input to the parent window only, so
+  other applications remain responsive.
+
+The dialog is UI-agnostic: it reads worker signals and emits
+``cancellation_requested`` for the caller to wire to
+``QThread.requestInterruption()``.  It does not call into the scan pipeline
+directly.
+
+See issue #96 and docs/scan-worker.md for design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtCore import Qt, QTimer, Signal
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+# ---------------------------------------------------------------------------
+# Stage weighting constants
+# ---------------------------------------------------------------------------
+
+# Maps stage name → (start_pct, weight_pct).
+# The five weights must sum to 100.
+_STAGE_WEIGHTS: dict[str, tuple[int, int]] = {
+    "detect":            (0,  5),
+    "scan_mods":         (5,  55),
+    "scan_animations":   (60, 30),
+    "build_conflict_map": (90, 5),
+    "build_stacks":      (95, 5),
+}
+
+# Human-readable label shown in the stage label widget.
+_STAGE_LABELS: dict[str, str] = {
+    "detect":            "Detecting instance…",
+    "scan_mods":         "Scanning mods…",
+    "scan_animations":   "Scanning animations…",
+    "build_conflict_map": "Building conflict map…",
+    "build_stacks":      "Resolving priorities…",
+}
+
+
+class ScanProgressDialog(QDialog):
+    """Splash-style modal dialog showing scan pipeline progress.
+
+    Attributes:
+        mode: Either ``"startup"`` or ``"refresh"``.  Controls window
+            modality and flags.
+    """
+
+    cancellation_requested: Signal = Signal()
+    """Emitted when the user clicks the Cancel button.
+
+    The caller should wire this to ``thread.requestInterruption()`` so the
+    worker stops cleanly after the current submod finishes.
+    """
+
+    def __init__(
+        self, mode: str, parent: QWidget | None = None
+    ) -> None:
+        """Initialise the dialog.
+
+        Args:
+            mode: ``"startup"`` or ``"refresh"``.  Determines window
+                modality and chrome style.
+            parent: Optional parent widget.  Should be the ``MainWindow``
+                instance when ``mode="refresh"``; ``None`` for startup.
+        """
+        super().__init__(parent)
+        self.mode = mode
+        self._setup_window_flags()
+        self._build_layout()
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    # ------------------------------------------------------------------
+
+    def _setup_window_flags(self) -> None:
+        """Apply window flags and modality based on the dialog mode.
+
+        Startup: ApplicationModal (no parent); uses SplashScreen-style
+            frameless chrome so it appears before any window is shown.
+        Refresh: WindowModal with parent; uses minimal title-bar chrome
+            so the user can still see which window is blocked.
+        """
+        if self.mode == "startup":
+            self.setWindowFlags(
+                Qt.WindowType.Dialog
+                | Qt.WindowType.FramelessWindowHint
+            )
+            self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        else:
+            self.setWindowFlags(
+                Qt.WindowType.Dialog
+                | Qt.WindowType.WindowTitleHint
+                | Qt.WindowType.CustomizeWindowHint
+            )
+            self.setWindowModality(Qt.WindowModality.WindowModal)
+
+        self.setWindowTitle("OAR Priority Manager — Scanning")
+        self.setMinimumWidth(420)
+
+    def _build_layout(self) -> None:
+        """Construct all child widgets and the layout.
+
+        Layout (top to bottom):
+            1. Title label
+            2. Stage label (current pipeline stage)
+            3. Overall progress bar (0–100)
+            4. Per-item label (current submod name, elided)
+            5. Cancel button (right-aligned)
+        """
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(10)
+
+        # Title
+        title = QLabel("OAR Priority Manager — Scanning")
+        font = title.font()
+        font.setBold(True)
+        title.setFont(font)
+        layout.addWidget(title)
+
+        # Stage label
+        self._stage_label = QLabel("Initialising…")
+        layout.addWidget(self._stage_label)
+
+        # Overall progress bar
+        self._bar = QProgressBar()
+        self._bar.setRange(0, 100)
+        self._bar.setValue(0)
+        self._bar.setTextVisible(True)
+        layout.addWidget(self._bar)
+
+        # Per-item label (elided with Qt.ElideMiddle via stylesheet is not
+        # directly available on QLabel, so we truncate manually in the slot).
+        self._item_label = QLabel("")
+        self._item_label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        layout.addWidget(self._item_label)
+
+        # Cancel button (right-aligned)
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn.clicked.connect(self._on_cancel_clicked)
+        btn_row.addWidget(self._cancel_btn)
+        layout.addLayout(btn_row)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _elide_middle(self, text: str, max_chars: int = 55) -> str:
+        """Truncate ``text`` to ``max_chars`` using middle-elision.
+
+        Args:
+            text: The string to shorten.
+            max_chars: Maximum character count before elision is applied.
+
+        Returns:
+            The original string if short enough, otherwise a version
+            with ``…`` inserted in the middle.
+        """
+        if len(text) <= max_chars:
+            return text
+        half = (max_chars - 1) // 2
+        return text[:half] + "…" + text[-(max_chars - half - 1):]
+
+    def _compute_overall(
+        self, stage: str, current: int, total: int
+    ) -> int:
+        """Compute the overall progress percentage for a stage update.
+
+        Args:
+            stage: One of the ``_STAGE_WEIGHTS`` keys.
+            current: Items processed so far in this stage.
+            total: Total items in this stage (0 means indeterminate).
+
+        Returns:
+            Integer percentage 0–100 for the overall bar.
+        """
+        if stage not in _STAGE_WEIGHTS:
+            return self._bar.value()
+
+        start_pct, weight = _STAGE_WEIGHTS[stage]
+        within = weight * current / total if total > 0 else 0.0
+        return round(start_pct + within)
+
+    # ------------------------------------------------------------------
+    # Slots wired to ScanWorker signals
+    # ------------------------------------------------------------------
+
+    def on_progress(
+        self, stage: str, current: int, total: int, label: str
+    ) -> None:
+        """Update bar value, stage label, and per-item label.
+
+        Designed to be connected directly to ``ScanWorker.progress_updated``.
+
+        Args:
+            stage: Pipeline stage name (one of the ``_STAGES`` constants).
+            current: Items processed so far in this stage.
+            total: Total items expected in this stage (0 if unknown).
+            label: Submod display name or empty string for stage boundaries.
+        """
+        stage_text = _STAGE_LABELS.get(stage, stage)
+        self._stage_label.setText(stage_text)
+
+        overall = self._compute_overall(stage, current, total)
+        self._bar.setValue(overall)
+
+        if label:
+            self._item_label.setText(self._elide_middle(label))
+        else:
+            self._item_label.setText("")
+
+    def on_finished(self, result: Any) -> None:
+        """Handle scan completion — show a brief "done" state then dismiss.
+
+        The dialog shows the final 100% state for ~1 second before calling
+        ``accept()`` so the user can see the scan completed before the UI
+        updates.
+
+        Designed to be connected to ``ScanWorker.finished``.
+
+        Args:
+            result: The ``(submods, conflict_map, stacks)`` tuple from the
+                worker.  Used to display a count in the stage label.
+        """
+        submods = result[0] if isinstance(result, tuple) and result else []
+        n = len(submods) if isinstance(submods, list) else 0
+
+        self._bar.setValue(100)
+        self._stage_label.setText(f"Done — {n} mods loaded")
+        self._item_label.setText("")
+        self._cancel_btn.setEnabled(False)
+
+        QTimer.singleShot(1000, self.accept)
+
+    def on_failed(self, exc: Exception) -> None:  # noqa: ARG002
+        """Close the dialog immediately when the scan fails.
+
+        Does not display the error — that is the caller's responsibility
+        (e.g. a QMessageBox after the dialog closes).
+
+        Designed to be connected to ``ScanWorker.failed``.
+
+        Args:
+            exc: The exception captured by the worker.  Not displayed here;
+                the caller handles error presentation.
+        """
+        self.reject()
+
+    def on_cancelled(self) -> None:
+        """Close the dialog immediately when the scan is cancelled.
+
+        Called after the worker emits ``cancelled``.  The dialog dismisses
+        without a timer because cancellation is synchronous from the user's
+        perspective.
+
+        Designed to be connected to ``ScanWorker.cancelled``.
+        """
+        self.reject()
+
+    # ------------------------------------------------------------------
+    # Internal slots
+    # ------------------------------------------------------------------
+
+    def _on_cancel_clicked(self) -> None:
+        """Emit ``cancellation_requested`` when the Cancel button is clicked.
+
+        The dialog does NOT close itself here.  It waits for the worker to
+        emit ``cancelled`` (via ``on_cancelled``), which then calls
+        ``reject()``.  This keeps the user informed that cancellation is
+        in progress rather than appearing to hang.
+        """
+        self._cancel_btn.setEnabled(False)
+        self._stage_label.setText("Cancelling…")
+        self.cancellation_requested.emit()

--- a/tests/unit/test_scan_progress_dialog.py
+++ b/tests/unit/test_scan_progress_dialog.py
@@ -1,0 +1,201 @@
+"""Tests for ui/scan_progress_dialog.py — splash-style scan progress dialog.
+
+Covers AC from issue #96:
+- Progress signal updates bar value and labels correctly.
+- Stage weighting maps scan_mods at 50% to overall ~32.5%.
+- finished() auto-dismisses the dialog after ~1 s via QTimer.
+- failed() closes the dialog immediately (no timer).
+- cancelled() closes the dialog immediately.
+- Cancel button click emits cancellation_requested signal.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from oar_priority_manager.ui.scan_progress_dialog import ScanProgressDialog
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def qapp_session():
+    """Session-scoped QApplication for dialog tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Progress signal updates
+# ---------------------------------------------------------------------------
+
+
+class TestProgressUpdates:
+    """on_progress() updates the bar value and labels."""
+
+    def test_progress_updates_bar(self, qapp_session, qtbot):
+        """Emitting on_progress updates the overall bar and per-item label.
+
+        Calls on_progress for the scan_mods stage and asserts that the
+        progress bar value and per-item label text are updated.
+        """
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+
+        dialog.on_progress("scan_mods", 10, 100, "SomeSubMod")
+
+        assert dialog._bar.value() > 0
+        assert "SomeSubMod" in dialog._item_label.text()
+
+    def test_stage_label_updates_on_progress(self, qapp_session, qtbot):
+        """Emitting on_progress with a known stage updates the stage label."""
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+
+        dialog.on_progress("detect", 0, 0, "")
+
+        assert "Detect" in dialog._stage_label.text() or \
+            dialog._stage_label.text() != ""
+
+    def test_stage_weighting(self, qapp_session, qtbot):
+        """scan_mods at 50% yields overall value near 32 (5 + 55*0.5 = 32.5).
+
+        Stage weights: detect=5, scan_mods=55, scan_animations=30,
+        build_conflict_map=5, build_stacks=5.
+        start offset for scan_mods = 5%.
+        overall = 5 + 55 * (50/100) = 32.5 → bar value 32 or 33.
+        """
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+
+        dialog.on_progress("scan_mods", 50, 100, "SomeMod")
+
+        bar_val = dialog._bar.value()
+        assert 32 <= bar_val <= 33, (
+            f"Expected bar value ~32-33 for scan_mods 50%, got {bar_val}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# finished() auto-dismiss
+# ---------------------------------------------------------------------------
+
+
+class TestFinishedAutoDismiss:
+    """on_finished() causes the dialog to close after ~1 second."""
+
+    def test_finished_auto_dismisses(self, qapp_session, qtbot):
+        """Dialog closes within 1.5 s after on_finished() is called.
+
+        The dialog uses QTimer.singleShot(1000, self.accept) internally,
+        so we allow 1.5 s total (1 s timer + 500 ms slack).
+        """
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+        dialog.show()
+
+        # on_finished receives the scan result tuple
+        fake_result = ([], {}, [])
+        with qtbot.waitSignal(dialog.finished, timeout=1500):
+            dialog.on_finished(fake_result)
+
+
+# ---------------------------------------------------------------------------
+# failed() closes immediately
+# ---------------------------------------------------------------------------
+
+
+class TestFailedClosesImmediately:
+    """on_failed() closes the dialog without a timer."""
+
+    def test_failed_closes_immediately(self, qapp_session, qtbot):
+        """Dialog closes within 200 ms after on_failed() is called.
+
+        No QTimer is involved — the dialog hides immediately so the caller
+        can show an error dialog in its place.
+        """
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+        dialog.show()
+
+        exc = RuntimeError("scan failed")
+        with qtbot.waitSignal(dialog.finished, timeout=200):
+            dialog.on_failed(exc)
+
+
+# ---------------------------------------------------------------------------
+# cancelled() closes immediately
+# ---------------------------------------------------------------------------
+
+
+class TestCancelledClosesImmediately:
+    """on_cancelled() closes the dialog without a timer."""
+
+    def test_cancelled_closes_immediately(self, qapp_session, qtbot):
+        """Dialog closes within 200 ms after on_cancelled() is called.
+
+        No QTimer — cancelled is a user-initiated action, so the dialog
+        dismisses synchronously rather than briefly showing a "done" state.
+        """
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+        dialog.show()
+
+        with qtbot.waitSignal(dialog.finished, timeout=200):
+            dialog.on_cancelled()
+
+
+# ---------------------------------------------------------------------------
+# Cancel button emits cancellation_requested
+# ---------------------------------------------------------------------------
+
+
+class TestCancelButton:
+    """Clicking the cancel button emits cancellation_requested."""
+
+    def test_cancel_button_emits_cancellation_requested(
+        self, qapp_session, qtbot
+    ):
+        """Clicking the cancel button fires the cancellation_requested signal.
+
+        The caller wires this signal to QThread.requestInterruption() so the
+        worker stops cleanly.  The dialog itself does not call requestInterruption
+        directly — it stays UI-agnostic w.r.t. the scan pipeline.
+        """
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+        dialog.show()
+
+        with qtbot.waitSignal(dialog.cancellation_requested, timeout=500):
+            dialog._cancel_btn.click()
+
+
+# ---------------------------------------------------------------------------
+# Mode differences
+# ---------------------------------------------------------------------------
+
+
+class TestModeConstruction:
+    """ScanProgressDialog constructs correctly for startup and refresh modes."""
+
+    def test_startup_mode_constructs(self, qapp_session, qtbot):
+        """ScanProgressDialog(mode='startup') constructs without error."""
+        dialog = ScanProgressDialog(mode="startup")
+        qtbot.addWidget(dialog)
+        assert dialog is not None
+
+    def test_refresh_mode_constructs(self, qapp_session, qtbot):
+        """ScanProgressDialog(mode='refresh') constructs without error."""
+        dialog = ScanProgressDialog(mode="refresh")
+        qtbot.addWidget(dialog)
+        assert dialog is not None

--- a/tests/unit/test_scan_worker.py
+++ b/tests/unit/test_scan_worker.py
@@ -137,7 +137,7 @@ class TestScanWorkerHappyPath:
 
         def fake_scan_mods(mods_dir, overwrite_dir, on_progress=None):
             if on_progress is not None:
-                on_progress(1, 1)
+                on_progress(1, 1, "FakeSub")
             return [fake_submod]
 
         with (
@@ -241,7 +241,7 @@ class TestScanWorkerCancellation:
             QThread.currentThread().requestInterruption()
             # The on_progress callback will detect the flag and raise _Cancelled.
             if on_progress is not None:
-                on_progress(1, 1)
+                on_progress(1, 1, "FakeSub")
             return []
 
         with (
@@ -270,7 +270,7 @@ class TestScanWorkerCancellation:
             # Request interruption from within the worker thread.
             QThread.currentThread().requestInterruption()
             if on_progress is not None:
-                on_progress(1, 5)
+                on_progress(1, 5, "FakeSub")
             return []
 
         with (

--- a/tests/unit/test_scan_worker.py
+++ b/tests/unit/test_scan_worker.py
@@ -1,0 +1,287 @@
+"""Tests for core/scan_worker.py — QThread-backed scan pipeline worker.
+
+Covers AC #6:
+- Happy-path completion: worker runs, emits progress_updated (≥1 emission),
+  emits finished with a valid ScanResult-shaped payload.
+- Exception propagation: scan_mods raises → failed fires, finished does NOT.
+- Cancellation: requestInterruption() → cancelled fires, finished does NOT.
+
+Uses pytest-qt's qtbot.waitSignal / waitSignals for async signal assertion.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PySide6.QtCore import QCoreApplication, QThread
+
+from oar_priority_manager.core.scan_worker import ScanWorker
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Ensure a QCoreApplication exists for QThread-based tests.
+
+    A QCoreApplication (no GUI) is sufficient for signal/slot testing.
+    """
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QCoreApplication([])
+    return app
+
+
+@pytest.fixture()
+def tmp_instance(tmp_path: Path) -> Path:
+    """Provide a minimal MO2 instance root with empty mods/ and overwrite/."""
+    (tmp_path / "mods").mkdir()
+    (tmp_path / "overwrite").mkdir()
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Happy-path completion tests
+# ---------------------------------------------------------------------------
+
+
+class TestScanWorkerHappyPath:
+    """ScanWorker runs to completion, emitting expected signals."""
+
+    def test_finished_emits_with_scan_result(self, qapp, qtbot, tmp_instance):
+        """Worker emits finished(result) with a 3-tuple payload on success.
+
+        The payload is (submods, conflict_map, stacks) — the ScanResult
+        returned by run_scan. An empty instance produces empty containers.
+        """
+        worker = ScanWorker(instance_root=tmp_instance)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        with qtbot.waitSignal(worker.finished, timeout=10_000) as blocker:
+            thread.start()
+
+        thread.quit()
+        thread.wait()
+
+        result = blocker.args[0]
+        submods, conflict_map, stacks = result
+        assert isinstance(submods, list)
+        assert isinstance(conflict_map, dict)
+        assert isinstance(stacks, list)
+
+    def test_failed_does_not_emit_on_success(self, qapp, qtbot, tmp_instance):
+        """Worker does NOT emit failed when scan completes successfully."""
+        worker = ScanWorker(instance_root=tmp_instance)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        with (
+            qtbot.waitSignal(worker.finished, timeout=10_000),
+            qtbot.assertNotEmitted(worker.failed),
+        ):
+            thread.start()
+
+        thread.quit()
+        thread.wait()
+
+    def test_progress_updated_emits_at_least_once(
+        self, qapp, qtbot, tmp_instance
+    ):
+        """Worker emits ≥1 progress_updated signal during a scan.
+
+        Even with zero submods, stage-transition progress events fire.
+        We patch scan_mods to call on_progress at least once so the
+        per-submod callback fires in addition to stage-boundary events.
+        """
+        from oar_priority_manager.core.models import OverrideSource, SubMod
+
+        # Create one minimal submod so on_progress fires at least once.
+        fake_submod = SubMod(
+            mo2_mod="FakeMod",
+            replacer="FakeReplacer",
+            name="FakeSub",
+            description="",
+            priority=100,
+            source_priority=100,
+            disabled=False,
+            config_path=tmp_instance / "mods" / "FakeMod" / "config.json",
+            override_source=OverrideSource.SOURCE,
+            override_is_ours=False,
+            raw_dict={},
+            conditions={},
+        )
+
+        progress_emissions: list[tuple] = []
+
+        worker = ScanWorker(instance_root=tmp_instance)
+        worker.progress_updated.connect(
+            lambda stage, cur, total, label: progress_emissions.append(
+                (stage, cur, total, label)
+            )
+        )
+
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        def fake_scan_mods(mods_dir, overwrite_dir, on_progress=None):
+            if on_progress is not None:
+                on_progress(1, 1)
+            return [fake_submod]
+
+        with (
+            patch(
+                "oar_priority_manager.core.scan_worker.scan_mods",
+                side_effect=fake_scan_mods,
+            ),
+            qtbot.waitSignal(worker.finished, timeout=10_000),
+        ):
+            thread.start()
+
+        thread.quit()
+        thread.wait()
+
+        assert len(progress_emissions) >= 1, (
+            f"Expected ≥1 progress_updated emissions, got {progress_emissions}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Exception propagation tests
+# ---------------------------------------------------------------------------
+
+
+class TestScanWorkerFailure:
+    """ScanWorker emits failed and suppresses finished when an error occurs."""
+
+    def test_failed_emits_on_scan_error(self, qapp, qtbot, tmp_instance):
+        """Worker emits failed(exc) when scan_mods raises an exception."""
+        boom = RuntimeError("synthetic scan failure")
+
+        worker = ScanWorker(instance_root=tmp_instance)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        with (
+            patch(
+                "oar_priority_manager.core.scan_worker.scan_mods",
+                side_effect=boom,
+            ),
+            qtbot.waitSignal(worker.failed, timeout=10_000) as blocker,
+            qtbot.assertNotEmitted(worker.finished),
+        ):
+            thread.start()
+
+        thread.quit()
+        thread.wait()
+
+        caught_exc = blocker.args[0]
+        assert isinstance(caught_exc, RuntimeError)
+        assert str(caught_exc) == "synthetic scan failure"
+
+    def test_finished_does_not_emit_on_error(self, qapp, qtbot, tmp_instance):
+        """Finished signal is NOT emitted when scan_mods raises."""
+        worker = ScanWorker(instance_root=tmp_instance)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        with (
+            patch(
+                "oar_priority_manager.core.scan_worker.scan_mods",
+                side_effect=ValueError("bad path"),
+            ),
+            qtbot.waitSignal(worker.failed, timeout=10_000),
+            qtbot.assertNotEmitted(worker.finished),
+        ):
+            thread.start()
+
+        thread.quit()
+        thread.wait()
+
+
+# ---------------------------------------------------------------------------
+# Cancellation tests
+# ---------------------------------------------------------------------------
+
+
+class TestScanWorkerCancellation:
+    """ScanWorker responds to requestInterruption() cleanly."""
+
+    def test_cancelled_emits_when_interrupted(
+        self, qapp, qtbot, tmp_instance
+    ):
+        """Calling QThread.requestInterruption() causes cancelled to emit.
+
+        We request interruption from *within* the fake scan_mods body so
+        there is no race between the ``started`` slot order.  The fake calls
+        ``on_progress`` once (which checks for interruption after the flag
+        is already set), causing ``_Cancelled`` to be raised and the worker
+        to emit ``cancelled``.
+        """
+        worker = ScanWorker(instance_root=tmp_instance)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        def interruptible_scan_mods(mods_dir, overwrite_dir, on_progress=None):
+            # Request interruption here — we are already on the worker thread.
+            QThread.currentThread().requestInterruption()
+            # The on_progress callback will detect the flag and raise _Cancelled.
+            if on_progress is not None:
+                on_progress(1, 1)
+            return []
+
+        with (
+            patch(
+                "oar_priority_manager.core.scan_worker.scan_mods",
+                side_effect=interruptible_scan_mods,
+            ),
+            qtbot.waitSignal(worker.cancelled, timeout=10_000),
+            qtbot.assertNotEmitted(worker.finished),
+        ):
+            thread.start()
+
+        thread.quit()
+        thread.wait()
+
+    def test_finished_does_not_emit_on_cancel(
+        self, qapp, qtbot, tmp_instance
+    ):
+        """Finished is NOT emitted when the worker is cancelled."""
+        worker = ScanWorker(instance_root=tmp_instance)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+
+        def self_interrupting_scan(mods_dir, overwrite_dir, on_progress=None):
+            # Request interruption from within the worker thread.
+            QThread.currentThread().requestInterruption()
+            if on_progress is not None:
+                on_progress(1, 5)
+            return []
+
+        with (
+            patch(
+                "oar_priority_manager.core.scan_worker.scan_mods",
+                side_effect=self_interrupting_scan,
+            ),
+            qtbot.waitSignal(worker.cancelled, timeout=10_000),
+            qtbot.assertNotEmitted(worker.finished),
+        ):
+            thread.start()
+
+        thread.quit()
+        thread.wait()


### PR DESCRIPTION
## Summary

Two issues land together: **#95** (move scan pipeline off the GUI thread) and **#96** (splash-style scan progress dialog). #96 was originally blocked by #95 — bundling them ships the user-facing payoff (live progress, cancel button, no UI freeze) in a single review.

**Why bundled rather than two PRs:** during testing, `_on_refresh()` was found to expose a race condition without the modal: the worker's `finished` slot mutates `self._submods` / `self._conflict_map` / `self._stacks` while UI delegates may be mid-iteration over the old reference. Synchronous-scan didn't have this risk because the GIL + frozen event loop made the swap atomic-feeling. The modal dialog from #96 closes that race by blocking input during the scan, so it's a regression-fix rather than a follow-up feature.

## What changed (8 files, ~+760 / -83)

### #95 — Off-thread scan pipeline

| File | Role |
|---|---|
| `src/oar_priority_manager/core/scan_worker.py` | New `ScanWorker(QObject)`. Signals: `progress_updated(stage, current, total, label)`, `finished(result)`, `failed(exc)`, `cancelled()`. UI-agnostic. Private `_Cancelled` for clean stage-boundary unwind. |
| `src/oar_priority_manager/app/main.py` | `_run_scan_blocking()` runs the worker on a dedicated `QThread` and pumps the GUI event loop via `QEventLoop.exec()` until the worker fires `finished`/`failed`. (`QThread.wait()` would deadlock — explained in code comments.) |
| `src/oar_priority_manager/ui/main_window.py` | `_on_refresh()` runs the worker async; concurrent-scan guard via `_scan_thread is not None and isRunning()`. Holds strong refs on `self._scan_thread` and `self._scan_worker` (the latter avoids a PySide6 weak-signal-receiver GC bug). |

### #96 — Splash-style progress dialog

| File | Role |
|---|---|
| `src/oar_priority_manager/ui/scan_progress_dialog.py` | **New (298 lines).** `ScanProgressDialog(QDialog)` with overall progress bar (stage-weighted: detect 5% / scan_mods 55% / scan_animations 30% / build_conflict_map 5% / build_stacks 5%), stage label, per-submod label (Qt.ElideMiddle for long names), cancel button. Modes: `"startup"` (`ApplicationModal`) and `"refresh"` (`WindowModal`). Emits `cancellation_requested` on cancel-button click. Auto-dismisses 1s after `finished` via `QTimer.singleShot`. |
| `src/oar_priority_manager/core/scanner.py` | Extended `scan_mods`'s `on_progress` callback signature from `(current, total)` to `(current, total, submod_name: str)` so the dialog can show the actual submod being processed. Single internal call site updated; one external caller (`ScanWorker`). |
| `src/oar_priority_manager/core/scan_worker.py` | `_make_progress_callback` now forwards the real submod name as the `label` argument to `progress_updated`. Synthesised `submod X/Y` label dropped. |
| `src/oar_priority_manager/app/main.py` | Startup wires the dialog before `loop.exec()`; cancel-on-startup → `sys.exit(0)` per the chosen behaviour. |
| `src/oar_priority_manager/ui/main_window.py` | Refresh wires a `mode="refresh"` dialog with `parent=self`; `dialog.exec()` blocks input to MainWindow during scan, eliminating the race condition. |
| `tests/unit/test_scan_progress_dialog.py` | **New (201 lines).** 9 `pytest-qt` tests covering progress updates, stage weighting, finished auto-dismiss timing, failed/cancelled close behaviour, cancel-button signal, and mode construction. |
| `tests/unit/test_scan_worker.py` | Existing 7 tests adjusted for the 3-arg `on_progress` signature. |
| `docs/scan-worker.md` | Architecture note expanded with a *Progress Dialog* section: stage weighting model, modality-by-mode rationale, signal flow. |

## Design notes

### `QEventLoop.exec()` for startup blocking — not `QThread.wait()`

`QThread.wait()` would deadlock because it blocks the GUI thread itself, so queued cross-thread signals from the worker can't dispatch. `QEventLoop.exec()` keeps the GUI event loop pumping, exited via `quit()` from a `finished`/`failed` slot. Documented in a comment at the call site.

### Stage weighting prevents jumpy progress

Without weighting, the bar would jump from 0% → 100% almost instantly because `scan_mods` and `scan_animations` are the heavy stages and the others are near-instant. Weights are tunable constants in `ScanProgressDialog`.

### Strong references vs PySide6 GC

`ScanWorker` is a parentless `QObject` moved to a thread; PySide6's signal connections hold only weak references to slot receivers. After `_on_refresh` returns, the local `worker` would be GC'd, silently severing `started → worker.run`. We hold `self._scan_worker = worker` and clear it in `finished`/`failed` handlers. (See the explanatory comment in `MainWindow.__init__`.)

### Modality differs by mode

- **Startup** (`ApplicationModal`) — there's no parent yet; the dialog blocks the entire app while initial scan runs.
- **Refresh** (`WindowModal` with `parent=MainWindow`) — blocks input only to the main window; other top-level windows (e.g., scan-issues pane) remain interactive.

### Cancel-on-startup

Per the design choice, cancellation during the initial scan calls `sys.exit(0)` cleanly after the worker emits `cancelled`. The user gets back to their shell.

## Verification (CI mirror)

```
ruff check src/ tests/                                    # ✅ All checks passed!
QT_QPA_PLATFORM=offscreen pytest -v --tb=short            # ✅ 537 passed, 9 skipped, 0 failed
```

| State | Passed | Skipped | Failed |
|---|---|---|---|
| `main` baseline | 524 | 6 | 0 |
| Post-change | **537** | 9 | **0** |

+13 net new tests (+7 `test_scan_worker.py` from the original #95 commit, +9 `test_scan_progress_dialog.py`, with 3 `test_scan_worker.py` tests that previously asserted on the synthesised label adjusted for the new 3-arg signature). The 3-skip drift between baseline and post-change is unrelated to this PR — environment-dependent `pytest.importorskip` tests that surfaced when the worktree's venv was repopulated mid-session.

## Acceptance criteria

### #95

- [x] `ScanWorker` (`QObject` + `moveToThread`)
- [x] Signals: `progress_updated`, `finished`, `failed`, `cancelled`
- [x] `scan_mods` invoked with on_progress callback that forwards to `progress_updated.emit`
- [x] Cancellation between submods (in-callback) and between stages (top of each block); no partial result on cancel
- [x] Both `main()` and `_on_refresh()` use the worker
- [x] Unit tests cover happy path / failure / cancellation
- [x] `ScanResult` payload unchanged
- [x] Architecture note in `docs/`
- [x] Tests pass; ruff clean

### #96

- [x] New splash-style `ScanProgressDialog` opens before main window on startup
- [x] Overall `QProgressBar` covering all 5 scan stages, weighted (5/55/30/5/5)
- [x] Stage label shows current stage human name
- [x] Per-item label shows current submod name (real, not synthesised)
- [x] Cancel button wired to `requestInterruption()`
- [x] Startup: cancel exits app cleanly with `sys.exit(0)`
- [x] Refresh: same dialog appears modally over main window; main window re-enabled after `finished`
- [x] Post-completion: ~1s "✓ Done — N mods loaded" before auto-dismiss
- [x] Error path: `failed` closes dialog immediately; existing error handling preserved
- [x] Tests using `pytest-qt`: progress, stage weighting, finished auto-dismiss, failed close, cancelled close, cancel-button signal, mode construction
- [ ] `README.md` update — skipped: README has no "scanning" section the dialog naturally fits into. `docs/scan-worker.md` is the canonical architecture reference.

## Out of scope

- Background / tray scans (#96 explicitly listed this as out of scope)
- Persisting scan results between runs
- Per-animation-file progress granularity
- Incremental scan (only changed submods)

Closes #95
Closes #96

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
